### PR TITLE
fix: prevent error when some group children are undefined

### DIFF
--- a/packages/FileDrop/doc.mdx
+++ b/packages/FileDrop/doc.mdx
@@ -66,6 +66,7 @@ By default, `accept`: is set to `image/*`, see more about [media type](http://ww
         component={FileDrop}
         hint="Files must be < 2MB"
         isEditable
+        isClearable
         label="Avatar"
         name="avatar"
         onAddFile={console.debug}
@@ -139,6 +140,14 @@ Sometime in the url we don't have the type of the file, you can override with `f
 <Playground>
   <Form initialValues={{}}>
     <ConnectedField name="avatar" component={FileDrop} disabled />
+  </Form>
+</Playground>
+
+## Bare example
+
+<Playground>
+  <Form initialValues={{}}>
+    <ConnectedField name="avatar" component={FileDrop} />
   </Form>
 </Playground>
 

--- a/packages/FileDrop/doc.mdx
+++ b/packages/FileDrop/doc.mdx
@@ -66,7 +66,6 @@ By default, `accept`: is set to `image/*`, see more about [media type](http://ww
         component={FileDrop}
         hint="Files must be < 2MB"
         isEditable
-        isClearable
         label="Avatar"
         name="avatar"
         onAddFile={console.debug}

--- a/packages/Group/index.js
+++ b/packages/Group/index.js
@@ -5,14 +5,16 @@ import * as S from './styles'
 
 export const Group = ({ children, dataTestId, disabled, size, variant }) => {
   function setGlobalProps(children) {
-    return Children.map(children, child => {
-      return cloneElement(child, {
-        ...child.props,
-        disabled: disabled || child.props.disabled,
-        size: size || child.props.size,
-        variant: variant || child.props.variant
+    return Children.toArray(children)
+      .filter(Boolean)
+      .map(child => {
+        return cloneElement(child, {
+          ...child.props,
+          disabled: disabled || child.props.disabled,
+          size: size || child.props.size,
+          variant: variant || child.props.variant
+        })
       })
-    })
   }
 
   return <S.Group data-testid={dataTestId}>{setGlobalProps(children)}</S.Group>


### PR DESCRIPTION
I removed `isClearable` in the exemple of `FileDrop` because when it's not set, `Group` was trying to to access it: https://github.com/WTTJ/welcome-ui/blob/master/packages/Group/index.js#L10