### PR TITLE
fix: tab component styles broken

### DIFF
--- a/src/components/Tabs/styles.js
+++ b/src/components/Tabs/styles.js
@@ -4,15 +4,17 @@ import { left, th, width } from '@xstyled/system'
 import { system } from '../../utils/utils'
 
 export const Tabs = styled.nav`
+  position: relative;
   width: 100%;
   overflow: auto;
-  position: relative;
   ${system};
 `
 
 export const List = styled.ul`
   ${th('tabs.tabs')}
   display: flex;
+  margin: 0;
+  list-style-type: none;
 `
 
 export const Item = styled.button(

--- a/src/theme/tabs.js
+++ b/src/theme/tabs.js
@@ -5,6 +5,7 @@ export const getTabs = theme => {
     tabs: {
       'border-style': 'solid',
       'border-color': colors.nude[200],
+      'border-width': 0,
       'border-bottom-width': borderWidths.sm
     },
     item: {


### PR DESCRIPTION
when the resets are not imported by the user, the styles break

fixes issue #111
Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>