### PR TITLE
fix: remove useless useTheme

### DIFF
--- a/packages/Core/WuiProvider.tsx
+++ b/packages/Core/WuiProvider.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ThemeProvider, useTheme as useXstyledTheme } from '@xstyled/styled-components'
+import { ThemeProvider } from '@xstyled/styled-components'
 import { HideFocusRingsRoot } from '@welcome-ui/utils'
 
 import { WuiTheme } from './theme/types'
@@ -36,15 +36,3 @@ export const WuiProvider: React.FC<WuiProviderProps> = ({
 }
 
 WuiProvider.displayName = 'WuiProvider'
-
-export const useTheme = (): WuiTheme => {
-  const theme = useXstyledTheme() as WuiTheme
-
-  if (!theme) {
-    throw Error(
-      'useTheme: `theme` is undefined. Seems you forgot to wrap your app in <WuiProvider />'
-    )
-  }
-
-  return theme
-}

--- a/packages/Core/index.ts
+++ b/packages/Core/index.ts
@@ -4,7 +4,7 @@ export * from './theme/core'
 // Base
 export * from './utils/base'
 
-// WuiProvider & useTheme
+// WuiProvider
 export * from './WuiProvider'
 
 // export WuiTheme and all ThemeProps


### PR DESCRIPTION
We need to use `useTheme` from "@xstyled/styled-components" instead of "@welcome-ui/core" in our applications to have a correctly typed theme according to our typescript configuration : https://www.welcome-ui.com/installation#typescript