### PR TITLE
fix: add forceFileType on fileDrop

### DIFF
--- a/packages/FileDrop/FilePreview.js
+++ b/packages/FileDrop/FilePreview.js
@@ -1,20 +1,20 @@
 import React from 'react'
-import { object, oneOfType, string } from 'prop-types'
+import { object, oneOf, oneOfType, string } from 'prop-types'
 import { Button } from '@welcome-ui/button'
 import { Text } from '@welcome-ui/text'
 import { ExternalLinkIcon } from '@welcome-ui/icons.external_link'
 import { getFileIcon, getFileName, getFileSize } from '@welcome-ui/files'
 
-export const FilePreview = ({ file }) => {
+export const FilePreview = ({ file, forceFileType }) => {
   const isUrl = typeof file === 'string'
-  const Icon = getFileIcon(file)
+  const Icon = getFileIcon(file, forceFileType)
   const size = getFileSize(file)
   const name = getFileName(file)
 
   return (
     <>
       <Icon color="dark.200" height={50} mb="md" width={50} />
-      <Text color="dark.200" fontWeight="bold" lines={1} m={0}>
+      <Text color="dark.200" fontWeight="bold" lines={1} m={0} maxWidth={600}>
         {name}
       </Text>
       {!isUrl && (
@@ -33,5 +33,6 @@ export const FilePreview = ({ file }) => {
 }
 
 FilePreview.propTypes /* remove-proptypes */ = {
-  file: oneOfType([string, object])
+  file: oneOfType([string, object]),
+  forceFileType: oneOf(['image', 'audio', 'video'])
 }

--- a/packages/FileDrop/Preview.js
+++ b/packages/FileDrop/Preview.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { bool, func, object, oneOfType, string } from 'prop-types'
+import { bool, func, object, oneOf, oneOfType, string } from 'prop-types'
 import { NegativeIcon } from '@welcome-ui/icons.negative'
 import { PositiveIcon } from '@welcome-ui/icons.positive'
 
@@ -12,6 +12,7 @@ export const Preview = ({
   error,
   file,
   fileUrl,
+  forceFileType,
   isAnImage,
   isHoverAccept,
   isHoverReject,
@@ -27,7 +28,7 @@ export const Preview = ({
     if (isAnImage) {
       return <ImagePreview src={fileUrl} />
     } else {
-      return <FilePreview file={file} />
+      return <FilePreview file={file} forceFileType={forceFileType} />
     }
   }
   return <Message disabled={disabled} openFile={openFile} />
@@ -38,6 +39,7 @@ Preview.propTypes /* remove-proptypes */ = {
   error: string,
   file: oneOfType([string, object]),
   fileUrl: string,
+  forceFileType: oneOf(['image', 'audio', 'video']),
   isAnImage: bool,
   isHoverAccept: bool,
   isHoverReject: bool,

--- a/packages/FileDrop/doc.mdx
+++ b/packages/FileDrop/doc.mdx
@@ -71,7 +71,6 @@ By default, `accept`: is set to `image/*`, see more about [media type](http://ww
         name="avatar"
         onAddFile={console.debug}
         onRemoveFile={console.debug}
-        required
       />
     </Form>
   )}
@@ -96,7 +95,41 @@ By default, `accept`: is set to `image/*`, see more about [media type](http://ww
         name="file"
         onAddFile={console.debug}
         onRemoveFile={console.debug}
-        required
+      />
+    </Form>
+  )}
+</Playground>
+
+## File without type
+
+Sometime in the url we don't have the type of the file, you can override with `forceFileType` set to `image`, `audio` or `video`.
+
+<Playground>
+  {() => (
+    <Form
+      initialValues={{
+        file1:
+          'https://cdn-images.welcomehome.io/zn9KvR98haoYRV6m1T-LR4c5h0HPZtVtvzwKPv02wgA/rs:auto:600::/q:100/czM6Ly93aC1wcml2YXRlLXByb2R1Y3Rpb24vcHJvZHVjdGlvbi91cGxvYWRzL3doL2Jsb2Nrcy9iZTI2MTc4OC1mYjc5LTRlZTQtYjQ4OC04ZDhiYTk4YTY3NDIvY292ZXIvdHdpdHRlckB4Mi5wbmc',
+        file2:
+          'https://cdn-images.welcomehome.io/zn9KvR98haoYRV6m1T-LR4c5h0HPZtVtvzwKPv02wgA/rs:auto:600::/q:100/czM6Ly93aC1wcml2YXRlLXByb2R1Y3Rpb24vcHJvZHVjdGlvbi91cGxvYWRzL3doL2Jsb2Nrcy9iZTI2MTc4OC1mYjc5LTRlZTQtYjQ4OC04ZDhiYTk4YTY3NDIvY292ZXIvdHdpdHRlckB4Mi5wbmc'
+      }}
+    >
+      <ConnectedField
+        component={FileDrop}
+        label="Image file"
+        name="file1"
+        onAddFile={console.debug}
+        onRemoveFile={console.debug}
+        forceFileType="image"
+      />
+      <ConnectedField
+        component={FileDrop}
+        mt="xl"
+        label="Music file"
+        name="file2"
+        onAddFile={console.debug}
+        onRemoveFile={console.debug}
+        forceFileType="audio"
       />
     </Form>
   )}

--- a/packages/FileDrop/index.js
+++ b/packages/FileDrop/index.js
@@ -1,5 +1,5 @@
 import React, { forwardRef, useEffect, useState } from 'react'
-import { bool, func, node, number, object, oneOfType, string } from 'prop-types'
+import { bool, func, node, number, object, oneOf, oneOfType, string } from 'prop-types'
 import { useDropzone } from 'react-dropzone'
 import { CrossIcon } from '@welcome-ui/icons.cross'
 import { PencilIcon } from '@welcome-ui/icons.pencil'
@@ -34,6 +34,7 @@ export const FileDrop = forwardRef(
       onError,
       onRemoveFile,
       value,
+      forceFileType,
       ...rest
     },
     ref
@@ -133,7 +134,8 @@ export const FileDrop = forwardRef(
           {children({
             error,
             file,
-            isAnImage: isAnImage(file),
+            forceFileType,
+            isAnImage: forceFileType === 'image' || isAnImage(file),
             fileUrl: file && getPreviewUrl(file),
             isDefault: !file && !isDragActive,
             isHoverAccept: isDragAccept,
@@ -174,11 +176,12 @@ export const FileDrop = forwardRef(
 FileDrop.type = 'FileDrop'
 FileDrop.displayName = 'FileDrop'
 
-FileDrop.propTypes = {
+FileDrop.propTypes = /* remove-proptypes */ {
   /** Pass a comma-separated string of file types e.g. "image/png" or "image/png,image/jpeg"  */
   accept: string,
   children: func,
   disabled: bool,
+  forceFileType: oneOf(['image', 'audio', 'video']),
   isClearable: bool,
   isEditable: bool,
   maxSize: number,

--- a/packages/FileDrop/styles.js
+++ b/packages/FileDrop/styles.js
@@ -3,7 +3,14 @@ import { th } from '@xstyled/system'
 import { componentSystem, filterFieldComponent, system } from '@welcome-ui/system'
 import { fieldStyles } from '@welcome-ui/utils'
 
-const FILTER_PROPS = ['onAddFile', 'onRemoveFile', 'isDragAccept', 'isDragActive', 'isDragReject']
+const FILTER_PROPS = [
+  'onAddFile',
+  'onRemoveFile',
+  'isDragAccept',
+  'isDragActive',
+  'isDragReject',
+  'forceFileType'
+]
 
 const getBorderColor = ({ isDragAccept, isDragReject }) => {
   if (isDragAccept) {

--- a/packages/Files/index.js
+++ b/packages/Files/index.js
@@ -24,20 +24,20 @@ const getMimeType = file => file.type || getType(getFileName(file).split('.')[1]
 
 export const getFileSize = file => (file.size ? formatBytes(file.size, 0) : null)
 
-export const getFileIcon = file => {
+export const getFileIcon = (file, forceFileType) => {
   const mimeType = getMimeType(file)
 
-  if (!mimeType) {
+  if (!forceFileType && !mimeType) {
     return AttachmentIcon
   }
 
-  if (mimeType.startsWith('image/')) {
+  if (forceFileType === 'image' || (mimeType && mimeType.startsWith('image/'))) {
     return CameraIcon
   }
-  if (mimeType.startsWith('audio/')) {
+  if (forceFileType === 'audio' || (mimeType && mimeType.startsWith('audio/'))) {
     return MusicIcon
   }
-  if (mimeType.startsWith('video/')) {
+  if (forceFileType === 'video' || (mimeType && mimeType.startsWith('video/'))) {
     return VideoIcon
   }
 


### PR DESCRIPTION
Sometime in the url we don't have the type of the file, you can override with `forceFileType` set to `image`, `audio` or `video`.