### PR TITLE
fix: don't override Link's Text fontWeight when using variant prop

### DIFF
--- a/packages/Link/index.js
+++ b/packages/Link/index.js
@@ -27,7 +27,7 @@ export const Link = forwardRef(({ children, variant = 'primary', ...props }, ref
       }
       return cloneElement(child, {
         color: theme.links.default.color,
-        fontWeight: child.props.variant ? null : theme.links.default.fontWeight,
+        fontWeight: child.props.variant ? undefined : theme.links.default.fontWeight,
         key,
         lineHeight: '1.5',
         ...child.props

--- a/packages/Link/index.js
+++ b/packages/Link/index.js
@@ -27,7 +27,7 @@ export const Link = forwardRef(({ children, variant = 'primary', ...props }, ref
       }
       return cloneElement(child, {
         color: theme.links.default.color,
-        fontWeight: theme.links.default.fontWeight,
+        fontWeight: child.props.variant ? null : theme.links.default.fontWeight,
         key,
         lineHeight: '1.5',
         ...child.props


### PR DESCRIPTION
Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>