### PR TITLE
fix(file-drop): don't crash if invalid url passed to filedrop

### DIFF
--- a/packages/FileDrop/utils.js
+++ b/packages/FileDrop/utils.js
@@ -18,7 +18,11 @@ export const getPreviewUrl = file => {
     return url
   }
   if (typeof window !== 'undefined') {
-    return new URL(url)
+    try {
+      return new URL(url)
+    } catch (error) {
+      return undefined
+    }
   }
   return undefined
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/677285/96992251-e5e89700-1529-11eb-841c-d70260a1996c.png)
