### PR TITLE
fix: logic when numberOfSlides isn't divisible by slidesToSwipe

### DIFF
--- a/docs/pages/components/swiper.mdx
+++ b/docs/pages/components/swiper.mdx
@@ -58,6 +58,7 @@ function() {
   const swiper = useSwiper({
       slidesToShow: 2,
       slidesToSwipe: 2,
+      loop: true,
       nextButton: <RightIcon size="lg" />,
       prevButton: <LeftIcon size="lg" />
     })
@@ -106,6 +107,7 @@ Providing `nextButton` and `prevButton` enables prev and next navigation with th
 ```jsx
 function() {
   const swiper = useSwiper({
+    loop: true,
     nextButton: <RightIcon size="lg" />,
     prevButton: <LeftIcon size="lg" />
   })
@@ -186,6 +188,7 @@ Providing `autoplay` lets the slides advance automatically. Pass `duration` to c
 function() {
   const swiper = useSwiper({
     autoplay: true,
+    loop: true,
     nextButton: <RightIcon size="lg" />,
     prevButton: <LeftIcon size="lg" />
   })

--- a/packages/Swiper/index.js
+++ b/packages/Swiper/index.js
@@ -34,11 +34,9 @@ export const Swiper = forwardRef((props, ref) => {
   }, [children, setNumberOfSlides])
 
   // Get array with indexes of visible slides so we know which ones are (aria-)hidden
-  const isVisible = slide =>
-    Array(slidesToShow)
-      .fill()
-      .map((_, idx) => pageIdx + idx)
-      .includes(slide)
+  const visibleSlides = Array(slidesToShow)
+    .fill()
+    .map((_, idx) => pageIdx + idx)
 
   return (
     <S.Wrapper
@@ -54,7 +52,7 @@ export const Swiper = forwardRef((props, ref) => {
           cloneElement(child, {
             key: i,
             role: 'group',
-            'aria-hidden': !isVisible(i),
+            'aria-hidden': !visibleSlides.includes(i),
             'aria-readonly': true,
             'aria-roledescription': 'slide',
             'aria-label': `${i + 1} of ${numberOfSlides}`

--- a/packages/Swiper/index.js
+++ b/packages/Swiper/index.js
@@ -33,6 +33,13 @@ export const Swiper = forwardRef((props, ref) => {
     setNumberOfSlides(children.length || children.size)
   }, [children, setNumberOfSlides])
 
+  // Get array with indexes of visible slides so we know which ones are (aria-)hidden
+  const isVisible = slide =>
+    Array(slidesToShow)
+      .fill()
+      .map((_, idx) => pageIdx + idx)
+      .includes(slide)
+
   return (
     <S.Wrapper
       {...rest}
@@ -47,7 +54,7 @@ export const Swiper = forwardRef((props, ref) => {
           cloneElement(child, {
             key: i,
             role: 'group',
-            'aria-hidden': i !== pageIdx,
+            'aria-hidden': !isVisible(i),
             'aria-readonly': true,
             'aria-roledescription': 'slide',
             'aria-label': `${i + 1} of ${numberOfSlides}`
@@ -121,9 +128,7 @@ export const useSwiper = (props = {}) => {
   const [numberOfSlides, setNumberOfSlides] = useState(0)
   const [pageIdx, setPageIdx] = useState(0)
 
-  const lastSlideIdx = numberOfSlides
-    ? Math.ceil((numberOfSlides - slidesToShow) / slidesToSwipe) + 1
-    : 0
+  const lastSlideIdx = numberOfSlides ? numberOfSlides - slidesToShow : 0
 
   // Add autoplay
   useInterval(
@@ -136,22 +141,22 @@ export const useSwiper = (props = {}) => {
   )
 
   const goNext = () => {
-    const nextPageIdx = pageIdx + slidesToSwipe
+    const nextPageIdx = Math.min(pageIdx + slidesToSwipe, lastSlideIdx)
 
-    if (nextPageIdx < lastSlideIdx) {
-      setPageIdx(nextPageIdx)
-    } else if (loop) {
+    if (pageIdx === lastSlideIdx && loop) {
       setPageIdx(0)
+    } else if (nextPageIdx <= lastSlideIdx) {
+      setPageIdx(nextPageIdx)
     }
   }
 
   const goPrev = () => {
-    const prevPageIdx = pageIdx - slidesToSwipe
+    const prevPageIdx = Math.max(pageIdx - slidesToSwipe, 0)
 
-    if (prevPageIdx >= 0) {
+    if (pageIdx === 0 && loop) {
+      setPageIdx(lastSlideIdx)
+    } else if (prevPageIdx >= 0) {
       setPageIdx(prevPageIdx)
-    } else if (loop) {
-      setPageIdx(lastSlideIdx - 1)
     }
   }
 

--- a/packages/Swiper/index.js
+++ b/packages/Swiper/index.js
@@ -48,14 +48,14 @@ export const Swiper = forwardRef((props, ref) => {
       role="region"
     >
       <S.Swiper slidesToShow={slidesToShow} translateX={translateX}>
-        {children.map((child, i) =>
+        {children.map((child, idx) =>
           cloneElement(child, {
-            key: i,
+            key: idx,
             role: 'group',
-            'aria-hidden': !visibleSlides.includes(i),
+            'aria-hidden': !visibleSlides.includes(idx),
             'aria-readonly': true,
             'aria-roledescription': 'slide',
-            'aria-label': `${i + 1} of ${numberOfSlides}`
+            'aria-label': `${idx + 1} of ${numberOfSlides}`
           })
         )}
       </S.Swiper>

--- a/packages/Swiper/index.test.js
+++ b/packages/Swiper/index.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 
@@ -17,6 +18,25 @@ const TestSwiper = () => {
   )
 }
 
+const TestLoopingSwiper = () => {
+  const swiper = useSwiper({
+    prevButton: <LeftIcon />,
+    nextButton: <RightIcon />,
+    loop: true,
+    slidesToShow: 2,
+    slidesToSwipe: 2
+  })
+  return (
+    <Swiper {...swiper} dataTestId="swiper">
+      <Swiper.Slide>page1</Swiper.Slide>
+      <Swiper.Slide>page2</Swiper.Slide>
+      <Swiper.Slide>page3</Swiper.Slide>
+      <Swiper.Slide>page4</Swiper.Slide>
+      <Swiper.Slide>page5</Swiper.Slide>
+    </Swiper>
+  )
+}
+
 describe('<Swiper>', () => {
   it('should render correctly with no props', () => {
     const { container } = render(<TestSwiper />)
@@ -25,12 +45,17 @@ describe('<Swiper>', () => {
   })
 
   it('should change page using pagination', () => {
-    const { getAllByRole, getByTestId } = render(<TestSwiper />)
-
-    const nextButton = getByTestId('swiper-button-next')
-    fireEvent.click(nextButton)
-
+    // Arrange
+    const { getAllByLabelText, getAllByRole } = render(<TestSwiper />)
+    // Both the swiper item and the corresponding pagination item have the same label
+    const labels = getAllByLabelText('2 of 3')
+    const firstPaginationButton = labels[1]
     const slides = getAllByRole('group')
+
+    // Act
+    fireEvent.click(firstPaginationButton)
+
+    // Assert
     expect(slides[0]).toHaveAttribute('aria-hidden', 'true')
     expect(slides[1]).toHaveAttribute('aria-hidden', 'false')
   })
@@ -44,5 +69,81 @@ describe('<Swiper>', () => {
     const slides = getAllByRole('group')
     expect(slides[0]).toHaveAttribute('aria-hidden', 'true')
     expect(slides[1]).toHaveAttribute('aria-hidden', 'false')
+  })
+})
+
+describe('<LoopingSwiper>', () => {
+  it('should change page (and loop) using next button', () => {
+    // Arrange
+    const { getAllByRole, getByTestId } = render(<TestLoopingSwiper />)
+    const slides = getAllByRole('group')
+    const nextButton = getByTestId('swiper-button-next')
+
+    // Act
+    fireEvent.click(nextButton)
+
+    // Assert
+    expect(slides[0]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[1]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[2]).toHaveAttribute('aria-hidden', 'false')
+    expect(slides[3]).toHaveAttribute('aria-hidden', 'false')
+    expect(slides[4]).toHaveAttribute('aria-hidden', 'true')
+
+    // Act
+    fireEvent.click(nextButton)
+
+    // Assert
+    expect(slides[0]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[1]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[2]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[3]).toHaveAttribute('aria-hidden', 'false')
+    expect(slides[4]).toHaveAttribute('aria-hidden', 'false')
+
+    // Act
+    fireEvent.click(nextButton)
+
+    // Assert
+    expect(slides[0]).toHaveAttribute('aria-hidden', 'false')
+    expect(slides[1]).toHaveAttribute('aria-hidden', 'false')
+    expect(slides[2]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[3]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[4]).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('should change page (and loop) using prev button', () => {
+    // Arrange
+    const { getAllByRole, getByTestId } = render(<TestLoopingSwiper />)
+    const slides = getAllByRole('group')
+    const nextButton = getByTestId('swiper-button-prev')
+
+    // Act
+    fireEvent.click(nextButton)
+
+    // Assert
+    expect(slides[0]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[1]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[2]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[3]).toHaveAttribute('aria-hidden', 'false')
+    expect(slides[4]).toHaveAttribute('aria-hidden', 'false')
+
+    // Act
+    fireEvent.click(nextButton)
+
+    // Assert
+    expect(slides[0]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[1]).toHaveAttribute('aria-hidden', 'false')
+    expect(slides[2]).toHaveAttribute('aria-hidden', 'false')
+    expect(slides[3]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[4]).toHaveAttribute('aria-hidden', 'true')
+
+    // Act
+    fireEvent.click(nextButton)
+
+    // Assert
+    expect(slides[0]).toHaveAttribute('aria-hidden', 'false')
+    expect(slides[1]).toHaveAttribute('aria-hidden', 'false')
+    expect(slides[2]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[3]).toHaveAttribute('aria-hidden', 'true')
+    expect(slides[4]).toHaveAttribute('aria-hidden', 'true')
   })
 })


### PR DESCRIPTION
Logic wasn't quite right when showing an even number of slides in a carousel with an odd number of slides.

https://www.loom.com/share/db88f37b581c4f6eaeaf2ef09f9569e7