### PR TITLE
fix: allow multiple types as size for Icon and Loader

### DIFF
--- a/packages/Icon/doc.mdx
+++ b/packages/Icon/doc.mdx
@@ -26,14 +26,17 @@ const { dependencies, peerDependencies, name, version } = require('./package.jso
 
 ## Size
 
-Use size property with `xs`, `sm`, `md`, `lg` or `xl`.
+Use size property with `xxs`, `xs`, `sm`, `md`, `lg`, `xl`, a string `35px` or a number `50` that will convert the value into rem
 
 <Playground>
+  <TwitterIcon size="xxs" />
   <TwitterIcon size="xs" />
   <TwitterIcon size="sm" />
   <TwitterIcon />
   <TwitterIcon size="lg" />
   <TwitterIcon size="xl" />
+  <TwitterIcon size="35px" />
+  <TwitterIcon size={50} />
 </Playground>
 
 ## Colour

--- a/packages/Icon/index.js
+++ b/packages/Icon/index.js
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react'
-import { number, oneOf, shape, string } from 'prop-types'
+import { number, oneOf, oneOfType, shape, string } from 'prop-types'
 
 import * as S from './styles'
 
@@ -33,7 +33,7 @@ Icon.propTypes /* remove-proptypes */ = {
     block: string
   }),
   name: string,
-  size: oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
+  size: oneOfType([oneOf(['xxs', 'xs', 'sm', 'md', 'lg', 'xl']), number, string]),
   title: string
 }
 

--- a/packages/Icon/styles.js
+++ b/packages/Icon/styles.js
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { css, useTheme } from '@xstyled/styled-components'
 import { system } from '@welcome-ui/system'
 
 const iconSvgStrokedStyles = css`
@@ -17,11 +16,13 @@ const iconSvgFilledStyles = css`
   }
 `
 
-export const Icon = styled.svg(
-  ({ size = 'md', stroked }) => css`
+export const Icon = styled.svg(({ size = 'md', stroked }) => {
+  const theme = useTheme()
+  const formattedSize = theme.icons[size] || size
+  return css`
     ${stroked ? iconSvgStrokedStyles : iconSvgFilledStyles};
-    width: ${th(`icons.${size}`)};
-    height: ${th(`icons.${size}`)};
+    width: ${formattedSize};
+    height: ${formattedSize};
     ${system};
   `
-)
+})

--- a/packages/Icon/theme.js
+++ b/packages/Icon/theme.js
@@ -1,4 +1,5 @@
 export const getIcons = ({ toRem }) => ({
+  xxs: toRem(7),
   xs: toRem(10),
   sm: toRem(12),
   md: toRem(15),

--- a/packages/Loader/doc.mdx
+++ b/packages/Loader/doc.mdx
@@ -24,7 +24,8 @@ import { Loader } from './index'
   <Loader />
   <Loader color="primary.500" size="md" />
   <Loader color="primary.500" size="lg" />
-  <Loader color="primary.500" width={40} height={40} />
+  <Loader color="primary.500" size="40px" />
+  <Loader color="primary.500" size={50} />
 </Playground>
 
 ## Properties

--- a/packages/Loader/index.js
+++ b/packages/Loader/index.js
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react'
-import { oneOf, string } from 'prop-types'
+import { number, oneOf, oneOfType, string } from 'prop-types'
 import { Box } from '@welcome-ui/box'
 
 import * as S from './styles'
@@ -16,5 +16,5 @@ Loader.displayName = 'Loader'
 
 Loader.propTypes = {
   color: string,
-  size: oneOf(['xs', 'sm', 'md', 'lg'])
+  size: oneOfType([oneOf(['xs', 'sm', 'md', 'lg']), number, string])
 }

--- a/packages/Loader/styles.js
+++ b/packages/Loader/styles.js
@@ -1,16 +1,15 @@
-import styled, { css, keyframes } from '@xstyled/styled-components'
+import styled, { css, keyframes, useTheme } from '@xstyled/styled-components'
 import { Shape } from '@welcome-ui/shape'
-import { th } from '@xstyled/system'
 import { system } from '@welcome-ui/system'
 
 const animation = keyframes`
   0%, 100% {
     opacity: .5;
-    transform: scale(.8);
+    transform: scale3d(.8, .8, 1);
   }
   30%, 60% {
     opacity: 1;
-    transform: scale(1);
+    transform: scale3d(1, 1, 1);
   }
 `
 
@@ -18,25 +17,27 @@ const animationRule = css`
   animation: ${animation} 1.5s cubic-bezier(0.86, 0, 0.07, 1) infinite;
 `
 
-export const LoadingDot = styled(Shape)(
-  ({ size }) =>
-    css`
-      width: ${th(`loaders.sizes.${size}`)};
-      height: ${th(`loaders.sizes.${size}`)};
-      background-color: currentColor;
-      ${system}
-      ${animationRule};
-      &:not(:first-child) {
-        margin-left: sm;
-      }
-      &:nth-child(1) {
-        animation-delay: 0s;
-      }
-      &:nth-child(2) {
-        animation-delay: 0.125s;
-      }
-      &:nth-child(3) {
-        animation-delay: 0.25s;
-      }
-    `
-)
+export const LoadingDot = styled(Shape)(({ size }) => {
+  const theme = useTheme()
+  const sizeValue = theme.loaders[size] || size
+  const formattedSize = typeof sizeValue === 'number' ? theme.toRem(sizeValue) : sizeValue
+  return css`
+    width: ${formattedSize};
+    height: ${formattedSize};
+    background-color: currentColor;
+    ${system}
+    ${animationRule};
+    &:not(:first-child) {
+      margin-left: calc(${formattedSize} / 2);
+    }
+    &:nth-child(1) {
+      animation-delay: 0s;
+    }
+    &:nth-child(2) {
+      animation-delay: 0.125s;
+    }
+    &:nth-child(3) {
+      animation-delay: 0.25s;
+    }
+  `
+})

--- a/packages/Loader/theme.js
+++ b/packages/Loader/theme.js
@@ -1,8 +1,6 @@
 export const getLoaders = ({ toRem }) => ({
-  sizes: {
-    xs: toRem(8),
-    sm: toRem(10),
-    md: toRem(15),
-    lg: toRem(20)
-  }
+  xs: toRem(8),
+  sm: toRem(10),
+  md: toRem(15),
+  lg: toRem(20)
 })


### PR DESCRIPTION
* also remove underline from breadcrumb

Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>