### PR TITLE
chore: netlify deploy w/ circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,56 @@ jobs:
           arguments: |
             --metadata GitCommit=$CIRCLE_SHA1 --delete
 
+  build:
+    <<: *defaults
+    resource_class: large
+    steps:
+      - attach_workspace:
+          at: ~/welcome-ui
+      - restore_cache:
+          key: v2-welcome-ui-{{ .Environment.CIRCLE_SHA1 }}
+      - run: yarn icons:build
+      - run: yarn build
+      - persist_to_workspace:
+          root: ~/welcome-ui
+          paths:
+            - packages/**/dist
+            - icons/**/dist
+            - packages/IconFont/fonts
+
+  docs_build:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/welcome-ui
+      - restore_cache:
+          key: v2-welcome-ui-{{ .Environment.CIRCLE_SHA1 }}
+      - run: yarn docs:build
+      - persist_to_workspace:
+          root: ~/welcome-ui
+          paths:
+            - docs/out
+
+  docs_deploy:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/welcome-ui
+      - restore_cache:
+          key: v2-welcome-ui-{{ .Environment.CIRCLE_SHA1 }}
+      - run: node_modules/.bin/netlify deploy --dir=docs/out --alias $CIRCLE_BRANCH
+
+  docs_deploy_prod:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/welcome-ui
+      - restore_cache:
+          key: v2-welcome-ui-{{ .Environment.CIRCLE_SHA1 }}
+      - run: node_modules/.bin/netlify deploy --dir=docs/out --prod
+
+
+
 workflows:
   version: 2
   btd:
@@ -104,4 +154,30 @@ workflows:
           requires:
             - lint
             - test
-
+      - build:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - yarn_install
+      - docs_build:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build
+      - docs_deploy_prod:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+          requires:
+            - test
+            - lint
+            - docs_build
+      - docs_deploy:
+          requires:
+            - test
+            - lint
+            - docs_build

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "start": "yarn docs:dev",
     "docs:dev": "yarn next docs -p 3020",
     "docs:build": "yarn next build docs && yarn next export docs",
-    "docs:deploy": "yarn && yarn icons:build && yarn build && yarn docs:build",
     "homerun": "yarn clean --yes && rm -rf node_modules/ docs/.next/ && yarn cache clean && yarn && yarn build && yarn start",
     "icons": "yarn icons:optimize && yarn icons:collect && yarn icons:build && yarn webfont:build && yarn build && yarn",
     "icons:optimize": "node -r esm scripts/icons-optimize.js",


### PR DESCRIPTION
The goal behind these changes is to disable netlify's deploy since we have a very limited plan to build on netlify.
Deploys are now fully handled by circle with bigger machines than netlify (the build is a bit faster)

Deploy to production are now back and triggered only on tags
Deploy of previews are automatic on all branches with this url template: `https://${nameOfTheBranch}--welcome-ui.netlify.app`