### PR TITLE
fix: docs:deploy command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "yarn docs:dev",
     "docs:dev": "yarn next docs -p 3020",
     "docs:build": "yarn next build docs && yarn next export docs",
-    "docs:deploy": "yarn && yarn icons:build && yarn webfont:build && yarn build && yarn docs:build",
+    "docs:deploy": "yarn && yarn icons:build && yarn build && yarn docs:build",
     "homerun": "yarn clean --yes && rm -rf node_modules/ docs/.next/ && yarn cache clean && yarn && yarn build && yarn start",
     "icons": "yarn icons:optimize && yarn icons:collect && yarn icons:build && yarn webfont:build && yarn build && yarn",
     "icons:optimize": "node -r esm scripts/icons-optimize.js",


### PR DESCRIPTION
* Now that `yarn build` task includes `yarn webfont:build` there is no need to call it inside `yarn docs:deploy` (doublon)

Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>