### PR TITLE
refactoring: use JSX components instead styled on modal

### DIFF
--- a/packages/Core/theme/modals.ts
+++ b/packages/Core/theme/modals.ts
@@ -25,15 +25,11 @@ export const getModals = (theme: WuiTheme): ThemeModals => {
       zIndex: 999,
     },
     footer: {
-      borderTopColor: colors.light[800],
-      borderTopStyle: 'solid',
-      borderTopWidth: borderWidths.sm,
+      borderTop: `${borderWidths.sm} solid ${colors.light[800]}`,
       padding: `${space.lg} ${space.xxl}`,
     },
     title: {
-      borderBottomColor: colors.light[800],
-      borderBottomStyle: 'solid',
-      borderBottomWidth: borderWidths.sm,
+      borderBottom: `${borderWidths.sm} solid ${colors.light[800]}`,
       padding: `${space.lg} ${space.xxl}`,
       ...texts.h4,
       /** space of close button */

--- a/packages/Modal/index.tsx
+++ b/packages/Modal/index.tsx
@@ -7,8 +7,11 @@ import {
   useDialogState,
 } from 'reakit/Dialog'
 import { DisclosureActions } from 'reakit/Disclosure'
-import { Text } from '@welcome-ui/text'
+import { Box, BoxProps } from '@welcome-ui/box'
+import { Text, TextProps } from '@welcome-ui/text'
+import { Shape, ShapeProps } from '@welcome-ui/shape'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
+import { useTheme } from '@xstyled/styled-components'
 
 import * as S from './styles'
 import { Close } from './Close'
@@ -66,21 +69,30 @@ const ModalComponent = forwardRef<'div', ModalProps>((props, ref) => {
 
 ModalComponent.displayName = 'Modal'
 
-export interface ModalTitleProps {
-  children: React.ReactNode
+const Title: React.FC<TextProps> = props => {
+  const { modals } = useTheme()
+  return <Text {...modals.title} m="0" p="xxl 50 xxl xxl" variant="h4" width="100%" {...props} />
 }
 
-const Title: React.FC<ModalTitleProps> = ({ children }) => (
-  <S.Title as={Text} m="0" variant="h4">
-    {children}
-  </S.Title>
+const Content: React.FC<BoxProps> = props => (
+  <Box flex={1} overflowY="auto" padding={50} {...props} />
 )
+
+const Cover: React.FC<ShapeProps> = props => {
+  const { modals } = useTheme()
+  return <Shape {...modals.cover} {...props} />
+}
+
+const Footer: React.FC<BoxProps> = props => {
+  const { modals } = useTheme()
+  return <Box {...modals.footer} width="100%" {...props} />
+}
 
 // Nested exports
 export const Modal = Object.assign(ModalComponent, {
   Trigger: DialogDisclosure,
-  Content: S.Content,
-  Title: Title,
-  Footer: S.Footer,
-  Cover: S.Cover,
+  Content,
+  Title,
+  Footer,
+  Cover,
 })

--- a/packages/Modal/styles.ts
+++ b/packages/Modal/styles.ts
@@ -72,7 +72,7 @@ export const Content = styled(Box)`
   padding: 50;
   flex: 1;
   overflow-y: auto;
-  // ${system} is usefull for fix this https://github.com/gregberge/xstyled/issues/340
+  /* ${system} is usefull for fix this https://github.com/gregberge/xstyled/issues/340 */
   ${system};
 `
 

--- a/packages/Modal/styles.ts
+++ b/packages/Modal/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css, th, up } from '@xstyled/styled-components'
+import styled, { css, system, th, up } from '@xstyled/styled-components'
 import { Box } from '@welcome-ui/box'
 import { cardStyles } from '@welcome-ui/utils'
 import { Shape } from '@welcome-ui/shape'
@@ -72,6 +72,8 @@ export const Content = styled(Box)`
   padding: 50;
   flex: 1;
   overflow-y: auto;
+  // ${system} is usefull for fix this https://github.com/gregberge/xstyled/issues/340
+  ${system};
 `
 
 export const Cover = styled(Shape)`

--- a/packages/Modal/styles.ts
+++ b/packages/Modal/styles.ts
@@ -1,7 +1,5 @@
-import styled, { css, system, th, up } from '@xstyled/styled-components'
-import { Box } from '@welcome-ui/box'
+import styled, { css, th, up } from '@xstyled/styled-components'
 import { cardStyles } from '@welcome-ui/utils'
-import { Shape } from '@welcome-ui/shape'
 import { DialogBackdrop, Dialog as ReakitDialog } from 'reakit/Dialog'
 
 import { Size } from '.'
@@ -67,26 +65,3 @@ export const Dialog = styled(ReakitDialog)<{ size: Size }>(
     )}
   `
 )
-
-export const Content = styled(Box)`
-  padding: 50;
-  flex: 1;
-  overflow-y: auto;
-  /* ${system} is usefull for fix this https://github.com/gregberge/xstyled/issues/340 */
-  ${system};
-`
-
-export const Cover = styled(Shape)`
-  ${th('modals.cover')};
-`
-
-export const Title = styled(Box)`
-  ${th('modals.title')};
-  width: 100%;
-  padding: xxl 50 xxl xxl;
-`
-
-export const Footer = styled(Box)`
-  ${th('modals.footer')};
-  width: 100%;
-`


### PR DESCRIPTION
Useful to override props on `Modal.Content/Modal.Title/Modal.Cover/Modal.Footer`