### PR TITLE
fix: memory leak on date / time / dateTime Pickers

### DIFF
--- a/src/components/DatePicker/doc.mdx
+++ b/src/components/DatePicker/doc.mdx
@@ -26,7 +26,7 @@ _Note_: Pass a value of `null` if you don't want the default value of `Date.now(
 ## Pass props from [the original library](https://github.com/Hacker0x01/react-datepicker).
 
 <Playground>
-  <DatePicker dateFormat="MMM dd YYYY" showMonthDropdown showYearDropdown />
+  <DatePicker dateFormat="MMM dd yyyy" showMonthDropdown showYearDropdown />
 </Playground>
 
 ## Give an Icon

--- a/src/components/DatePicker/index.js
+++ b/src/components/DatePicker/index.js
@@ -8,13 +8,14 @@ import { DatePickerPopper } from '../DatePickerPopper'
 
 import * as S from './styles'
 
-const DEFAULT_FORMAT = 'dd/MM/yyyy'
+// Set default date in a const to avoid memory leak
+const DEFAULT_DATE = new Date()
 
 export const DatePicker = forwardRef(
   (
     {
       autoFocus,
-      dateFormat = DEFAULT_FORMAT,
+      dateFormat = 'dd/MM/yyyy',
       icon,
       iconPlacement = 'left',
       inputRef,
@@ -23,7 +24,7 @@ export const DatePicker = forwardRef(
       onFocus,
       placeholder,
       size = 'lg',
-      value = new Date(),
+      value = DEFAULT_DATE,
       ...rest
     },
     ref

--- a/src/components/DateTimePicker/doc.mdx
+++ b/src/components/DateTimePicker/doc.mdx
@@ -33,7 +33,7 @@ _Note_: Pass a value of `null` if you don't want the default value of `Date.now(
 
 <Playground>
   <DateTimePicker value={Date.now()}>
-    <DatePicker dateFormat="MMM dd YYYY" showMonthDropdown showYearDropdown />
+    <DatePicker dateFormat="MMM dd yyyy" showMonthDropdown showYearDropdown />
     <TimePicker />
   </DateTimePicker>
 </Playground>

--- a/src/components/DateTimePicker/index.js
+++ b/src/components/DateTimePicker/index.js
@@ -8,8 +8,11 @@ import { TimePicker } from '../TimePicker'
 
 import * as S from './styles'
 
+// Set default date in a const to avoid memory leak
+const DEFAULT_DATE = new Date()
+
 export const DateTimePicker = forwardRef(
-  ({ children, onChange, size = 'lg', value = new Date() }, ref) => {
+  ({ children, onChange, size = 'lg', value = DEFAULT_DATE }, ref) => {
     const [date, setDate] = useState(value)
 
     const handleChange = newDate => {

--- a/src/components/TimePicker/index.js
+++ b/src/components/TimePicker/index.js
@@ -8,15 +8,15 @@ import { DatePickerPopper } from '../DatePickerPopper'
 
 import * as S from './styles'
 
-const DEFAULT_INTERVAL = 15
-const DEFAULT_FORMAT = 'HH:mm'
+// Set default date in a const to avoid memory leak
+const DEFAULT_DATE = new Date()
 
 export const TimePicker = forwardRef(
   (
     {
       autoFocus,
-      dateFormat = DEFAULT_FORMAT,
-      value = new Date(),
+      dateFormat = 'HH:mm',
+      value = DEFAULT_DATE,
       onBlur,
       onChange,
       onFocus,
@@ -25,7 +25,7 @@ export const TimePicker = forwardRef(
       iconPlacement = 'left',
       inputRef,
       placeholder,
-      timeIntervals = DEFAULT_INTERVAL,
+      timeIntervals = 15,
       ...rest
     },
     ref


### PR DESCRIPTION
also fix invalid dateFormat used in the docs (cf https://welcome-ui.now.sh/fields/date-picker#pass-props-from-the-original-library)

Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>