### PR TITLE
fix(tabs): tab panel should use tabId prop instead of id

### DIFF
--- a/packages/Tabs/doc.mdx
+++ b/packages/Tabs/doc.mdx
@@ -47,19 +47,19 @@ Set the tab activated by default using `selectedId` on `useTabState`.
             Tab 5
           </Tab>
         </Tab.List>
-        <Tab.Panel {...tab} id="tab1">
+        <Tab.Panel {...tab} tabId="tab1">
           Tab.Panel 1
         </Tab.Panel>
-        <Tab.Panel {...tab} id="tab2">
+        <Tab.Panel {...tab} tabId="tab2">
           Tab.Panel 2
         </Tab.Panel>
-        <Tab.Panel {...tab} id="tab3">
+        <Tab.Panel {...tab} tabId="tab3">
           Tab.Panel 3
         </Tab.Panel>
-        <Tab.Panel {...tab} id="tab4">
+        <Tab.Panel {...tab} tabId="tab4">
           Tab.Panel 4
         </Tab.Panel>
-        <Tab.Panel {...tab} disabled id="tab5">
+        <Tab.Panel {...tab} disabled tabId="tab5">
           Tab.Panel 5
         </Tab.Panel>
       </>
@@ -94,13 +94,13 @@ Add badges in tab.
             Tab 3
           </Tab>
         </Tab.List>
-        <Tab.Panel {...tab} id="tab1">
+        <Tab.Panel {...tab} tabId="tab1">
           Tab.Panel 1
         </Tab.Panel>
-        <Tab.Panel {...tab} id="tab2">
+        <Tab.Panel {...tab} tabId="tab2">
           Tab.Panel 2
         </Tab.Panel>
-        <Tab.Panel {...tab} id="tab3">
+        <Tab.Panel {...tab} tabId="tab3">
           Tab.Panel 3
         </Tab.Panel>
       </>
@@ -128,13 +128,13 @@ Use another component in tab.
             Tab 3
           </Tab>
         </Tab.List>
-        <Tab.Panel {...tab} id="tab1">
+        <Tab.Panel {...tab} tabId="tab1">
           Tab.Panel 1
         </Tab.Panel>
-        <Tab.Panel {...tab} id="tab2">
+        <Tab.Panel {...tab} tabId="tab2">
           Tab.Panel 2
         </Tab.Panel>
-        <Tab.Panel {...tab} id="tab3">
+        <Tab.Panel {...tab} tabId="tab3">
           Tab.Panel 3
         </Tab.Panel>
       </>
@@ -156,7 +156,7 @@ Active bar doesn't display with only one tab.
             Tab 1
           </Tab>
         </Tab.List>
-        <Tab.Panel {...tab} id="tab1">
+        <Tab.Panel {...tab} tabId="tab1">
           Tab.Panel 1
         </Tab.Panel>
       </>

--- a/packages/Tabs/index.js
+++ b/packages/Tabs/index.js
@@ -73,9 +73,9 @@ TabList.propTypes /* remove-proptypes */ = {
   children: node
 }
 
-export const TabPanel = React.forwardRef(({ as, children, id, ...props }, ref) => {
+export const TabPanel = React.forwardRef(({ as, children, tabId, ...props }, ref) => {
   return (
-    <ReakitTabPanel id={id} ref={ref} {...props}>
+    <ReakitTabPanel ref={ref} tabId={tabId} {...props}>
       {tabPanelProps => (
         <S.TabPanel as={as} {...tabPanelProps}>
           {children}
@@ -88,7 +88,7 @@ TabPanel.displayName = 'TabPanel'
 TabPanel.propTypes /* remove-proptypes */ = {
   as: oneOfType(COMPONENT_TYPE),
   children: node,
-  id: string.isRequired
+  tabId: string
 }
 
 export const Tab = React.forwardRef(({ as, children, id, ...props }, ref) => {

--- a/packages/Tabs/index.test.js
+++ b/packages/Tabs/index.test.js
@@ -28,13 +28,13 @@ describe('Tabs', () => {
               Tab 3
             </Tab>
           </Tab.List>
-          <Tab.Panel id="tab1" {...tab}>
+          <Tab.Panel tabId="tab1" {...tab}>
             Panel 1
           </Tab.Panel>
-          <Tab.Panel id="tab2" {...tab}>
+          <Tab.Panel tabId="tab2" {...tab}>
             Panel 2
           </Tab.Panel>
-          <Tab.Panel id="tab3" {...tab}>
+          <Tab.Panel tabId="tab3" {...tab}>
             Panel 3
           </Tab.Panel>
         </>
@@ -86,7 +86,7 @@ describe('Tabs', () => {
                 Tab 1
               </Tab>
             </Tab.List>
-            <Tab.Panel id="tab1" {...tab}>
+            <Tab.Panel tabId="tab1" {...tab}>
               Panel 1
             </Tab.Panel>
           </>


### PR DESCRIPTION
On the Reakit's `TabPanel` component, `stopId` has been renamed to `tabId`, not `id`.

Note also that both `Tab`'s `id` and `TabPanel`'s `tabId` aren't required anymore. Reakit now uses the DOM order to determine the `Tab`/`TabPanel` relationship, although you can still set `id`/`tabId`, especially if you render panels out of order.