### PR TITLE
Use xstyled's box instead of system

### DIFF
--- a/packages/Box/doc.mdx
+++ b/packages/Box/doc.mdx
@@ -12,7 +12,7 @@ const { dependencies, peerDependencies, component, name, version } = require('./
 
 <TagVersion version={version} name={name} />
 
-Use properties from [xstyled](https://xstyled.dev/docs/style-props/).
+Is an export of [xstyled's `<Box>` component](https://xstyled.dev/docs/style-using-props/#use-the-box-component).
 
 ## Install and import
 
@@ -27,9 +27,9 @@ Use properties from [xstyled](https://xstyled.dev/docs/style-props/).
     height="500px"
     justifyContent="center"
     alignItems="center"
-    backgroundColor="primary.100"
+    backgroundColor="nude.100"
   >
-    <Box backgroundColor="light.900" padding="50px">
+    <Box backgroundColor="light.900" borderRadius="sm" padding="50px" boxShadow="sm">
       Centered Box
     </Box>
   </Box>

--- a/packages/Box/index.js
+++ b/packages/Box/index.js
@@ -1,9 +1,1 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system } from '@welcome-ui/system'
-
-export const Box = styled.div(
-  () =>
-    css`
-      ${system};
-    `
-)
+export { Box } from '@xstyled/styled-components'

--- a/packages/Stack/index.test.js
+++ b/packages/Stack/index.test.js
@@ -12,8 +12,8 @@ describe('<Stack>', () => {
     const foo = getByText('Foo')
     const bar = getByText('Bar')
 
-    expect(foo.parentElement).toHaveStyleRule('margin-bottom', '0.75rem')
-    expect(bar.parentElement).not.toHaveStyleRule()
+    expect(getComputedStyle(foo.parentElement).marginBottom).toBe('0.75rem')
+    expect(getComputedStyle(bar.parentElement).marginBottom).toBe('')
   })
 
   it('should render correctly with custom props', () => {
@@ -24,7 +24,7 @@ describe('<Stack>', () => {
     )
     const foo = getByText('Foo')
 
-    expect(foo.parentElement).toHaveStyleRule('margin-right', '1.5rem')
+    expect(getComputedStyle(foo.parentElement).marginRight).toBe('1.5rem')
     expect(foo.parentElement.tagName).toBe('LI')
   })
 })

--- a/packages/System/index.test.js
+++ b/packages/System/index.test.js
@@ -17,6 +17,6 @@ describe('<Box>', () => {
 
     expect(container).toHaveTextContent(content)
     // check if font-style is set to italic
-    expect(box).toHaveStyleRule('font-style', 'italic')
+    expect(getComputedStyle(box).fontStyle).toBe('italic')
   })
 })


### PR DESCRIPTION
![localhost_3020_components_box](https://user-images.githubusercontent.com/243189/78025694-be966680-735a-11ea-9501-2ff4e0c016e5.png)

⚠️ A caveat is that `toHaveStyleRule` doesn't work with `<Box>` anymore, I tried other solutions and they didn't work, e.g:

```jsx
import styled from '@xstyled/styled-components'

export const Box = styled.box``
```

```jsx
import { Box as XStyledBox } from '@xstyled/styled-components'

export const Box = styled(XStyledBox)``
```

But the fix is quite simple, e.g: https://github.com/WTTJ/welcome-ui/pull/566/files#diff-3b0b985ffc5b2bd14071e7fc664710ccL27-R27