### PR TITLE
fix: tablist boxShadow controllable via style props

### DIFF
--- a/packages/System/index.js
+++ b/packages/System/index.js
@@ -58,6 +58,7 @@ const SYSTEM_PROPS = Object.freeze([
   S.backgrounds,
   S.basics,
   S.borders,
+  S.boxShadow,
   S.color,
   S.display,
   S.flexboxes,

--- a/packages/Tabs/doc.mdx
+++ b/packages/Tabs/doc.mdx
@@ -67,6 +67,52 @@ Set the tab activated by default using `selectedId` on `useTabState`.
   }}
 </Playground>
 
+## With no border
+
+The border on `Tab.List` is an inset shadow that you can customize or disable via the `boxShadow` style prop
+
+<Playground>
+  {() => {
+    const tab = useTabState({ selectedId: 'tab1' })
+    return (
+      <>
+        <Tab.List aria-label="Tabs" boxShadow="none" {...tab}>
+          <Tab {...tab} id="tab1">
+            Tab 1
+          </Tab>
+          <Tab {...tab} id="tab2">
+            Tab 2
+          </Tab>
+          <Tab {...tab} id="tab3">
+            Tab 3
+          </Tab>
+          <Tab {...tab} id="tab4">
+            Tab 4
+          </Tab>
+          <Tab {...tab} disabled id="tab5">
+            Tab 5
+          </Tab>
+        </Tab.List>
+        <Tab.Panel {...tab} tabId="tab1">
+          Tab.Panel 1
+        </Tab.Panel>
+        <Tab.Panel {...tab} tabId="tab2">
+          Tab.Panel 2
+        </Tab.Panel>
+        <Tab.Panel {...tab} tabId="tab3">
+          Tab.Panel 3
+        </Tab.Panel>
+        <Tab.Panel {...tab} tabId="tab4">
+          Tab.Panel 4
+        </Tab.Panel>
+        <Tab.Panel {...tab} disabled tabId="tab5">
+          Tab.Panel 5
+        </Tab.Panel>
+      </>
+    )
+  }}
+</Playground>
+
 ## With a badge
 
 Add badges in tab.

--- a/packages/Tabs/styles.js
+++ b/packages/Tabs/styles.js
@@ -8,13 +8,8 @@ export const TabList = styled.div`
   overflow-x: auto;
   display: flex;
   border: 0;
+  ${th('tabs.tabsBorder')};
   ${system};
-
-  &::before {
-    content: '';
-    position: absolute;
-    ${th('tabs.tabsBorder')};
-  }
 `
 
 export const Tab = styled.button`

--- a/packages/Tabs/theme.js
+++ b/packages/Tabs/theme.js
@@ -3,10 +3,7 @@ export const getTabs = theme => {
 
   return {
     tabsBorder: {
-      bottom: 0,
-      width: '100%',
-      height: borderWidths.sm,
-      backgroundColor: colors.light[800]
+      boxShadow: `inset 0 -${borderWidths.sm} 0 ${colors.light[800]}`
     },
     item: {
       default: {


### PR DESCRIPTION
Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>