### PR TITLE
refactor: new Link primary styles and applyOn prop

### DIFF
--- a/docz/Dependencies.js
+++ b/docz/Dependencies.js
@@ -17,12 +17,13 @@ export const Dependencies = ({ dependencies }) => {
         return (
           <li as={Button} key={dependency}>
             <Link
+              applyOn="span"
               border="none"
               href={`https://npmjs.com/package/${dependency}/v/${baseVersion}`}
               rel="nofollow"
               target="_npm"
             >
-              {dependency}
+              <span>{dependency}</span>
               <Tag ml="sm" size="md">
                 {version}
               </Tag>

--- a/packages/Core/theme/core.js
+++ b/packages/Core/theme/core.js
@@ -1,3 +1,4 @@
+import { css } from '@xstyled/styled-components'
 import merge from 'ramda/src/mergeDeepRight'
 import { rpxTransformers } from '@xstyled/system'
 
@@ -99,16 +100,26 @@ export const createTheme = (options = {}) => {
     md: '3px 4px 10px 0 rgba(0,0,0,0.07)'
   }
 
-  theme.underline = {
-    'border-bottom-style': 'solid',
-    'border-bottom-width': theme.borderWidths.sm
-  }
-
   theme = merge(theme, rest)
+
+  theme.underline = css`
+    background-image: linear-gradient(
+      0deg,
+      ${theme.colors.primary[500]},
+      ${theme.colors.primary[500]} 100%
+    );
+    background-repeat: no-repeat;
+    background-size: 100% 50%;
+    background-position-y: calc(200% - ${theme.borderWidths.sm});
+    transition: background-position-y ${theme.transitions.medium};
+  `
+
+  theme.underlineHover = css`
+    background-position-y: 100%;
+  `
 
   // CSS blocks
   // These attributes depend on colors and fontSizes and must come last
-  theme.underline['border-bottom-color'] = theme.colors.primary[500]
   theme.alerts = getAlerts(theme)
   theme.buttons = getButtons(theme)
   theme.fields = getFields(theme)

--- a/packages/Core/theme/welcomekit.js
+++ b/packages/Core/theme/welcomekit.js
@@ -1,6 +1,3 @@
-import { createTheme } from './core'
-const theme = createTheme()
-
 const palette = {
   jade: '#00A772',
   mountainmeadow: '#23C28F',
@@ -120,9 +117,6 @@ export const welcomekitTheme = {
       'background-color': colors.primary[100],
       color: colors.secondary[700]
     }
-  },
-  underline: {
-    'border-bottom-width': theme.borderWidths.md
   },
   fields: {
     default: {

--- a/packages/InputText/styles.js
+++ b/packages/InputText/styles.js
@@ -6,6 +6,7 @@ import { fieldStyles } from '@welcome-ui/utils'
 export const InputText = styled(filterFieldComponent('input'))(
   ({ connected, icon, iconPlacement, isClearable, size, ...rest }) => css`
     ${fieldStyles};
+    text-overflow: ellipsis;
 
     ${icon &&
       iconPlacement === 'left' &&

--- a/packages/Link/doc.mdx
+++ b/packages/Link/doc.mdx
@@ -43,18 +43,79 @@ It can also be `disabled`
   </Link>
 </Playground>
 
-## Special case
-
-Use `<Text>` with `underline` props to add specific style _(here a border line)_
+## It works on multiple lines too
 
 <Playground>
   <Box>
-    <Link as={LinkDocz} to="/components/shape" variant="secondary">
+    <Link as={LinkDocz} to="/components/shape" variant="primary">
+      Ipsum ipsam fugiat doloribus sit hic ducimus dolorem Aperiam unde adipisci deserunt corporis
+      neque commodi. Quasi odit esse molestias reprehenderit incidunt Velit non expedita atque
+      exercitationem enim! Quidem quasi nihil.
+    </Link>
+  </Box>
+</Playground>
+
+## If you want to apply variant styles on specific css selector
+
+Can be a tag like _span_ or _div_
+
+<Playground>
+  <Box>
+    <Link
+      alignItems="center"
+      applyOn="span"
+      as={LinkDocz}
+      display="inline-flex"
+      to="/components/shape"
+      variant="primary"
+    >
       <Shape height="30px" shape="circle" width="30px">
         <img src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4" />
       </Shape>
-      <Text as="span" underline variant="body2">
+      <Text as="span" variant="body2">
         see shape component
+      </Text>
+    </Link>
+  </Box>
+  <Box>
+    <Link
+      alignItems="center"
+      applyOn="div"
+      as={LinkDocz}
+      display="inline-flex"
+      to="/components/shape"
+      variant="secondary"
+    >
+      <Shape height="30px" shape="circle" width="30px">
+        <img src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4" />
+      </Shape>
+      <Text as="span" variant="body2">
+        see shape component
+      </Text>
+    </Link>
+  </Box>
+</Playground>
+
+Can be any css selector _span:last-child_
+
+<Playground>
+  <Box>
+    <Link
+      alignItems="center"
+      applyOn="span:last-child"
+      as={LinkDocz}
+      display="inline-flex"
+      to="/components/shape"
+      variant="primary"
+    >
+      <Shape height="30px" shape="circle" width="30px">
+        <img src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4" />
+      </Shape>
+      <Text as="span" variant="body2">
+        first span
+      </Text>
+      <Text as="span" variant="body2">
+        second span
       </Text>
     </Link>
   </Box>

--- a/packages/Link/index.js
+++ b/packages/Link/index.js
@@ -1,21 +1,25 @@
 import styled, { css } from '@xstyled/styled-components'
 import { th } from '@xstyled/system'
 import { UniversalLink } from '@welcome-ui/universal-link'
-import { system } from '@welcome-ui/system'
+import { filterComponent, system } from '@welcome-ui/system'
 
-export const Link = styled(UniversalLink)(
-  ({ variant }) => css`
-    display: inline-flex;
-    flex-direction: row;
-    align-items: center;
+export const Link = styled(filterComponent(UniversalLink))(
+  ({ applyOn, variant }) => css`
     opacity: 1;
     text-decoration: none;
     cursor: pointer;
-    transition: opacity 300ms;
+    transition: medium;
+    transition-property: opacity;
 
     &:hover,
     &:focus {
-      opacity: 0.6;
+      ${applyOn &&
+        css`
+          > ${applyOn} {
+            ${th(`links.${variant || 'primary'}.hover`)};
+          }
+        `}
+      ${!applyOn && th(`links.${variant || 'primary'}.hover`)};
       outline: none !important; /* important for firefox */
     }
 
@@ -25,7 +29,14 @@ export const Link = styled(UniversalLink)(
     }
 
     ${th('links.default')};
-    ${th(`links.${variant || 'primary'}`)};
+    ${applyOn &&
+      css`
+        > ${applyOn} {
+          transition: inherit;
+          ${th(`links.${variant || 'primary'}.default`)};
+        }
+      `}
+    ${!applyOn && th(`links.${variant || 'primary'}.default`)}
     ${system};
 
     & > *:not(:only-child):not(:last-child) {

--- a/packages/Link/theme.js
+++ b/packages/Link/theme.js
@@ -1,10 +1,20 @@
+import { css } from '@xstyled/styled-components'
+
 export const getLinks = theme => {
-  const { colors, underline } = theme
+  const { colors, underline, underlineHover } = theme
   return {
     default: {
       color: colors.dark[500]
     },
-    primary: underline,
-    secondary: {}
+    primary: {
+      default: underline,
+      hover: underlineHover
+    },
+    secondary: {
+      default: '',
+      hover: css`
+        opacity: 0.6;
+      `
+    }
   }
 }

--- a/packages/Text/index.js
+++ b/packages/Text/index.js
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react'
-import { node, number, oneOf, oneOfType } from 'prop-types'
+import { bool, node, number, oneOf, oneOfType } from 'prop-types'
 
 import { COMPONENT_TYPE } from '../../src/utils/propTypes'
 
@@ -21,7 +21,7 @@ const TAG_NAMES = {
 }
 
 export const Text = forwardRef(
-  ({ as, children, dataTestId, lines, variant = 'body1', ...rest }, ref) => {
+  ({ as, children, dataTestId, lines, underline = false, variant = 'body1', ...rest }, ref) => {
     const tagName = as || TAG_NAMES[variant]
 
     return (
@@ -30,6 +30,7 @@ export const Text = forwardRef(
         data-testid={dataTestId}
         lines={lines}
         ref={ref}
+        underline={underline}
         variant={variant}
         {...rest}
       >
@@ -45,5 +46,6 @@ Text.propTypes /* remove-proptypes */ = {
   as: oneOfType(COMPONENT_TYPE),
   children: node,
   lines: number,
+  underline: bool,
   variant: oneOf(Object.keys(TAG_NAMES))
 }

--- a/packages/UniversalLink/styles.js
+++ b/packages/UniversalLink/styles.js
@@ -1,6 +1,7 @@
 import styled from '@xstyled/styled-components'
+import { filterComponent } from '@welcome-ui/system'
 
-export const UniversalLink = styled.a`
+export const UniversalLink = styled(filterComponent('a'))`
   color: inherit;
   text-decoration: none;
 `


### PR DESCRIPTION
BREAKING CHANGE for custom Links where you don't want the whole Link
to be styled with its variant styles, use applyOn prop (css selector string)
to choose the element on which you want your variant styles to be applied on

Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>