### PR TITLE
fix: reset breadcrumb item direction

### DIFF
--- a/packages/Breadcrumb/Item.styles.js
+++ b/packages/Breadcrumb/Item.styles.js
@@ -8,6 +8,7 @@ export const Item = styled(Box).withConfig({ shouldForwardProp })(
     ${th('breadcrumbs.item.default')};
     align-items: center;
     transition: medium;
+    direction: initial;
 
     ${withSeparator &&
       css`


### PR DESCRIPTION
Signed-off-by: Stéphane Robino <stephane@wttj.co>