### PR TITLE
chore: remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @Calvein @P1X3L @anucreative @theo-mesnil @guillaumewttj @mleralec @cnairiwttj @DuarteParadela @jeromeraffin @leiksa @RobelTekle @stevenpersia


### PR DESCRIPTION
Now we got a new team `wui-maintainers`