### PR TITLE
fix: border & placeholder colors

### DIFF
--- a/packages/Core/theme/defaultFields.ts
+++ b/packages/Core/theme/defaultFields.ts
@@ -44,7 +44,7 @@ export const getDefaultFields = (theme: WuiTheme): ThemeDefaultFields => {
       lineHeight: '1rem',
       fontWeight: fontWeights.regular,
       backgroundColor: colors.light[900],
-      borderColor: colors.nude[200],
+      borderColor: colors.light[800],
       borderWidth: borderWidths.sm,
       borderStyle: 'solid',
       outline: 'none',
@@ -77,7 +77,7 @@ export const getDefaultFields = (theme: WuiTheme): ThemeDefaultFields => {
       cursor: 'not-allowed',
     },
     placeholder: {
-      color: colors.nude[500],
+      color: colors.light[500],
     },
     focused: {
       default: {


### PR DESCRIPTION
Placeholder color used to be `nude.600` which isn't a color in the theme, so it defaulted to browser's defaults.

It was "fixed" by using `nude.500` which is way too light, so design asked us to replace it with `light.500`