### PR TITLE
fix: change get* to only * for theme exports & use local theme for label

### DIFF
--- a/packages/Checkbox/theme.js
+++ b/packages/Checkbox/theme.js
@@ -1,6 +1,6 @@
 import { css } from '@xstyled/styled-components'
 
-export const getCheckboxes = () => ({
+export const checkboxes = {
   default: css`
     width: 20;
     height: 20;
@@ -14,4 +14,4 @@ export const getCheckboxes = () => ({
     border-color: primary.500;
     color: dark.900;
   `
-})
+}

--- a/packages/Core/theme/core.js
+++ b/packages/Core/theme/core.js
@@ -14,13 +14,14 @@ import { getIcons } from '../../Icon/theme'
 import { getTags } from '../../Tag/theme'
 import { getTooltips } from '../../Tooltip/theme'
 import { getDropdownMenu } from '../../DropdownMenu/theme'
-import { getTables } from '../../Table/theme'
 import { getCards } from '../../Card/theme'
 import { getModals } from '../../Modal/theme'
 import { getLoaders } from '../../Loader/theme'
 import { getAccordions } from '../../Accordion/theme'
 import { getSwipers } from '../../Swiper/theme'
-import { getCheckboxes } from '../../Checkbox/theme'
+import { checkboxes } from '../../Checkbox/theme'
+import { tables } from '../../Table/theme'
+import { labels } from '../../Label/theme'
 
 import { colors } from './colors'
 import { fontFaces } from './fonts'
@@ -35,7 +36,7 @@ import {
 } from './typography'
 import { transitionCurves, transitions } from './transitions'
 import { getUnderline } from './underline'
-import { getDefaultFields } from './defaultFields'
+import { defaultFields } from './defaultFields'
 
 const DEFAULT_FONT_SIZE = 16
 const DEFAULT_FONT_FAMILY = 'work-sans'
@@ -135,15 +136,16 @@ export const createTheme = (options = {}) => {
   theme.tooltips = getTooltips(theme)
   theme.links = getLinks(theme)
   theme.dropdownMenu = getDropdownMenu(theme)
-  theme.tables = getTables
+  theme.tables = tables
   theme.cards = getCards(theme)
   theme.modals = getModals(theme)
   theme.loaders = getLoaders(theme)
   theme.accordions = getAccordions(theme)
   theme.swipers = getSwipers(theme)
+  theme.labels = labels
   // fields
-  theme.defaultFields = getDefaultFields()
-  theme.checkboxes = getCheckboxes(theme)
+  theme.defaultFields = defaultFields
+  theme.checkboxes = checkboxes
 
   theme = merge(theme, rest)
 

--- a/packages/Core/theme/defaultFields.js
+++ b/packages/Core/theme/defaultFields.js
@@ -1,6 +1,6 @@
 import { css } from '@xstyled/styled-components'
 
-export const getDefaultFields = () => ({
+export const defaultFields = {
   default: css`
     color: nude.800;
     font-size: body3;
@@ -37,4 +37,4 @@ export const getDefaultFields = () => ({
   focused: css`
     border-color: primary.500;
   `
-})
+}

--- a/packages/Field/theme.js
+++ b/packages/Field/theme.js
@@ -58,12 +58,6 @@ export const getFields = theme => {
       'font-size': fontSizes.body4,
       'font-weight': fontWeights.regular
     },
-    label: {
-      color: colors.light[100],
-      'font-size': fontSizes.body3,
-      'font-weight': fontWeights.medium,
-      'min-height': '1.4em'
-    },
     checkablelabel: {
       default: {
         'font-weight': fontWeights.regular

--- a/packages/Label/styles.js
+++ b/packages/Label/styles.js
@@ -9,7 +9,7 @@ export const Label = styled.label(
     flex-shrink: 0;
     align-items: flex-start;
     line-height: body1;
-    ${th('fields.label')};
+    ${th('labels')};
     ${system};
     user-select: none;
 

--- a/packages/Label/theme.js
+++ b/packages/Label/theme.js
@@ -1,0 +1,8 @@
+import { css } from '@xstyled/styled-components'
+
+export const labels = css`
+  color: light.100;
+  font-size: body3;
+  font-weight: medium;
+  min-height: 1.4em;
+`

--- a/packages/Label/theme.js
+++ b/packages/Label/theme.js
@@ -4,5 +4,4 @@ export const labels = css`
   color: light.100;
   font-size: body3;
   font-weight: medium;
-  min-height: 1.4em;
 `

--- a/packages/Table/theme.js
+++ b/packages/Table/theme.js
@@ -1,6 +1,6 @@
 import { css } from '@xstyled/styled-components'
 
-export const getTables = {
+export const tables = {
   th: css`
     color: light.100;
     font-weight: medium;


### PR DESCRIPTION
- Create Label/theme.js and remove label key into Field/theme.js
- Use `tables` instead of `getTables` when the exported theme part is const (https://github.com/WTTJ/welcome-ui/pull/660#discussion_r437250275)