### PR TITLE
feat: automated deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: NPM Deploy
+
+on:
+  # Defines how to run this workflow manually from the Actions tab
+  workflow_dispatch:  
+    inputs:
+      bump_type:
+        type: choice
+        description: Release type
+        options: 
+        - major
+        - minor
+        - patch
+        required: true
+        default: patch
+      mode:
+        type: choice
+        description: Mode 
+        options: 
+        - dry_run
+        - production
+        required: true
+        default: dry_run
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install
+        run: yarn
+      - name: Build
+        run: yarn webfont:build && yarn build:core && yarn build:packages && yarn build:types
+
+      # dry run
+      - name: "[DRY RUN] NPM Deploy"
+        if: ${{ github.event.inputs.mode == 'dry_run' }}
+        run: yarn lerna version ${{ github.event.inputs.bump_type }} --conventional-commits --no-private --no-git-tag-version --no-push
+
+      # production run, publishes to npm registry, aws and git.
+      - name: NPM Deploy
+        if: ${{ github.event.inputs.mode == 'production' }}
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+          yarn lerna publish ${{ github.event.inputs.bump_type }} --conventional-commits --no-private


### PR DESCRIPTION
Will allow us to trigger workflows manualy w/ paramters (minor, major, patch). Also added the ability to dry run the workflow to see wich packages gonna be released w/ wich version.

Quick demo of what it should look like once on master: https://www.loom.com/share/efca05ee09f14811b61c7ec86c85456a

Questions to be answered:
- Does the method used to trigger the release is simple enough to stop using our local environnements for production releases ?
- Should we then move all our workflows to github actions ? Seems to be very close to circleci in terms of features by now