### PR TITLE
fix(popover): add system to ArrowItem in order to process h & w prop

### DIFF
--- a/packages/Popover/index.js
+++ b/packages/Popover/index.js
@@ -36,7 +36,7 @@ export const Popover = memo(function Popover({
     <S.Popover {...rest} $withCloseButton={withCloseButton}>
       <Box position="relative">
         <S.Arrow {...rest} style={{ ...arrowStyle }}>
-          <S.ArrowItem $transform={transform} h="30" w="30" xmlns="http://www.w3.org/2000/svg">
+          <S.ArrowItem $transform={transform} h={30} w={30} xmlns="http://www.w3.org/2000/svg">
             <path d="M6 30l9-10 9 10z" fill="currentColor" fillRule="nonzero" />
           </S.ArrowItem>
         </S.Arrow>

--- a/packages/Popover/styles.js
+++ b/packages/Popover/styles.js
@@ -7,10 +7,9 @@ export const Arrow = styled(PopoverArrow)`
   color: ${th('popovers.default.backgroundColor')};
 `
 
-export const ArrowItem = styled.svg(
+export const ArrowItem = styled.svgBox(
   ({ $transform }) => css`
     transform: ${$transform};
-    ${system}
   `
 )
 

--- a/packages/Popover/styles.js
+++ b/packages/Popover/styles.js
@@ -7,9 +7,10 @@ export const Arrow = styled(PopoverArrow)`
   color: ${th('popovers.default.backgroundColor')};
 `
 
-export const ArrowItem = styled('svg')(
+export const ArrowItem = styled.svg(
   ({ $transform }) => css`
     transform: ${$transform};
+    ${system}
   `
 )
 


### PR DESCRIPTION
The bug is only visible when the `placement` is set to `top`
Before: 
<img width="794" alt="Capture d’écran 2021-04-01 à 13 39 56" src="https://user-images.githubusercontent.com/61152048/113288927-d4cd5e80-92ef-11eb-8bee-bda615df7c6a.png">
After:
<img width="741" alt="Capture d’écran 2021-04-01 à 13 40 06" src="https://user-images.githubusercontent.com/61152048/113288953-dd259980-92ef-11eb-850c-86635a4cd697.png">

