### PR TITLE
Fix scroll drawer mobile

### DIFF
--- a/docs/components/Header/index.js
+++ b/docs/components/Header/index.js
@@ -52,10 +52,12 @@ export function Header() {
       >
         {mobileMenuDrawer.visible ? <CrossIcon /> : <MenuIcon />}
       </Drawer.Trigger>
-      <S.MenuMobileDrawer aria-label="Menu backdrop" {...mobileMenuDrawer}>
-        <NavBar isMobileMenu mb="xl" />
-        <ComponentsList onClick={() => mobileMenuDrawer.hide()} />
-      </S.MenuMobileDrawer>
+      <Drawer.Backdrop {...mobileMenuDrawer} backdropVisible={false}>
+        <S.MenuMobileDrawer aria-label="Menu backdrop" {...mobileMenuDrawer}>
+          <NavBar isMobileMenu mb="xl" />
+          <ComponentsList onClick={() => mobileMenuDrawer.hide()} />
+        </S.MenuMobileDrawer>
+      </Drawer.Backdrop>
     </S.Header>
   )
 }

--- a/docs/components/Header/styles.js
+++ b/docs/components/Header/styles.js
@@ -42,11 +42,9 @@ export const Header = styled.header(
   `
 )
 
-// best hack ever 🙈 need to fix drawer and modal for mobile scrolling
 export const MenuMobileDrawer = styled(WUIDrawer)`
   top: ${`calc(${headerHeight} - 1px)`} !important;
   width: 100% !important;
-  overflow: scroll;
   padding: xl;
 
   @media (min-width: md) {

--- a/docs/pages/components/drawer.mdx
+++ b/docs/pages/components/drawer.mdx
@@ -21,7 +21,7 @@ Drawer based on [Reakit's dialog](https://reakit.io/docs/dialog/) with a really 
 
 ## Usage
 
-The most basic drawer needs `useDrawerState()`, `<Drawer.Trigger />`, `<Drawer.Backdrop />` and `<Drawer />`. Please note you have to wrap your `<Drawer />` with a `<Drawer.Backdrop />`. If you don't want this `<Drawer.Backdrop />` to be visible, please provide it a `backdropVisible` prop set to `false`.
+The most basic drawer needs `useDrawerState()`, `<Drawer.Trigger />`, `<Drawer.Backdrop />` and `<Drawer />`. **Please note you have to wrap your `<Drawer />` with a `<Drawer.Backdrop />`**. If you don't want this `<Drawer.Backdrop />` to be visible, please provide it a `backdropVisible` prop set to `false`. Backdrop allows us to have a smooth scroll across all browsers by wrapping the Drawer. This way, the Drawer can be absolutely positioned in the fixed Backdrop wrapper.
 
 ```jsx
 function DefaultDrawer() {

--- a/docs/pages/components/drawer.mdx
+++ b/docs/pages/components/drawer.mdx
@@ -21,7 +21,7 @@ Drawer based on [Reakit's dialog](https://reakit.io/docs/dialog/) with a really 
 
 ## Usage
 
-The most basic drawer needs `useDrawerState()`, `<Drawer.Trigger />` and `<Drawer />`.
+The most basic drawer needs `useDrawerState()`, `<Drawer.Trigger />`, `<Drawer.Backdrop />` and `<Drawer />`. Please note you have to wrap your `<Drawer />` with a `<Drawer.Backdrop />`. If you don't want this `<Drawer.Backdrop />` to be visible, please provide it a `backdropVisible` prop set to `false`.
 
 ```jsx
 function DefaultDrawer() {
@@ -46,7 +46,7 @@ function DefaultDrawer() {
 
 ## Backdrop
 
-You can wrap `<Drawer />` with `<Drawer.Backdrop />` to add a backdrop. It corresponds to [Reakit Dialog's Backdrop](https://reakit.io/docs/dialog/#backdrop) with custom styling.
+You have to wrap `<Drawer />` with `<Drawer.Backdrop />`. It can be either visible or not, thanks to the `backdropVisible` prop (which is true by default). It corresponds to [Reakit Dialog's Backdrop](https://reakit.io/docs/dialog/#backdrop) with custom styling.
 
 ```jsx
 function BackdropDrawer() {

--- a/docs/pages/components/drawer.mdx
+++ b/docs/pages/components/drawer.mdx
@@ -221,49 +221,7 @@ function StylingDrawer() {
           </Drawer.Title>
           <Drawer.Content backgroundColor="light.900">
             Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
-            aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet
-            quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
-            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
-            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
-            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
-            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
-            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
-            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent
-            sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
-            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
-            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
-            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
-            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
-            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
-            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent
-            sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
-            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
-            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
-            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
-            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
-            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
-            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent
-            sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
-            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
-            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
-            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
-            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
-            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
-            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent
-            sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
-            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
-            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
-            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
-            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
-            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
-            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent
-            sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
-            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
-            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
-            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
-            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
-            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
-            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta.
+            aliquam nec, convallis sit amet erat. Mauris auctor blandit porta.
           </Drawer.Content>
           <Drawer.Footer borderTop="1px solid" borderTopColor="dark.200">
             <Stack direction="row">

--- a/docs/pages/components/drawer.mdx
+++ b/docs/pages/components/drawer.mdx
@@ -32,11 +32,13 @@ function DefaultDrawer() {
       <Drawer.Trigger as={Button} {...drawer}>
         Open Drawer
       </Drawer.Trigger>
-      <Drawer aria-label="Default drawer" {...drawer}>
-        <Drawer.Close {...drawer} />
-        Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam
-        nec, convallis sit amet erat. Mauris auctor blandit porta.
-      </Drawer>
+      <Drawer.Backdrop {...drawer} backdropVisible={false}>
+        <Drawer aria-label="Default drawer" {...drawer}>
+          <Drawer.Close {...drawer} />
+          Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam
+          nec, convallis sit amet erat. Mauris auctor blandit porta.
+        </Drawer>
+      </Drawer.Backdrop>
     </>
   )
 }
@@ -219,7 +221,49 @@ function StylingDrawer() {
           </Drawer.Title>
           <Drawer.Content backgroundColor="light.900">
             Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
-            aliquam nec, convallis sit amet erat. Mauris auctor blandit porta.
+            aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet
+            quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
+            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
+            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
+            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
+            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
+            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
+            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent
+            sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
+            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
+            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
+            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
+            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
+            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
+            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent
+            sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
+            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
+            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
+            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
+            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
+            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
+            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent
+            sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
+            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
+            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
+            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
+            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
+            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
+            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent
+            sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
+            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
+            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
+            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
+            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
+            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
+            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. Praesent
+            sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec,
+            convallis sit amet erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit
+            faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet
+            erat. Mauris auctor blandit porta. Praesent sit amet quam ac velit faucibus dapibus.
+            Quisque sapien ligula, rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor
+            blandit porta. Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula,
+            rutrum quis aliquam nec, convallis sit amet erat. Mauris auctor blandit porta.
           </Drawer.Content>
           <Drawer.Footer borderTop="1px solid" borderTopColor="dark.200">
             <Stack direction="row">

--- a/docs/pages/upgrade.mdx
+++ b/docs/pages/upgrade.mdx
@@ -70,6 +70,12 @@ We reduce the size (and variant) of headings on mobile :
 
 ### Components
 
+#### Drawer
+
+The Drawer component has to be wrapped with a Backdrop component, visible by default. If you don't want the Backdrop to be visible, you can pass it a `backdropVisible` prop set to `false`.
+
+This decision was made for browser compatibility purpose.
+
 #### ConnectedField
 
 The ConnectedField component was built to work with react-final-form and was not generic enough so we have decided to remove it on v4.

--- a/packages/Core/theme/drawers.ts
+++ b/packages/Core/theme/drawers.ts
@@ -28,19 +28,19 @@ export const getDrawers = (theme: WuiTheme): ThemeDrawers => {
       zIndex: 999,
     },
     closeButton: {
-      top: `${space.xl}`,
-      right: `${space.xl}`,
+      marginRight: `${space.xl}`,
+      marginTop: `${space.xl}`,
     },
     title: {
       margin: 0,
-      padding: `${space['3xl']} ${space['5xl']} ${space['3xl']} ${space['3xl']}`,
+      padding: `${space['xl']} ${space['5xl']} ${space['xl']} ${space['xl']}`,
       ...texts.h3,
     },
     content: {
       padding: `${space['3xl']}`,
     },
     footer: {
-      padding: `${space['3xl']}`,
+      padding: `${space['xl']}`,
     },
     sizes: {
       horizontal: {

--- a/packages/Core/theme/drawers.ts
+++ b/packages/Core/theme/drawers.ts
@@ -18,7 +18,7 @@ export type ThemeDrawers = {
 }
 
 export const getDrawers = (theme: WuiTheme): ThemeDrawers => {
-  const { colors, space, texts, toRem } = theme
+  const { colors, space, toRem } = theme
   return {
     backdrop: {
       backgroundColor: colors.overlay,
@@ -33,13 +33,14 @@ export const getDrawers = (theme: WuiTheme): ThemeDrawers => {
     },
     title: {
       margin: 0,
+      backgroundColor: colors.light[900],
       padding: `${space['xl']} ${space['5xl']} ${space['xl']} ${space['xl']}`,
-      ...texts.h3,
     },
     content: {
       padding: `${space['3xl']}`,
     },
     footer: {
+      backgroundColor: colors.light[900],
       padding: `${space['xl']}`,
     },
     sizes: {

--- a/packages/Drawer/index.test.tsx
+++ b/packages/Drawer/index.test.tsx
@@ -43,22 +43,22 @@ describe('<Drawer>', () => {
     expect(queryByRole('dialog')).toHaveStyleRule('height', '50%')
   })
 
-  it("should error if <Drawer.Backdrop />'s children isn't <Drawer />", () => {
-    const Test = () => {
-      const drawer = useDrawerState()
-      return (
-        <>
-          <Drawer.Trigger {...drawer}>open</Drawer.Trigger>
-          <Drawer.Backdrop {...drawer}>
-            <div>nope</div>
-          </Drawer.Backdrop>
-        </>
-      )
-    }
+  // it("should error if <Drawer.Backdrop />'s children isn't <Drawer />", () => {
+  //   const Test = () => {
+  //     const drawer = useDrawerState()
+  //     return (
+  //       <>
+  //         <Drawer.Trigger {...drawer}>open</Drawer.Trigger>
+  //         <Drawer.Backdrop {...drawer}>
+  //           <div>nope</div>
+  //         </Drawer.Backdrop>
+  //       </>
+  //     )
+  //   }
 
-    const renderDrawer = () => {
-      render(<Test />)
-    }
-    expect(renderDrawer).toThrowError()
-  })
+  //   const renderDrawer = () => {
+  //     render(<Test />)
+  //   }
+  //   expect(renderDrawer).toThrowError()
+  // })
 })

--- a/packages/Drawer/index.test.tsx
+++ b/packages/Drawer/index.test.tsx
@@ -42,23 +42,4 @@ describe('<Drawer>', () => {
     getByText('open').click()
     expect(queryByRole('dialog')).toHaveStyleRule('height', '50%')
   })
-
-  // it("should error if <Drawer.Backdrop />'s children isn't <Drawer />", () => {
-  //   const Test = () => {
-  //     const drawer = useDrawerState()
-  //     return (
-  //       <>
-  //         <Drawer.Trigger {...drawer}>open</Drawer.Trigger>
-  //         <Drawer.Backdrop {...drawer}>
-  //           <div>nope</div>
-  //         </Drawer.Backdrop>
-  //       </>
-  //     )
-  //   }
-
-  //   const renderDrawer = () => {
-  //     render(<Test />)
-  //   }
-  //   expect(renderDrawer).toThrowError()
-  // })
 })

--- a/packages/Drawer/index.tsx
+++ b/packages/Drawer/index.tsx
@@ -106,19 +106,22 @@ export const Close: React.FC<CloseProps> = ({ hide, ...props }) => {
   )
 }
 
-export const Title: React.FC<TextProps> = props => {
+export const Title: React.FC<TextProps> = ({ children, ...props }) => {
   const { drawers } = useTheme()
   return (
     <Box
       alignItems="center"
-      backgroundColor="light.900"
       display="flex"
       justifyContent="space-between"
       position={{ xs: 'sticky', md: 'static' }}
       top={{ xs: 0, md: 'auto' }}
       w="100%"
+      {...drawers.title}
+      {...props}
     >
-      <Text {...drawers.title} w="100%" {...props} />
+      <Text m="0" variant="h3" w="100%">
+        {children}
+      </Text>
     </Box>
   )
 }
@@ -132,7 +135,6 @@ export const Footer: React.FC<BoxProps> = props => {
   const { drawers } = useTheme()
   return (
     <Box
-      backgroundColor={{ xs: 'white', md: 'transparent' }}
       bottom={{ xs: 0, md: 'auto' }}
       position={{ xs: 'sticky', md: 'static' }}
       {...drawers.footer}

--- a/packages/Drawer/index.tsx
+++ b/packages/Drawer/index.tsx
@@ -29,11 +29,11 @@ export interface DrawerOptions {
 export type DrawerProps = CreateWuiProps<'div', DrawerOptions & DialogOptions>
 
 const DrawerComponent = forwardRef<'div', DrawerProps>(
-  ({ as, children, placement = 'right', size = 'lg', tabIndex, ...rest }, ref) => {
+  ({ as, children, placement = 'right', size = 'lg', ...rest }, ref) => {
     return (
       // Needed to allow to style the backdrop
       // see: https://reakit.io/docs/styling/#css-in-js
-      <Dialog as={as} ref={ref} tabIndex={tabIndex} {...rest}>
+      <Dialog as={as} ref={ref} {...rest}>
         {(props: DrawerProps) => (
           <S.Drawer {...props} placement={placement} size={size}>
             {children}

--- a/packages/Drawer/styles.ts
+++ b/packages/Drawer/styles.ts
@@ -5,9 +5,15 @@ import { DialogBackdrop } from 'reakit/Dialog'
 
 import { DrawerProps, Placement, Size } from '.'
 
+type DrawerWrapperProps = {
+  hideOnClickOutside: boolean
+  placement?: Placement
+  size?: Size
+}
+
 export const Backdrop = styled(DialogBackdrop).withConfig({
   shouldForwardProp: prop => !['hideOnClickOutside'].includes(prop),
-})<{ hideOnClickOutside: boolean }>(
+})<DrawerWrapperProps>(
   ({ hideOnClickOutside }) => css`
     ${th('drawers.backdrop')};
     display: flex;
@@ -151,7 +157,7 @@ const getBackdropWrapperPlacementStyle = (placement: Placement) => {
 
 export const NoBackdropWrapper = styled(DialogBackdrop).withConfig({
   shouldForwardProp: prop => !['hideOnClickOutside'].includes(prop),
-})<{ hideOnClickOutside: boolean; placement: Placement; size: Size; visible: boolean }>(
+})<DrawerWrapperProps>(
   ({ hideOnClickOutside, placement, size }) => css`
     ${th('drawers.backdrop')};
     ${getBackdropWrapperPlacementStyle(placement)}

--- a/packages/Drawer/styles.ts
+++ b/packages/Drawer/styles.ts
@@ -1,11 +1,14 @@
 import styled, { css, th } from '@xstyled/styled-components'
 import { Box } from '@welcome-ui/box'
 import { cardStyles } from '@welcome-ui/utils'
+import { DialogBackdrop } from 'reakit/Dialog'
 
 import { DrawerProps, Placement, Size } from '.'
 
-export const Backdrop = styled(Box)<{ isClickable: boolean }>(
-  ({ isClickable }) => css`
+export const Backdrop = styled(DialogBackdrop).withConfig({
+  shouldForwardProp: prop => !['hideOnClickOutside'].includes(prop),
+})<{ hideOnClickOutside: boolean }>(
+  ({ hideOnClickOutside }) => css`
     ${th('drawers.backdrop')};
     display: flex;
     align-items: center;
@@ -17,7 +20,7 @@ export const Backdrop = styled(Box)<{ isClickable: boolean }>(
     bottom: 0;
     opacity: 0;
     transition: fast;
-    ${isClickable &&
+    ${hideOnClickOutside &&
     css`
       cursor: pointer;
     `}
@@ -33,7 +36,7 @@ const getPlacementStyle = (placement: Placement) => {
   switch (placement) {
     case 'top':
       return {
-        top: 0,
+        top: '0 !important',
         right: 0,
         left: 0,
         // Used for animation
@@ -41,7 +44,7 @@ const getPlacementStyle = (placement: Placement) => {
       }
     case 'right':
       return {
-        top: 0,
+        top: '0 !important',
         right: 0,
         bottom: 0,
         transform: 'translateX(100%)',
@@ -55,7 +58,7 @@ const getPlacementStyle = (placement: Placement) => {
       }
     case 'left':
       return {
-        top: 0,
+        top: '0 !important',
         bottom: 0,
         left: 0,
         transform: 'translateX(-100%)',
@@ -91,13 +94,15 @@ export const Drawer = styled(Box)<DrawerProps>(
     ${th('drawers.default')};
     ${getPlacementStyle(placement)}
     ${getSizeStyle(size, placement)}
-    position: fixed;
+    position: absolute;
     display: flex;
     flex-direction: column;
     max-width: 100%;
     max-height: 100%;
     transition: medium;
     cursor: auto;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
 
     &:focus {
       /* important for firefox */
@@ -111,6 +116,63 @@ export const Drawer = styled(Box)<DrawerProps>(
 
     &[data-leave] {
       transition: fast;
+    }
+  `
+)
+
+const getBackdropWrapperPlacementStyle = (placement: Placement) => {
+  switch (placement) {
+    case 'top':
+      return {
+        top: 0,
+        right: 0,
+        left: 0,
+      }
+    case 'right':
+      return {
+        top: 0,
+        right: 0,
+        bottom: 0,
+      }
+    case 'bottom':
+      return {
+        right: 0,
+        bottom: 0,
+        left: 0,
+      }
+    case 'left':
+      return {
+        top: 0,
+        bottom: 0,
+        left: 0,
+      }
+  }
+}
+
+export const NoBackdropWrapper = styled(DialogBackdrop).withConfig({
+  shouldForwardProp: prop => !['hideOnClickOutside'].includes(prop),
+})<{ hideOnClickOutside: boolean; placement: Placement; size: Size; visible: boolean }>(
+  ({ hideOnClickOutside, placement, size }) => css`
+    ${th('drawers.backdrop')};
+    ${getBackdropWrapperPlacementStyle(placement)}
+    ${getSizeStyle(size, placement)}
+    background-color: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    max-width: 100%;
+    max-height: 100%;
+    opacity: 0;
+    transition: fast;
+    ${hideOnClickOutside &&
+    css`
+      cursor: pointer;
+    `}
+
+    /* on open dialog for animation */
+    &[data-enter] {
+      opacity: 1;
     }
   `
 )

--- a/packages/Modal/styles.ts
+++ b/packages/Modal/styles.ts
@@ -42,7 +42,7 @@ export const Dialog = styled(ReakitDialog)<{ size: Size }>(
     opacity: 0;
     height: 100%;
     width: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     -webkit-overflow-scrolling: touch;
 
     transition: opacity 250ms ease-in-out, margin-top 250ms ease-in-out;


### PR DESCRIPTION
Drawer was reworked in order to work on Safari mobile as well on Chrome, desktop or mobile etc.

Here is the breaking changes we've introduced:

You have to wrap your Drawer with a <Drawer.Backdrop/> component. If you don't want this backdrop to appear, you have to give him a backdropVisible props set to "false" : backdropVisible={false}
We had a test on the children type of the Backdrop, to be sure to receive a drawer. Still, this was not working with Styled Drawer. So we remove this check. Be sure to pass a Drawer or styled Drawer as a children to Backdrop.
We sure plan to rework entirely for a future version.