### PR TITLE
feat: new tabs colors

### DIFF
--- a/packages/Tabs/theme.js
+++ b/packages/Tabs/theme.js
@@ -6,22 +6,22 @@ export const getTabs = theme => {
       bottom: borderWidths.sm,
       width: '100%',
       height: borderWidths.sm,
-      'background-color': colors.nude[200]
+      'background-color': colors.light[800]
     },
     item: {
       default: {
-        color: colors.nude[600],
-        'font-size': fontSizes.body2,
-        'font-weight': fontWeights.medium
+        color: colors.light[100],
+        'font-weight': fontWeights.medium,
+        'font-size': fontSizes.body1
       },
       active: {
-        color: colors.dark[700]
+        color: colors.dark[900]
       },
       focus: {
-        color: colors.nude[800]
+        color: colors.dark[900]
       },
       disabled: {
-        color: colors.nude[400]
+        color: colors.light[700]
       }
     },
     panel: {
@@ -31,10 +31,9 @@ export const getTabs = theme => {
       }
     },
     activeBar: {
-      bottom: 0,
+      bottom: '1px',
       background: colors.primary[500],
-      height: '3px',
-      'border-radius': '3px'
+      height: '1px'
     }
   }
 }

--- a/packages/Tag/theme.js
+++ b/packages/Tag/theme.js
@@ -14,9 +14,16 @@ export const getTags = theme => {
     'border-style': 'solid'
   }
 
+  const withoutVisibleBorder = color => ({
+    ...border,
+    'border-color': color,
+    'background-color': color
+  })
+
   return {
     default: {
       'font-weight': fontWeights.medium,
+      'background-color': colors.light[900],
       color: colors.light[900]
     },
     variants: {
@@ -26,14 +33,14 @@ export const getTags = theme => {
         'border-color': hexToRGBA(colors.dark[900], 0.1),
         ...border
       },
-      primary: { 'background-color': colors.primary[500], color: colors.dark[900] },
+      primary: { ...withoutVisibleBorder(colors.primary[500]), color: colors.dark[900] },
       secondary: {
         'background-color': colors.sub[4],
         color: colors.light[900],
         'border-color': hexToRGBA(colors.dark[900], 0.1),
         ...border
       },
-      dark: { 'background-color': colors.dark[900] },
+      dark: { ...withoutVisibleBorder(colors.dark[900]) },
       success: {
         'background-color': colors.success[100],
         color: colors.success[500],
@@ -58,12 +65,12 @@ export const getTags = theme => {
         'border-color': colors.info[200],
         ...border
       },
-      1: { 'background-color': colors.sub[1] },
-      2: { 'background-color': colors.sub[2] },
-      3: { 'background-color': colors.sub[3] },
-      4: { 'background-color': colors.sub[4] },
-      5: { 'background-color': colors.sub[5] },
-      6: { 'background-color': colors.sub[6] }
+      1: { ...withoutVisibleBorder(colors.sub[1]) },
+      2: { ...withoutVisibleBorder(colors.sub[2]) },
+      3: { ...withoutVisibleBorder(colors.sub[3]) },
+      4: { ...withoutVisibleBorder(colors.sub[4]) },
+      5: { ...withoutVisibleBorder(colors.sub[5]) },
+      6: { ...withoutVisibleBorder(colors.sub[6]) }
     },
     sizes: {
       sm: {


### PR DESCRIPTION
<img width="429" alt="Capture d’écran 2020-06-08 à 17 47 24" src="https://user-images.githubusercontent.com/50322149/84052152-75910d00-a9b0-11ea-889b-2ea454d5b209.png">
