### PR TITLE
fix: add margins to CodeEditor except on DropdownMenu to avoid warnings

### DIFF
--- a/docz/CodeEditor.styled.js
+++ b/docz/CodeEditor.styled.js
@@ -3,7 +3,7 @@ import { th } from '@xstyled/system'
 import { LiveEditor as ReactLiveEditor, LiveError as ReactLiveError } from 'react-live'
 
 import { Card } from '../packages/Card'
-import { DropdownMenu } from '../packages/DropdownMenu'
+import { Inner } from '../packages/DropdownMenu/styles'
 
 export const LiveEditor = styled(ReactLiveEditor)`
   margin-top: md;
@@ -46,7 +46,7 @@ export const LivePreviewContent = styled.div(
         & > div {
           margin-bottom: -sm;
 
-          & > *:not(${DropdownMenu.Menu}) {
+          & > *:not(${Inner}) {
             margin-right: sm;
             margin-bottom: sm;
           }


### PR DESCRIPTION
Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>