### PR TITLE
fix: styles on tags now stick to the mockups

### DIFF
--- a/src/components/Tag/index.test.js
+++ b/src/components/Tag/index.test.js
@@ -12,7 +12,7 @@ describe('<Tag>', () => {
     const tag = getByTestId('tag')
 
     expect(tag).toHaveTextContent(content)
-    expect(tag).toHaveStyleRule('background-color', '#c4c4c4')
+    expect(tag).toHaveStyleRule('background-color', '#E5E5E5')
     expect(tag).toHaveStyleRule('color', '#727272')
     expect(tag).toHaveStyleRule('padding', '0.28125rem 0.375rem')
   })

--- a/src/theme/tags.js
+++ b/src/theme/tags.js
@@ -1,7 +1,7 @@
 export const getTags = ({ colors, fontSizes, fontWeights, space, toRem }) => ({
   default: {
     'font-size': fontSizes.meta2,
-    'font-weight': fontWeights.bold,
+    'font-weight': fontWeights.medium,
     'line-height': '1em',
     color: colors.nude[800]
   },

--- a/src/utils/variants.js
+++ b/src/utils/variants.js
@@ -34,7 +34,7 @@ export const getVariantStateColor = variant => {
 
 const variantColors = {
   blue: 'colors.sub.blue',
-  default: 'colors.nude.300',
+  default: 'colors.nude.100',
   green: 'colors.sub.green',
   orange: 'colors.sub.orange',
   pink: 'colors.sub.pink',


### PR DESCRIPTION
stick to the mockups for tags

fixes #141

Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>