### PR TITLE
chore: use google fonts work sans

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ yarn first:install
 yarn start
 ```
 
-3. Start a watch on all packages to rebuild them easely
+3. Start a watch on all packages to rebuild them easily
 
 ```bash
 yarn watch

--- a/packages/Core/package.json
+++ b/packages/Core/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@welcome-ui/utils": "^2.0.2",
-    "polished": "^3.4.1",
     "ramda": "^0.27.0"
   },
   "peerDependencies": {

--- a/packages/Core/theme/core.js
+++ b/packages/Core/theme/core.js
@@ -47,7 +47,7 @@ import { getDefaultFields } from './defaultFields'
 import { getDefaultCards } from './defaultCards'
 
 const DEFAULT_FONT_SIZE = 16
-const DEFAULT_FONT_FAMILY = 'work-sans'
+const DEFAULT_FONT_FAMILY = 'Work Sans'
 const DEFAULT_LINE_HEIGHT = 1.15
 const DEFAULT_LETTER_SPACING = 0
 const HEADING_FONT_FAMILY = 'welcome-font'
@@ -91,8 +91,8 @@ export const createTheme = (options = {}) => {
   }
   theme.letterSpacings = getLetterSpacings(theme)
   theme.fonts = {
-    texts: defaultFontFamily,
-    headings: headingFontFamily,
+    texts: [defaultFontFamily, 'sans-serif'].join(', '),
+    headings: [headingFontFamily, 'sans-serif'].join(', '),
     icons: iconFontFamily
   }
 

--- a/packages/Core/theme/fonts.js
+++ b/packages/Core/theme/fonts.js
@@ -3,76 +3,48 @@ export const fontFaces = {
     {
       url: 'https://cdn.welcometothejungle.com/common/assets/fonts/welcome-font-regular',
       weight: '400',
-      extensions: ['woff2', 'woff', 'ttf']
+      display: 'swap',
+      extensions: ['woff2', 'woff']
     },
     {
       url: 'https://cdn.welcometothejungle.com/common/assets/fonts/welcome-font-medium',
       weight: '500',
-      extensions: ['woff2', 'woff', 'ttf']
+      display: 'swap',
+      extensions: ['woff2', 'woff']
     },
     {
       url: 'https://cdn.welcometothejungle.com/common/assets/fonts/welcome-font-bold',
       weight: '600',
-      extensions: ['woff2', 'woff', 'ttf']
+      display: 'swap',
+      extensions: ['woff2', 'woff']
     },
     {
       url: 'https://cdn.welcometothejungle.com/common/assets/fonts/welcome-font-regular-italic',
       weight: '400',
       style: 'italic',
-      extensions: ['woff2', 'woff', 'ttf']
+      display: 'swap',
+      extensions: ['woff2', 'woff']
     },
     {
       url: 'https://cdn.welcometothejungle.com/common/assets/fonts/welcome-font-medium-italic',
       weight: '500',
       style: 'italic',
-      extensions: ['woff2', 'woff', 'ttf']
+      display: 'swap',
+      extensions: ['woff2', 'woff']
     },
     {
       url: 'https://cdn.welcometothejungle.com/common/assets/fonts/welcome-font-bold-italic',
       weight: '600',
       style: 'italic',
-      extensions: ['woff2', 'woff', 'ttf']
-    }
-  ],
-  'work-sans': [
-    {
-      url: 'https://cdn.welcometothejungle.com/common/assets/fonts/work-sans-regular',
-      weight: '400',
-      extensions: ['woff2', 'woff', 'ttf']
-    },
-    {
-      url: 'https://cdn.welcometothejungle.com/common/assets/fonts/work-sans-medium',
-      weight: '500',
-      extensions: ['woff2', 'woff', 'ttf']
-    },
-    {
-      url: 'https://cdn.welcometothejungle.com/common/assets/fonts/work-sans-semibold',
-      weight: '600',
-      extensions: ['woff2', 'woff', 'ttf']
-    },
-    {
-      url: 'https://cdn.welcometothejungle.com/common/assets/fonts/work-sans-regular-italic',
-      weight: '400',
-      style: 'italic',
-      extensions: ['woff2', 'woff', 'ttf']
-    },
-    {
-      url: 'https://cdn.welcometothejungle.com/common/assets/fonts/work-sans-medium-italic',
-      weight: '500',
-      style: 'italic',
-      extensions: ['woff2', 'woff', 'ttf']
-    },
-    {
-      url: 'https://cdn.welcometothejungle.com/common/assets/fonts/work-sans-semibold-italic',
-      weight: '600',
-      style: 'italic',
-      extensions: ['woff2', 'woff', 'ttf']
+      display: 'swap',
+      extensions: ['woff2', 'woff']
     }
   ],
   'welcome-icon-font': [
     {
       url: 'https://cdn.welcometothejungle.com/common/assets/fonts/welcome-icon-font',
-      extensions: ['woff2', 'woff', 'ttf']
+      display: 'block',
+      extensions: ['woff2', 'woff']
     }
   ]
 }

--- a/packages/Core/utils/base.js
+++ b/packages/Core/utils/base.js
@@ -1,12 +1,9 @@
 import { createGlobalStyle, css } from '@xstyled/styled-components'
