### PR TITLE
fix: break all words on Text component with lines set to 1

### DIFF
--- a/packages/Text/styles.js
+++ b/packages/Text/styles.js
@@ -11,6 +11,7 @@ const getBlockHeight = lines => css`
   -webkit-line-clamp: ${lines || 'none'};
   line-height: normal;
   overflow: hidden;
+  word-break: ${lines === 1 ? 'break-all' : null};
 `
 
 export const Text = styled.p(


### PR DESCRIPTION
`word-break` is set to `break-all` when you use `Text` component with `lines` prop set to `1`

Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>