### PR TITLE
fix: add async/await inline polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "aws-sdk": "^2.1094.0",
     "babel-jest": "27.5.1",
     "babel-plugin-annotate-pure-calls": "^0.4.0",
+    "babel-plugin-transform-async-to-promises": "^0.8.18",
     "colors": "^1.4.0",
     "conventional-github-releaser": "^3.1.3",
     "date-fns": "^2.28.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,7 @@ const getBabelOptions = ({ babelConfigFile = '../../babel.config.js' }) => ({
   exclude: '**/node_modules/**',
   configFile: babelConfigFile,
   extensions,
-  plugins: ['babel-plugin-annotate-pure-calls'],
+  plugins: ['babel-plugin-annotate-pure-calls', 'babel-plugin-transform-async-to-promises'],
   babelHelpers: 'inline',
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5717,6 +5717,11 @@ babel-plugin-syntax-jsx@6.18.0, babel-plugin-syntax-jsx@^6.18.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
+babel-plugin-transform-async-to-promises@^0.8.18:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.18.tgz#f4dc5980b8afa0fc9c784b8d931afde913413e39"
+  integrity sha512-WpOrF76nUHijnNn10eBGOHZmXQC8JYRME9rOLxStOga7Av2VO53ehVFvVNImMksVtQuL2/7ZNxEgxnx7oo/3Hw==
+
 babel-plugin-transform-react-remove-prop-types@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"


### PR DESCRIPTION
Currently, if you build the `@welcome-ui/search` package (the only one that uses **async/await** in our components), in the output, we can find this : 

```js
  var searchResults = useCallback( /*#__PURE__*/function () {
    var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(value) {
      var data;
      return regeneratorRuntime.wrap(function _callee$(_context) {
        while (1) {
        ...
```

But there is no import of `regeneratorRuntime` because we have babelHelpers in `inline` mode. 💀 :boom:


This new polyfill will create `_async` and `_await` function in the current file and use them like this :
```js
function _await(value, then, direct) { ... }
function _async(f) { ... }

 var searchResults = useCallback(_async(function (value) {
    return _invokeIgnored(function () {
      if (minChars === 0 || (value === null || value === void 0 ? void 0 : value.length) >= minChars) {
        return _await(search(value), function (data) {
        ...
```