### PR TITLE
Fix slow toggle

### DIFF
--- a/packages/Toggle/styles.ts
+++ b/packages/Toggle/styles.ts
@@ -6,7 +6,7 @@ import { shouldForwardProp, system } from '@welcome-ui/system'
 import { ToggleOptions } from './index'
 
 export const Toggle = styled(ReakitCheckbox).withConfig({ shouldForwardProp })<ToggleOptions>(
-  ({ checked, disabled, order = '-1', theme }) => css`
+  ({ order = '-1', theme }) => css`
     ${th('toggles.item.default')};
     position: relative;
     display: block;
@@ -28,33 +28,29 @@ export const Toggle = styled(ReakitCheckbox).withConfig({ shouldForwardProp })<T
       transition: medium;
     }
 
-    ${checked &&
-    css`
-      &::after {
-        left: 100%;
-        transform: translateX(calc(-100% - ${theme.toRem(1)}));
-      }
-    `};
-
-    ${checked &&
-    !disabled &&
-    css`
-      ${th('toggles.item.checked')};
-
-      &::after {
-        ${th('toggles.after.checked')};
-      }
-    `};
-
-    ${disabled &&
-    css`
+    &:disabled {
       ${th('toggles.item.disabled')};
       cursor: not-allowed;
 
       &::after {
         ${th('toggles.after.disabled')};
       }
-    `};
+    }
+
+    &:checked {
+      &::after {
+        /* 3 is border + left padding + right padding */
+        transform: translateX(calc(${th('toggles.item.default.width')} - 100% - ${theme.toRem(3)}));
+      }
+
+      &:not(:disabled) {
+        ${th('toggles.item.checked')};
+
+        &::after {
+          ${th('toggles.after.checked')};
+        }
+      }
+    }
 
     ${system};
   `


### PR DESCRIPTION
Toggle acts weirdly when there is a performance bottleneck.

In this case, it's caused by algolia rerendering wayyy too many things:

[before](https://user-images.githubusercontent.com/243189/150114372-06217b86-c079-47c8-8261-92be76d5c923.mov)

I first used `:checked` & `:disabled` pseudo-classes to prevent having css generated at run time but it wasn't enough, the main culprit being the transition on the `left` property.
Here's a fixed version (still slow but not wonky):

[after](https://user-images.githubusercontent.com/243189/150114377-3507d52b-14e9-4a9b-9eec-9b372c33794e.mov)

