### PR TITLE
fix: remove clearButton if Date or Time Pickers have no value

### DIFF
--- a/src/components/DateTimePicker/CustomInput.js
+++ b/src/components/DateTimePicker/CustomInput.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react'
-import { func, oneOf } from 'prop-types'
+import { func, oneOf, string } from 'prop-types'
 
 import { COMPONENT_TYPE, SIZES_TYPE } from '../../utils'
 import { IconWrapper } from '../Field/styles'
@@ -19,6 +19,7 @@ export class CustomInput extends PureComponent {
       inputRef,
       onReset,
       size,
+      value,
       ...rest
     } = this.props
 
@@ -36,10 +37,12 @@ export class CustomInput extends PureComponent {
             {icon}
           </IconWrapper>
         )}
-        <input ref={inputRef} {...rest} />
-        <IconWrapper iconPlacement="right" size={size}>
-          <ClearButton onClick={onReset} />
-        </IconWrapper>
+        <input ref={inputRef} value={value} {...rest} />
+        {value && (
+          <IconWrapper iconPlacement="right" size={size}>
+            <ClearButton aria-label="clear date" onClick={onReset} />
+          </IconWrapper>
+        )}
       </S.CustomInput>
     )
   }
@@ -53,5 +56,6 @@ CustomInput.propTypes = {
   iconPlacement: oneOf('right', 'left'),
   inputRef: func,
   onReset: func,
-  size: SIZES_TYPE
+  size: SIZES_TYPE,
+  value: string
 }

--- a/src/components/DateTimePicker/index.test.js
+++ b/src/components/DateTimePicker/index.test.js
@@ -119,7 +119,7 @@ test('<DateTimePicker> updating text updates selects', () => {
   expect(yearSelect).toHaveTextContent('2018')
 })
 
-test('<DatePicker> can be cleared', () => {
+test('<DatePicker> can be cleared and has no `ClearButton` when no value', () => {
   const { container, getAllByRole, getByTestId } = render(
     <Form initialValues={{ welcome: new Date() }}>
       <ConnectedField component={DateTimePicker} name="welcome" />
@@ -127,11 +127,18 @@ test('<DatePicker> can be cleared', () => {
   )
 
   const datePicker = container.querySelector('.date-picker')
-  const clearButton = getAllByRole('button')[0]
+  const [clearButton] = getAllByRole('button')
 
   fireEvent.click(clearButton)
+
   expect(datePicker).toHaveValue('')
 
   const formValues = getFormValues(getByTestId('values'))
   expect(formValues.welcome).toBeUndefined()
+  expect(clearButton).not.toBeInTheDocument()
+
+  userEvent.type(datePicker, '20/06/2018')
+
+  expect(datePicker).toHaveValue('20/06/2018')
+  expect(getAllByRole('button')[0]).toBeInTheDocument()
 })


### PR DESCRIPTION
Fixes #370
Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>