### PR TITLE
feat: redesign hint & placeholder

### DIFF
--- a/packages/Field/theme.js
+++ b/packages/Field/theme.js
@@ -51,11 +51,11 @@ export const getFields = theme => {
       }
     },
     placeholder: {
-      color: colors.nude[600]
+      color: colors.light[500]
     },
     hint: {
-      color: colors.nude[600],
-      'font-size': fontSizes.body3,
+      color: colors.light[500],
+      'font-size': fontSizes.body4,
       'font-weight': fontWeights.regular
     },
     label: {

--- a/packages/Hint/index.test.js
+++ b/packages/Hint/index.test.js
@@ -13,7 +13,7 @@ describe('<Hint>', () => {
     const button = getByTestId('hint')
 
     expect(button).toHaveTextContent(content)
-    expect(button).toHaveStyleRule('color', colors.nude[600])
+    expect(button).toHaveStyleRule('color', colors.light[500])
   })
 
   it('should render correctly with a state', () => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/243189/84016790-13b7af80-a97e-11ea-82d0-be3cca24e184.png)

(placeholder has the same color as the normal hint as well)