-import { getFont, th } from '@xstyled/system'
+import { th } from '@xstyled/system'
 
 import { fonts } from './font'
 import { resetStyles } from './reset'
-
-function getFontFamilies(...fonts) {
-  return fonts.filter(Boolean).join(', ')
-}
+import WorkSans from './work-sans.css'
 
 const baseBoxSizing = css`
   * {
@@ -18,9 +15,7 @@ const baseBoxSizing = css`
   }
 `
 
-function baseFonts(props) {
-  const texts = getFont('texts')(props)
-  const sansSerif = 'sans-serif'
+function baseFonts() {
   return css`
     @media (max-width: 1200px) {
       html {
@@ -45,7 +40,7 @@ function baseFonts(props) {
     input,
     select,
     textarea {
-      font-family: ${getFontFamilies(texts, sansSerif)};
+      font-family: texts;
       -webkit-font-smoothing: antialiased;
       line-height: html;
       letter-spacing: html;
@@ -55,9 +50,10 @@ function baseFonts(props) {
 
 export const GlobalStyle = createGlobalStyle(
   ({ useReset }) => css`
-    ${useReset ? resetStyles : baseBoxSizing};
+    ${WorkSans};
     ${fonts()};
-    ${baseFonts};
+    ${baseFonts()};
+    ${useReset ? resetStyles : baseBoxSizing};
 
     ::selection {
       ${th('selection')};

--- a/packages/Core/utils/base.js
+++ b/packages/Core/utils/base.js
@@ -1,6 +1,5 @@
 import { createGlobalStyle, css } from '@xstyled/styled-components'
 import { getFont, th } from '@xstyled/system'
-import { normalize } from 'polished'
 
 import { fonts } from './font'
 import { resetStyles } from './reset'
@@ -56,7 +55,6 @@ function baseFonts(props) {
 
 export const GlobalStyle = createGlobalStyle(
   ({ useReset }) => css`
-    ${normalize()};
     ${useReset ? resetStyles : baseBoxSizing};
     ${fonts()};
     ${baseFonts};

--- a/packages/Core/utils/font.js
+++ b/packages/Core/utils/font.js
@@ -17,7 +17,7 @@ function getFont(descriptor) {
     @font-face {
       font-family: ${descriptor.name};
       src: ${getSrc(descriptor)};
-      font-display: fallback;
+      font-display: ${descriptor.display || 'fallback'};
       ${descriptor.weight &&
         css`
           font-weight: ${descriptor.weight};
@@ -32,10 +32,7 @@ function getFont(descriptor) {
 
 export const fonts = () => ({ theme }) => {
   if (!theme || !theme.fontFaces) return null
-  return (
-    Object.entries(theme.fontFaces)
-      // Ignore anything else than array
-      .filter(([, variations]) => Array.isArray(variations))
-      .map(([name, variations]) => variations.map(variation => getFont({ name, ...variation })))
+  return Object.entries(theme.fontFaces).map(([name, variations]) =>
+    variations.map(variation => getFont({ name, ...variation }))
   )
 }

--- a/packages/Core/utils/work-sans.css
+++ b/packages/Core/utils/work-sans.css
@@ -1,0 +1,94 @@
+/* Taken from https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600&display=swap */
+/* woff */
+@font-face {
+  font-family: 'Work Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/worksans/v8/QGY_z_wNahGAdqQ43RhVcIgYT2Xz5u32K0nXNis.woff)
+    format('woff');
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Work Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/worksans/v8/QGYsz_wNahGAdqQ43Rh_cqDptfpA4cD3.woff2)
+    format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113,
+    U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Work Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/worksans/v8/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2)
+    format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* woff */
+@font-face {
+  font-family: 'Work Sans';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/worksans/v8/QGY_z_wNahGAdqQ43RhVcIgYT2Xz5u32K0nXNis.woff)
+    format('woff');
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Work Sans';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/worksans/v8/QGYsz_wNahGAdqQ43Rh_cqDptfpA4cD3.woff2)
+    format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113,
+    U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Work Sans';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/worksans/v8/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2)
+    format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* woff */
+@font-face {
+  font-family: 'Work Sans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/worksans/v8/QGY_z_wNahGAdqQ43RhVcIgYT2Xz5u32K0nXNis.woff)
+    format('woff');
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Work Sans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/worksans/v8/QGYsz_wNahGAdqQ43Rh_cqDptfpA4cD3.woff2)
+    format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113,
+    U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Work Sans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/worksans/v8/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2)
+    format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}

--- a/packages/DateTimePickerCommon/datePickerStyles.js
+++ b/packages/DateTimePickerCommon/datePickerStyles.js
@@ -90,7 +90,6 @@ export const datePickerStyles = css`
   }
 
   .react-datepicker {
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-size: 0.8rem;
     background-color: #fff;
     color: #000;


### PR DESCRIPTION
This means that…

1. Google will deliver the fonts reducing our CDN costs
2. 2 versions are served (`Latin` and `Latin extended`) so the initial font is smaller and the second font is only downloaded for SK/CS

Also set up fallbacks (`sans-serif`) and removed `ttf`