### PR TITLE
fix: use rem instead of px for icons

### DIFF
--- a/src/components/Icon/styles.js
+++ b/src/components/Icon/styles.js
@@ -22,8 +22,8 @@ const iconSvgFilledStyles = css`
 export const Icon = styled.svg(
   ({ size = 'md', stroked }) => css`
     ${stroked ? iconSvgStrokedStyles : iconSvgFilledStyles};
-    width: ${th(`icons.${size}`)}px;
-    height: ${th(`icons.${size}`)}px;
+    width: ${th(`icons.${size}`)};
+    height: ${th(`icons.${size}`)};
     ${system};
   `
 )

--- a/src/theme/core.js
+++ b/src/theme/core.js
@@ -65,11 +65,11 @@ export const getBaseTheme = (options = {}) => {
   }
 
   theme.icons = {
-    xs: 10,
-    sm: 16,
-    md: 24,
-    lg: 32,
-    xl: 48
+    xs: theme.toRem(10),
+    sm: theme.toRem(16),
+    md: theme.toRem(24),
+    lg: theme.toRem(32),
+    xl: theme.toRem(48)
   }
 
   theme.radii = radii


### PR DESCRIPTION
rems are now used to size the Icon component

fixes issue #159

Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>