### PR TITLE
Add render props to FileUpload (and fixes)

### DIFF
--- a/docs/pages/fields/file-upload.mdx
+++ b/docs/pages/fields/file-upload.mdx
@@ -172,6 +172,28 @@ function() {
 }
 ```
 
+You can also set the `preview` prop to `null` and handle your own preview in place of the upload button with `files` & `onRemoveFile` render props:
+
+```jsx
+<Form initialValues={{}}>
+  <ConnectedField component={FileUpload} name="file" label="File" multiple preview={null}>
+    {({ openFile, files, onRemoveFile }) =>
+      files.length === 0 ? (
+        <Button onClick={openFile}>Upload files</Button>
+      ) : (
+        <Stack direction="row">
+          {files.map(file => (
+            <Button key={file.preview} onClick={() => onRemoveFile(file)}>
+              {getFileIcon(file)} Click to remove {file.name}
+            </Button>
+          ))}
+        </Stack>
+      )
+    }
+  </ConnectedField>
+</Form>
+```
+
 ## Properties
 
 ### FileUpload

--- a/packages/FileUpload/index.js
+++ b/packages/FileUpload/index.js
@@ -87,6 +87,10 @@ export const FileUpload = forwardRef(
       inputRef.current.click()
     }
 
+    // We need to add this key on the input[file] because we can't change it's value programmatically for security reasons
+    // Changing its key means that we can add a file, remove it & re-add it
+    const inputKey = files.map(file => file.preview)
+
     return (
       <>
         {children ? (
@@ -101,6 +105,7 @@ export const FileUpload = forwardRef(
           accept={accept}
           data-testid={dataTestId}
           disabled={disabled}
+          key={inputKey}
           maxSize={maxSize}
           multiple={multiple}
           name={name}

--- a/packages/FileUpload/index.js
+++ b/packages/FileUpload/index.js
@@ -72,15 +72,14 @@ export const FileUpload = forwardRef(
       onBlur && onBlur()
     }
 
-    const handleRemove = index => {
-      const newFiles = [...files]
-      const file = newFiles.splice(index, 1)
+    const handleRemove = removedFile => {
+      const newFiles = files.filter(file => file !== removedFile)
       const value = multiple ? newFiles : undefined
       setFiles(newFiles)
 
       const event = createEvent({ name, value })
       onChange && onChange(event)
-      handleRemoveFile && handleRemoveFile(file)
+      handleRemoveFile && handleRemoveFile(removedFile)
       onBlur && onBlur()
     }
 
@@ -112,7 +111,7 @@ export const FileUpload = forwardRef(
           type="file"
         />
         {files.map(file => (
-          <Preview file={file} key={file.name || file} onRemove={handleRemove} />
+          <Preview file={file} key={file.name || file} onRemove={() => handleRemove(file)} />
         ))}
       </>
     )

--- a/packages/FileUpload/index.js
+++ b/packages/FileUpload/index.js
@@ -90,7 +90,7 @@ export const FileUpload = forwardRef(
     return (
       <>
         {children ? (
-          children({ openFile: handleClick, disabled })
+          children({ openFile: handleClick, disabled, files, onRemoveFile: handleRemove })
         ) : (
           <Button disabled={disabled} onClick={handleClick}>
             Upload file
@@ -110,9 +110,10 @@ export const FileUpload = forwardRef(
           {...rest}
           type="file"
         />
-        {files.map(file => (
-          <Preview file={file} key={file.name || file} onRemove={() => handleRemove(file)} />
-        ))}
+        {Preview &&
+          files.map(file => (
+            <Preview file={file} key={file.name || file} onRemove={() => handleRemove(file)} />
+          ))}
       </>
     )
   }


### PR DESCRIPTION
I need to be able to replace the Button set in the render prop with a component to prevent the page to jump, so I added `file` & `onRemoveFile` to the render prop.
In addition, I've fixed an issue with `handleRemove` that was taking an event but was expected an index, which meant we were possibly removing the wrong one when multiple files were uploaded.
And last (and the one I'm really keen to get a review of) is that I added a key prop on the input based on the current files, to allow React to re-render this input thus allowing the user to upload a file, removing it & then re-adding it. I feel that it was needed because we can't manipulate the value of an input[type=file] element for security reasons.

https://www.loom.com/share/a35b315b60694936a63128d7567dbad1