### PR TITLE
Remove deprecated process.browser by typeof window

### DIFF
--- a/docs/context/theme.js
+++ b/docs/context/theme.js
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState } from 'react'
 import { object } from 'prop-types'
 
-const themeStorage = (process.browser && localStorage.getItem('theme')) || 'welcome'
+const themeStorage = (typeof window !== 'undefined' && localStorage.getItem('theme')) || 'welcome'
 
 const ThemeContext = createContext({
   theme: themeStorage,
@@ -20,7 +20,7 @@ export function useSetThemeContext() {
 
 export function ThemeProvider({ children }) {
   const [theme, setTheme] = useState(themeStorage)
-  process.browser && localStorage.setItem('theme', theme)
+  typeof window !== 'undefined' && localStorage.setItem('theme', theme)
 
   const value = {
     theme,


### PR DESCRIPTION
The use of a legacy ```process.browser``` has been deprecated since june 2019 in favor of  ```typeof window ```

[Deprecated by this pull request](https://github.com/vercel/next.js/pull/7651)