### PR TITLE
fix: remove babel dependency from output

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,15 +8,12 @@ import json from '@rollup/plugin-json'
 
 const extensions = ['.js', '.ts', '.tsx']
 
-const getBabelOptions = ({ babelConfigFile = '../../babel.config.js', useESModules }) => ({
+const getBabelOptions = ({ babelConfigFile = '../../babel.config.js' }) => ({
   exclude: '**/node_modules/**',
   runtimeHelpers: true,
   configFile: babelConfigFile,
   extensions,
-  plugins: [
-    'babel-plugin-annotate-pure-calls',
-    ['@babel/plugin-transform-runtime', { useESModules }],
-  ],
+  plugins: ['babel-plugin-annotate-pure-calls'],
 })
 
 const external = id => !id.startsWith('.') && !id.startsWith('/')
@@ -44,14 +41,14 @@ export const getRollupConfig = ({ babelConfigFile, inputFile, pwd, ts }) => {
     input,
     output: { file: `${SOURCE_DIR}/${pkg.main}`, format: 'cjs' },
     external,
-    plugins: [...PLUGINS, babel(getBabelOptions({ babelConfigFile, useESModules: false }))],
+    plugins: [...PLUGINS, babel(getBabelOptions({ babelConfigFile }))],
   }
 
   const esmConfig = {
     input,
     output: { file: `${SOURCE_DIR}/${pkg.module}`, format: 'esm' },
     external,
-    plugins: [...PLUGINS, babel(getBabelOptions({ babelConfigFile, useESModules: true }))],
+    plugins: [...PLUGINS, babel(getBabelOptions({ babelConfigFile }))],
   }
 
   if (process.env.WATCH_MODE) {


### PR DESCRIPTION
**Output actuel de `dist/box.es.js` :**
```
import _extends from '@babel/runtime/helpers/esm/extends';
import React from 'react';
import { x } from '@xstyled/styled-components';
import { forwardRef } from '@welcome-ui/system';

var Box = /*#__PURE__*/forwardRef(function (props, ref) {
  return /*#__PURE__*/React.createElement(x.div, _extends({
    ref: ref
  }, props));
});

export { Box };
```

Ça me semble pas tiptop cette première ligne qui importe un helper depuis babel alors que ce n'est pas une peerDependecy de Box. (C'est la même chose sur tous les packages)

**Output de `dist/box.es.js` après le fix :** 
```
import React from 'react';
import { x } from '@xstyled/styled-components';
import { forwardRef } from '@welcome-ui/system';

function _extends() {
  _extends = Object.assign || function (target) {
    for (var i = 1; i < arguments.length; i++) {
      var source = arguments[i];

      for (var key in source) {
        if (Object.prototype.hasOwnProperty.call(source, key)) {
          target[key] = source[key];
        }
      }
    }

    return target;
  };

  return _extends.apply(this, arguments);
}

var Box = /*#__PURE__*/forwardRef(function (props, ref) {
  return /*#__PURE__*/React.createElement(x.div, _extends({
    ref: ref
  }, props));
});

export { Box };
```

Du coup ça rajoute un peu plus de code dans chaque package à l'output mais je pense que c'est ok 🌵 