### PR TITLE
fix: persist Themes subfolders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
           root: ~/welcome-ui
           paths:
             - packages/**/dist
+            - packages/Themes/**/dist
             - icons/**/dist
             - packages/IconFont/fonts
 


### PR DESCRIPTION
Before / after on the circle ci machine:
<img width="529" alt="Capture d’écran 2021-11-22 à 09 12 06" src="https://user-images.githubusercontent.com/61152048/142827454-34dc06be-2e74-4378-ae49-5f5386cb2369.png">
