### PR TITLE
refactor: system

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Here you'll find all the core components you need to create a delightful webapp.
 1 - Install the **peer dependencies** listed below:
 
 ```bash
-yarn add @xstyled/styled-components @xstyled/system react react-dom styled-components
+yarn add @xstyled/styled-components react react-dom styled-components
 ```
 
 2 - Install the the **core** component and any other components you need for your webapp e.g. if you need just a button…
@@ -43,12 +43,12 @@ const options = {
   headingFontFamily: 'Georgia',
   colors: {
     primary: {
-      500: '#124C80'
+      500: '#124C80',
     },
     success: {
-      500: '#32CD32'
-    }
-  }
+      500: '#32CD32',
+    },
+  },
 }
 
 // Create your theme

--- a/docs/components/ComponentsList/styles.js
+++ b/docs/components/ComponentsList/styles.js
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { th } from '@xstyled/styled-components'
 import { Box } from '@welcome-ui/box'
 
 export const Ul = styled.ul`

--- a/docs/components/Header/NavBar/styles.js
+++ b/docs/components/Header/NavBar/styles.js
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 
 export const NavBar = styled.ul`
   display: inline-flex;

--- a/docs/components/Layouts/Docs/styles.js
+++ b/docs/components/Layouts/Docs/styles.js
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { th } from '@xstyled/styled-components'
 
 import { headerHeight } from '../../Header/styles'
 

--- a/docs/components/Mdx/Code/styles.js
+++ b/docs/components/Mdx/Code/styles.js
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { css, th } from '@xstyled/styled-components'
 import { LiveEditor as ReactLiveEditor, LiveError as ReactLiveError } from 'react-live'
 import { Box } from '@welcome-ui/box'
 

--- a/docs/components/Mdx/Headings/styles.js
+++ b/docs/components/Mdx/Headings/styles.js
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { system } from '@xstyled/system'
+import styled, { system } from '@xstyled/styled-components'
 import { Text } from '@welcome-ui/text'
 
 export const Link = styled.a`

--- a/docs/components/Mdx/Pagination/styles.js
+++ b/docs/components/Mdx/Pagination/styles.js
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { css, th } from '@xstyled/styled-components'
 
 export const Link = styled.a(
   ({ isNext }) => css`

--- a/docs/pages/blog.js
+++ b/docs/pages/blog.js
@@ -11,8 +11,7 @@ import { Link } from '@welcome-ui/link'
 import { Tag } from '@welcome-ui/tag'
 import { Stack } from '@welcome-ui/stack'
 import { RightIcon } from '@welcome-ui/icons'
-import { th } from '@xstyled/system'
-import styled from '@xstyled/styled-components'
+import styled, { th } from '@xstyled/styled-components'
 import { Avatar } from '@welcome-ui/avatar'
 
 const posts = [

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -7,7 +7,7 @@
 Install the `@welcome-ui/core` component and **peer dependencies** listed below:
 
 ```bash
-yarn add @welcome-ui/core @xstyled/styled-components @xstyled/system react react-dom styled-components
+yarn add @welcome-ui/core @xstyled/styled-components react react-dom styled-components
 ```
 
 ### 2. Install UI components
@@ -109,21 +109,20 @@ In order to get your theme object typed with our theme, you have to override the
 ```
 // styled.d.ts
 import 'styled-components'
-import '@xstyled/system'
+import '@xstyled/styled-components'
 import { WuiTheme } from '@welcome-ui/core'
 
 interface AppTheme extends WuiTheme {
   // customize your theme
 }
 
-declare module '@xstyled/system' {
+declare module '@xstyled/styled-components' {
   export interface Theme extends AppTheme {}
 }
 
 declare module 'styled-components' {
   export interface DefaultTheme extends AppTheme {}
 }
-
 ```
 
 <pagination />

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "aws-sdk": "^2.1094.0",
     "babel-jest": "28.1.0",
     "babel-plugin-annotate-pure-calls": "^0.4.0",

--- a/packages/Accordion/package.json
+++ b/packages/Accordion/package.json
@@ -45,7 +45,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Accordion/styles.ts
+++ b/packages/Accordion/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { DisclosureContent, Disclosure as ReakitDisclosure } from 'reakit/Disclosure'
 import { Box } from '@welcome-ui/box'
 

--- a/packages/Accordion/styles.ts
+++ b/packages/Accordion/styles.ts
@@ -1,8 +1,7 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { DisclosureContent, Disclosure as ReakitDisclosure } from 'reakit/Disclosure'
 import { Box } from '@welcome-ui/box'
-import { system } from '@welcome-ui/system'
 
 export const Accordion = styled.div`
   ${th('accordions.wrapper')};

--- a/packages/Alert/package.json
+++ b/packages/Alert/package.json
@@ -46,7 +46,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Alert/styles.ts
+++ b/packages/Alert/styles.ts
@@ -1,8 +1,7 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { Box } from '@welcome-ui/box'
 import { Text } from '@welcome-ui/text'
-import { system } from '@welcome-ui/system'
 
 import { AlertOptions } from '.'
 

--- a/packages/Alert/styles.ts
+++ b/packages/Alert/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { Box } from '@welcome-ui/box'
 import { Text } from '@welcome-ui/text'
 

--- a/packages/AspectRatio/package.json
+++ b/packages/AspectRatio/package.json
@@ -42,7 +42,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Avatar/package.json
+++ b/packages/Avatar/package.json
@@ -45,7 +45,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Avatar/styles.ts
+++ b/packages/Avatar/styles.ts
@@ -1,7 +1,6 @@
-import styled from '@xstyled/styled-components'
+import styled, { th } from '@xstyled/styled-components'
 import { Shape } from '@welcome-ui/shape'
 import { Text as TextWUI } from '@welcome-ui/text'
-import { th } from '@xstyled/system'
 
 export const Avatar = styled(Shape)`
   flex-shrink: 0;

--- a/packages/Breadcrumb/Item.styles.ts
+++ b/packages/Breadcrumb/Item.styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { css, th } from '@xstyled/styled-components'
 import { Box } from '@welcome-ui/box'
 import { shouldForwardProp } from '@welcome-ui/system'
 

--- a/packages/Breadcrumb/package.json
+++ b/packages/Breadcrumb/package.json
@@ -46,7 +46,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Breadcrumb/styles.ts
+++ b/packages/Breadcrumb/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { css, th } from '@xstyled/styled-components'
 import { Box } from '@welcome-ui/box'
 import { hexToRGBA } from '@welcome-ui/utils'
 import { WuiTheme } from '@welcome-ui/core'

--- a/packages/Button/package.json
+++ b/packages/Button/package.json
@@ -45,7 +45,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Button/styles.ts
+++ b/packages/Button/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { Button as ReakitButton } from 'reakit/Button'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { hideFocusRingsDataAttribute } from '@welcome-ui/utils'

--- a/packages/ButtonGroup/styles.ts
+++ b/packages/ButtonGroup/styles.ts
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { system } from '@xstyled/system'
+import styled, { system } from '@xstyled/styled-components'
 
 export const ButtonGroup = styled.div`
   display: inline-flex;

--- a/packages/ButtonGroup/styles.ts
+++ b/packages/ButtonGroup/styles.ts
@@ -1,5 +1,5 @@
 import styled from '@xstyled/styled-components'
-import { system } from '@welcome-ui/system'
+import { system } from '@xstyled/system'
 
 export const ButtonGroup = styled.div`
   display: inline-flex;

--- a/packages/Card/Cover.styles.ts
+++ b/packages/Card/Cover.styles.ts
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { system, th } from '@xstyled/styled-components'
 import { Shape } from '@welcome-ui/shape'
 
 export const Cover = styled(Shape)`

--- a/packages/Card/Cover.styles.ts
+++ b/packages/Card/Cover.styles.ts
@@ -1,7 +1,6 @@
 import styled from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { Shape } from '@welcome-ui/shape'
-import { system } from '@welcome-ui/system'
 
 export const Cover = styled(Shape)`
   ${th('cards.cover')};

--- a/packages/Card/package.json
+++ b/packages/Card/package.json
@@ -45,7 +45,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Card/styles.ts
+++ b/packages/Card/styles.ts
@@ -1,7 +1,6 @@
 import styled from '@xstyled/styled-components'
+import { system, th } from '@xstyled/system'
 import { Box } from '@welcome-ui/box'
-import { system } from '@welcome-ui/system'
-import { th } from '@xstyled/system'
 import { cardStyles } from '@welcome-ui/utils'
 
 export const Card = styled(Box)`

--- a/packages/Card/styles.ts
+++ b/packages/Card/styles.ts
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { system, th } from '@xstyled/styled-components'
 import { Box } from '@welcome-ui/box'
 import { cardStyles } from '@welcome-ui/utils'
 

--- a/packages/Checkbox/package.json
+++ b/packages/Checkbox/package.json
@@ -44,7 +44,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Checkbox/styles.ts
+++ b/packages/Checkbox/styles.ts
@@ -1,7 +1,7 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { Checkbox as ReakitCheckbox } from 'reakit/Checkbox'
-import { shouldForwardProp, system } from '@welcome-ui/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 
 import { CheckboxProps } from './index'

--- a/packages/Checkbox/styles.ts
+++ b/packages/Checkbox/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { Checkbox as ReakitCheckbox } from 'reakit/Checkbox'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'

--- a/packages/ClearButton/package.json
+++ b/packages/ClearButton/package.json
@@ -44,7 +44,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/ClearButton/styles.ts
+++ b/packages/ClearButton/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css, keyframes } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { css, keyframes, th } from '@xstyled/styled-components'
 import { Button } from '@welcome-ui/button'
 
 const fade = keyframes`

--- a/packages/CloseButton/package.json
+++ b/packages/CloseButton/package.json
@@ -44,7 +44,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Core/package.json
+++ b/packages/Core/package.json
@@ -43,7 +43,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Core/theme/accordions.ts
+++ b/packages/Core/theme/accordions.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/alerts.ts
+++ b/packages/Core/theme/alerts.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/avatars.ts
+++ b/packages/Core/theme/avatars.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/breadcrumbs.ts
+++ b/packages/Core/theme/breadcrumbs.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/buttons.ts
+++ b/packages/Core/theme/buttons.ts
@@ -1,5 +1,5 @@
 import { hexToRGB } from '@welcome-ui/utils'
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { ThemeFocus } from './focus'
 import { WuiTheme } from './types'

--- a/packages/Core/theme/cards.ts
+++ b/packages/Core/theme/cards.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/checkboxes.ts
+++ b/packages/Core/theme/checkboxes.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/core.ts
+++ b/packages/Core/theme/core.ts
@@ -1,5 +1,5 @@
 import merge from 'ramda/src/mergeDeepRight'
-import { defaultTheme, rpxTransformers } from '@xstyled/system'
+import { defaultTheme, rpxTransformers } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 import { colors } from './colors'

--- a/packages/Core/theme/dateTimePickerCommon.ts
+++ b/packages/Core/theme/dateTimePickerCommon.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/defaultCards.ts
+++ b/packages/Core/theme/defaultCards.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { ThemeBorderWidths } from './borders'
 import { ThemeColors } from './colors'

--- a/packages/Core/theme/defaultFields.ts
+++ b/packages/Core/theme/defaultFields.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 import { Size } from '@welcome-ui/utils'
 
 import { ThemeFocus } from './focus'

--- a/packages/Core/theme/drawers.ts
+++ b/packages/Core/theme/drawers.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/dropdownMenu.ts
+++ b/packages/Core/theme/dropdownMenu.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/filedrops.ts
+++ b/packages/Core/theme/filedrops.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/focus.ts
+++ b/packages/Core/theme/focus.ts
@@ -1,5 +1,5 @@
 import { hexToRGBA } from '@welcome-ui/utils'
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 export type ThemeFocus = (color?: string) => {
   boxShadow: CSSObject['boxShadow']

--- a/packages/Core/theme/hints.ts
+++ b/packages/Core/theme/hints.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/labels.ts
+++ b/packages/Core/theme/labels.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/links.ts
+++ b/packages/Core/theme/links.ts
@@ -1,5 +1,5 @@
 import { css } from '@xstyled/styled-components'
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/modals.ts
+++ b/packages/Core/theme/modals.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/paginations.ts
+++ b/packages/Core/theme/paginations.ts
@@ -1,5 +1,5 @@
 import { hexToRGB } from '@welcome-ui/utils'
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/popovers.ts
+++ b/packages/Core/theme/popovers.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/radios.ts
+++ b/packages/Core/theme/radios.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/radiosTabs.ts
+++ b/packages/Core/theme/radiosTabs.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/selection.ts
+++ b/packages/Core/theme/selection.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/swipers.ts
+++ b/packages/Core/theme/swipers.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/tables.ts
+++ b/packages/Core/theme/tables.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/tabs.ts
+++ b/packages/Core/theme/tabs.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/tags.ts
+++ b/packages/Core/theme/tags.ts
@@ -1,5 +1,5 @@
 import { hexToRGBA } from '@welcome-ui/utils'
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/textareas.ts
+++ b/packages/Core/theme/textareas.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/toasts.ts
+++ b/packages/Core/theme/toasts.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 import { getTexts } from './typography'

--- a/packages/Core/theme/toggles.ts
+++ b/packages/Core/theme/toggles.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/tooltips.ts
+++ b/packages/Core/theme/tooltips.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/transitions.ts
+++ b/packages/Core/theme/transitions.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 export type ThemeTimingFunction = {
   primary: CSSObject['transition-timing-function']

--- a/packages/Core/theme/types.ts
+++ b/packages/Core/theme/types.ts
@@ -1,9 +1,9 @@
 import {
+  CSSObject,
   CSSScalar,
   ITheme as StyledComponentDefaultTheme,
   DefaultTheme as XStyledDefaultTheme,
 } from '@xstyled/styled-components'
-import { CSSObject } from '@xstyled/system'
 
 import { ThemeAccordions } from './accordions'
 import { ThemeAlerts } from './alerts'

--- a/packages/Core/theme/typography.ts
+++ b/packages/Core/theme/typography.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/system'
+import { CSSObject } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/utils/base.ts
+++ b/packages/Core/utils/base.ts
@@ -1,5 +1,4 @@
-import { createGlobalStyle, css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { createGlobalStyle, css, th } from '@xstyled/styled-components'
 
 import { fonts } from './font'
 import { normalizeStyle, resetStyles } from './reset'

--- a/packages/DateTimePicker/package.json
+++ b/packages/DateTimePicker/package.json
@@ -53,7 +53,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/DateTimePicker/styles.ts
+++ b/packages/DateTimePicker/styles.ts
@@ -1,6 +1,5 @@
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css, system } from '@xstyled/styled-components'
 import { StyledDatePicker, StyledTimePicker } from '@welcome-ui/date-time-picker-common'
-import { system } from '@xstyled/system'
 
 const focusStyles = css`
   &:focus {

--- a/packages/DateTimePicker/styles.ts
+++ b/packages/DateTimePicker/styles.ts
@@ -1,6 +1,6 @@
 import styled, { css } from '@xstyled/styled-components'
 import { StyledDatePicker, StyledTimePicker } from '@welcome-ui/date-time-picker-common'
-import { wrapperSystem } from '@welcome-ui/system'
+import { system } from '@xstyled/system'
 
 const focusStyles = css`
   &:focus {
@@ -40,5 +40,5 @@ export const DateTimePicker = styled.div`
     font-family: inherit;
   }
 
-  ${wrapperSystem};
+  ${system};
 `

--- a/packages/DateTimePickerCommon/CustomPopper.tsx
+++ b/packages/DateTimePickerCommon/CustomPopper.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { th } from '@xstyled/system'
-import styled, { css, CSSObject } from '@xstyled/styled-components'
+import styled, { css, CSSObject, th } from '@xstyled/styled-components'
 import { cardStyles } from '@welcome-ui/utils'
 
 import { datePickerStyles } from './datePickerStyles'

--- a/packages/DateTimePickerCommon/package.json
+++ b/packages/DateTimePickerCommon/package.json
@@ -53,7 +53,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/DateTimePickerCommon/styles.ts
+++ b/packages/DateTimePickerCommon/styles.ts
@@ -1,6 +1,5 @@
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import ReactDatePicker, { ReactDatePickerProps } from 'react-datepicker'
-import { system, th } from '@xstyled/system'
 import { IconWrapper } from '@welcome-ui/field'
 import { StyledIcon } from '@welcome-ui/icon'
 import { StyledButton } from '@welcome-ui/button'

--- a/packages/DateTimePickerCommon/styles.ts
+++ b/packages/DateTimePickerCommon/styles.ts
@@ -1,11 +1,11 @@
 import styled, { css } from '@xstyled/styled-components'
 import ReactDatePicker, { ReactDatePickerProps } from 'react-datepicker'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { IconWrapper } from '@welcome-ui/field'
 import { StyledIcon } from '@welcome-ui/icon'
 import { StyledButton } from '@welcome-ui/button'
 import { StyledClearButton } from '@welcome-ui/clear-button'
-import { componentSystem, shouldForwardProp } from '@welcome-ui/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import { StyledSelect } from '@welcome-ui/select'
 import { defaultFieldStyles, DefaultFieldStylesProps } from '@welcome-ui/utils'
 
@@ -16,7 +16,7 @@ export const StyledDatePicker = styled(ReactDatePicker)<
 >(
   ({ size, variant }) => css`
     ${defaultFieldStyles({ size, variant })};
-    ${componentSystem};
+    ${system};
   `
 )
 
@@ -24,7 +24,7 @@ export const StyledTimePicker = styled(ReactDatePicker)<DefaultFieldStylesProps>
   ({ size, variant }) => css`
     ${defaultFieldStyles({ size, variant })};
     text-align: center;
-    ${componentSystem};
+    ${system};
   `
 )
 

--- a/packages/Drawer/package.json
+++ b/packages/Drawer/package.json
@@ -47,7 +47,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/DropdownMenu/Item.styled.ts
+++ b/packages/DropdownMenu/Item.styled.ts
@@ -1,6 +1,5 @@
 import styled from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
 
 export const Item = styled.button`
   ${th('dropdownMenu.item')};

--- a/packages/DropdownMenu/Item.styled.ts
+++ b/packages/DropdownMenu/Item.styled.ts
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { system, th } from '@xstyled/styled-components'
 
 export const Item = styled.button`
   ${th('dropdownMenu.item')};

--- a/packages/DropdownMenu/Separator.styled.ts
+++ b/packages/DropdownMenu/Separator.styled.ts
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { th } from '@xstyled/styled-components'
 
 export const Separator = styled.hr`
   ${th('dropdownMenu.separator')};

--- a/packages/DropdownMenu/styles.ts
+++ b/packages/DropdownMenu/styles.ts
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { th } from '@xstyled/styled-components'
 import { cardStyles } from '@welcome-ui/utils'
 import { Box } from '@welcome-ui/box'
 

--- a/packages/EmojiPicker/package.json
+++ b/packages/EmojiPicker/package.json
@@ -56,7 +56,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/EmojiPicker/styles.ts
+++ b/packages/EmojiPicker/styles.ts
@@ -1,5 +1,4 @@
-import styled, { th } from '@xstyled/styled-components'
-import { system } from '@xstyled/system'
+import styled, { system, th } from '@xstyled/styled-components'
 import { Tab } from '@welcome-ui/tabs'
 import { Popover as WUIPopover } from '@welcome-ui/popover'
 import { Box } from '@welcome-ui/box'

--- a/packages/EmojiPicker/styles.ts
+++ b/packages/EmojiPicker/styles.ts
@@ -1,5 +1,5 @@
 import styled, { th } from '@xstyled/styled-components'
-import { system } from '@welcome-ui/system'
+import { system } from '@xstyled/system'
 import { Tab } from '@welcome-ui/tabs'
 import { Popover as WUIPopover } from '@welcome-ui/popover'
 import { Box } from '@welcome-ui/box'

--- a/packages/Field/package.json
+++ b/packages/Field/package.json
@@ -45,7 +45,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Field/styles.ts
+++ b/packages/Field/styles.ts
@@ -1,8 +1,8 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { StyledLabel } from '@welcome-ui/label'
 import { StyledFieldGroup } from '@welcome-ui/field-group'
-import { shouldForwardProp, system, WuiProps } from '@welcome-ui/system'
+import { shouldForwardProp, WuiProps } from '@welcome-ui/system'
 import { DefaultFieldStylesProps } from '@welcome-ui/utils'
 
 const rowStyles = css`

--- a/packages/Field/styles.ts
+++ b/packages/Field/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { StyledLabel } from '@welcome-ui/label'
 import { StyledFieldGroup } from '@welcome-ui/field-group'
 import { shouldForwardProp, WuiProps } from '@welcome-ui/system'

--- a/packages/FieldGroup/package.json
+++ b/packages/FieldGroup/package.json
@@ -43,7 +43,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/FieldGroup/styles.ts
+++ b/packages/FieldGroup/styles.ts
@@ -1,7 +1,7 @@
 import styled from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { StyledLabel } from '@welcome-ui/label'
-import { shouldForwardProp, system } from '@welcome-ui/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 
 export const FieldGroup = styled('fieldset').withConfig({ shouldForwardProp })`
   width: 100%;

--- a/packages/FieldGroup/styles.ts
+++ b/packages/FieldGroup/styles.ts
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { system, th } from '@xstyled/styled-components'
 import { StyledLabel } from '@welcome-ui/label'
 import { shouldForwardProp } from '@welcome-ui/system'
 

--- a/packages/FileDrop/package.json
+++ b/packages/FileDrop/package.json
@@ -53,7 +53,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/FileDrop/styles.ts
+++ b/packages/FileDrop/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { getVariantColor } from '@welcome-ui/utils'
 

--- a/packages/FileDrop/styles.ts
+++ b/packages/FileDrop/styles.ts
@@ -1,17 +1,16 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { componentSystem, shouldForwardProp, system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import { getVariantColor } from '@welcome-ui/utils'
 
 export interface StyledFileDropProps {
-  connected?: boolean
   disabled?: boolean
   isDragAccept?: boolean
   isDragReject?: boolean
 }
 
 export const FileDrop = styled('div').withConfig({ shouldForwardProp })<StyledFileDropProps>(
-  ({ connected, disabled, isDragAccept, isDragReject }) => css`
+  ({ disabled, isDragAccept, isDragReject }) => css`
     ${th('defaultFields.default')};
     ${th('filedrops.default')};
     ${isDragAccept && th('filedrops.dragAccept')};
@@ -26,7 +25,7 @@ export const FileDrop = styled('div').withConfig({ shouldForwardProp })<StyledFi
     align-items: center;
     padding: md;
     transition: medium;
-    ${connected ? componentSystem : system};
+    ${system};
 
     &:focus {
       ${th('defaultFields.focused.default')};

--- a/packages/Flex/index.tsx
+++ b/packages/Flex/index.tsx
@@ -1,23 +1,22 @@
 import React from 'react'
 import { Box } from '@welcome-ui/box'
-import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
-import { SystemProps } from '@xstyled/system'
+import { CreateWuiProps, forwardRef, WuiProps } from '@welcome-ui/system'
 
 export interface FlexOptions {
   /** same as alignItems */
-  align?: SystemProps['alignItems']
+  align?: WuiProps['alignItems']
   /** same as justifyContent */
-  justify?: SystemProps['justifyContent']
+  justify?: WuiProps['justifyContent']
   /** same as flexWrap */
-  wrap?: SystemProps['flexWrap']
+  wrap?: WuiProps['flexWrap']
   /** same as flexDirection */
-  direction?: SystemProps['flexDirection']
+  direction?: WuiProps['flexDirection']
   /** same as flexBasis */
-  basis?: SystemProps['flexBasis']
+  basis?: WuiProps['flexBasis']
   /** same as flexGrow */
-  grow?: SystemProps['flexGrow']
+  grow?: WuiProps['flexGrow']
   /** same as flexShrink */
-  shrink?: SystemProps['flexShrink']
+  shrink?: WuiProps['flexShrink']
 }
 
 export type FlexProps = CreateWuiProps<'div', FlexOptions>

--- a/packages/Flex/package.json
+++ b/packages/Flex/package.json
@@ -43,7 +43,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Grid/Item.tsx
+++ b/packages/Grid/Item.tsx
@@ -1,15 +1,14 @@
 import React from 'react'
 import { Box } from '@welcome-ui/box'
-import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
-import { SystemProps } from '@xstyled/system'
+import { CreateWuiProps, forwardRef, WuiProps } from '@welcome-ui/system'
 
 export interface ItemOptions {
   /** same as gridArea */
-  area?: SystemProps['gridArea']
+  area?: WuiProps['gridArea']
   /** same as gridColumn */
-  column?: SystemProps['gridColumn']
+  column?: WuiProps['gridColumn']
   /** same as gridRow */
-  row?: SystemProps['row']
+  row?: WuiProps['row']
 }
 
 export type ItemProps = CreateWuiProps<'div', ItemOptions>

--- a/packages/Grid/index.tsx
+++ b/packages/Grid/index.tsx
@@ -1,35 +1,34 @@
 import React from 'react'
 import { Box } from '@welcome-ui/box'
-import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
-import { SystemProps } from '@xstyled/system'
+import { CreateWuiProps, forwardRef, WuiProps } from '@welcome-ui/system'
 
 import { Item } from './Item'
 
 export interface GridOptions {
   /** same as gridArea */
-  area?: SystemProps['gridArea']
+  area?: WuiProps['gridArea']
   /** same as gridAutoColumns */
-  autoColumns?: SystemProps['gridAutoColumns']
+  autoColumns?: WuiProps['gridAutoColumns']
   /** same as gridAutoFlow */
-  autoFlow?: SystemProps['gridAutoFlow']
+  autoFlow?: WuiProps['gridAutoFlow']
   /** same as gridAutoRows */
-  autoRows?: SystemProps['gridAutoRows']
+  autoRows?: WuiProps['gridAutoRows']
   /** same as gridColumn */
-  column?: SystemProps['gridColumn']
+  column?: WuiProps['gridColumn']
   /** same as columnGap */
-  columnGap?: SystemProps['columnGap']
+  columnGap?: WuiProps['columnGap']
   /** same as gridGap */
-  gap?: SystemProps['gap']
+  gap?: WuiProps['gap']
   /** same as gridRow */
-  row?: SystemProps['gridRow']
+  row?: WuiProps['gridRow']
   /** same as gridRowGap */
-  rowGap?: SystemProps['rowGap']
+  rowGap?: WuiProps['rowGap']
   /** same as gridTemplateAreas */
-  templateAreas?: SystemProps['gridTemplateAreas']
+  templateAreas?: WuiProps['gridTemplateAreas']
   /** same as gridTemplateColumns */
-  templateColumns?: SystemProps['gridTemplateColumns']
+  templateColumns?: WuiProps['gridTemplateColumns']
   /** same as gridTemplateRows */
-  templateRows?: SystemProps['gridTemplateRows']
+  templateRows?: WuiProps['gridTemplateRows']
 }
 
 export type GridProps = CreateWuiProps<'div', GridOptions>

--- a/packages/Grid/package.json
+++ b/packages/Grid/package.json
@@ -43,7 +43,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Hint/package.json
+++ b/packages/Hint/package.json
@@ -44,7 +44,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Hint/styles.ts
+++ b/packages/Hint/styles.ts
@@ -1,6 +1,5 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
 import { getVariantColor, Variant } from '@welcome-ui/utils'
 
 export const Hint = styled.div<{ variant: Variant }>(

--- a/packages/Hint/styles.ts
+++ b/packages/Hint/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { getVariantColor, Variant } from '@welcome-ui/utils'
 
 export const Hint = styled.div<{ variant: Variant }>(

--- a/packages/Icon/package.json
+++ b/packages/Icon/package.json
@@ -42,7 +42,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Icon/styles.ts
+++ b/packages/Icon/styles.ts
@@ -1,5 +1,6 @@
 import styled, { css } from '@xstyled/styled-components'
-import { system, WuiProps } from '@welcome-ui/system'
+import { system } from '@xstyled/system'
+import { WuiProps } from '@welcome-ui/system'
 import { WuiTheme } from '@welcome-ui/core'
 
 import { IconOptions } from './index'

--- a/packages/Icon/styles.ts
+++ b/packages/Icon/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system } from '@xstyled/system'
+import styled, { css, system } from '@xstyled/styled-components'
 import { WuiProps } from '@welcome-ui/system'
 import { WuiTheme } from '@welcome-ui/core'
 

--- a/packages/IconFont/package.json
+++ b/packages/IconFont/package.json
@@ -41,7 +41,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/IconFont/styles.ts
+++ b/packages/IconFont/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { IconOptions } from '@welcome-ui/icon'
 
 import unicodeMap from './unicode.json'

--- a/packages/IconFont/styles.ts
+++ b/packages/IconFont/styles.ts
@@ -1,6 +1,5 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
 import { IconOptions } from '@welcome-ui/icon'
 
 import unicodeMap from './unicode.json'

--- a/packages/InputText/package.json
+++ b/packages/InputText/package.json
@@ -45,7 +45,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/InputText/styles.ts
+++ b/packages/InputText/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 

--- a/packages/InputText/styles.ts
+++ b/packages/InputText/styles.ts
@@ -1,6 +1,6 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { shouldForwardProp, system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 
 import { InputTextOptions } from './index'

--- a/packages/Label/package.json
+++ b/packages/Label/package.json
@@ -45,7 +45,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Label/styles.ts
+++ b/packages/Label/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { getVariantColor, Variant } from '@welcome-ui/utils'
 

--- a/packages/Label/styles.ts
+++ b/packages/Label/styles.ts
@@ -1,6 +1,6 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { shouldForwardProp, system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import { getVariantColor, Variant } from '@welcome-ui/utils'
 
 export const Label = styled('label').withConfig({ shouldForwardProp })<{ required: boolean }>(

--- a/packages/Link/package.json
+++ b/packages/Link/package.json
@@ -43,7 +43,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Link/styles.ts
+++ b/packages/Link/styles.ts
@@ -1,7 +1,7 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { UniversalLink } from '@welcome-ui/universal-link'
-import { shouldForwardProp, system } from '@welcome-ui/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 
 import { Variant } from './index'
 

--- a/packages/Link/styles.ts
+++ b/packages/Link/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { UniversalLink } from '@welcome-ui/universal-link'
 import { shouldForwardProp } from '@welcome-ui/system'
 

--- a/packages/Loader/package.json
+++ b/packages/Loader/package.json
@@ -44,7 +44,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Loader/styles.ts
+++ b/packages/Loader/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css, keyframes } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, keyframes, system, th } from '@xstyled/styled-components'
 import { Shape } from '@welcome-ui/shape'
 import { shouldForwardProp } from '@welcome-ui/system'
 

--- a/packages/Loader/styles.ts
+++ b/packages/Loader/styles.ts
@@ -1,7 +1,6 @@
 import styled, { css, keyframes } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { Shape } from '@welcome-ui/shape'
-import { system } from '@welcome-ui/system'
 import { shouldForwardProp } from '@welcome-ui/system'
 
 import { Size } from '.'

--- a/packages/MarkdownEditor/package.json
+++ b/packages/MarkdownEditor/package.json
@@ -55,7 +55,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/MarkdownEditor/styles.ts
+++ b/packages/MarkdownEditor/styles.ts
@@ -1,6 +1,6 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { shouldForwardProp, system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 
 import { emojiMartStyles } from './emojiMartStyles'

--- a/packages/MarkdownEditor/styles.ts
+++ b/packages/MarkdownEditor/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 

--- a/packages/Modal/package.json
+++ b/packages/Modal/package.json
@@ -50,7 +50,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Pagination/package.json
+++ b/packages/Pagination/package.json
@@ -46,7 +46,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Pagination/styles.ts
+++ b/packages/Pagination/styles.ts
@@ -1,6 +1,5 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
 import { hideFocusRingsDataAttribute } from '@welcome-ui/utils'
 
 export const Pagination = styled.nav(system)

--- a/packages/Pagination/styles.ts
+++ b/packages/Pagination/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { hideFocusRingsDataAttribute } from '@welcome-ui/utils'
 
 export const Pagination = styled.nav(system)

--- a/packages/PasswordInput/package.json
+++ b/packages/PasswordInput/package.json
@@ -46,7 +46,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Picker/package.json
+++ b/packages/Picker/package.json
@@ -47,7 +47,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Picker/styles.ts
+++ b/packages/Picker/styles.ts
@@ -1,5 +1,4 @@
-import styled from '@xstyled/styled-components'
-import { system } from '@xstyled/system'
+import styled, { system } from '@xstyled/styled-components'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { Radio as ReakitRadio } from 'reakit/Radio'
 

--- a/packages/Picker/styles.ts
+++ b/packages/Picker/styles.ts
@@ -1,5 +1,6 @@
 import styled from '@xstyled/styled-components'
-import { shouldForwardProp, system } from '@welcome-ui/system'
+import { system } from '@xstyled/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import { Radio as ReakitRadio } from 'reakit/Radio'
 
 export const Radio = styled(ReakitRadio).withConfig({ shouldForwardProp })`

--- a/packages/Popover/package.json
+++ b/packages/Popover/package.json
@@ -46,7 +46,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Popover/styles.ts
+++ b/packages/Popover/styles.ts
@@ -1,7 +1,6 @@
 import styled, { css } from '@xstyled/styled-components'
 import { Popover as BasePopover, PopoverArrow } from 'reakit/Popover'
-import { th } from '@xstyled/system'
-import { system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
 
 export const Arrow = styled(PopoverArrow)`
   color: ${th('popovers.default.backgroundColor')};

--- a/packages/Popover/styles.ts
+++ b/packages/Popover/styles.ts
@@ -1,6 +1,5 @@
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { Popover as BasePopover, PopoverArrow } from 'reakit/Popover'
-import { system, th } from '@xstyled/system'
 
 export const Arrow = styled(PopoverArrow)`
   color: ${th('popovers.default.backgroundColor')};

--- a/packages/Radio/package.json
+++ b/packages/Radio/package.json
@@ -47,7 +47,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Radio/styles.ts
+++ b/packages/Radio/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { Box } from '@welcome-ui/box'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'

--- a/packages/Radio/styles.ts
+++ b/packages/Radio/styles.ts
@@ -1,11 +1,11 @@
 import styled, { css } from '@xstyled/styled-components'
+import { system, th } from '@xstyled/system'
 import { Box } from '@welcome-ui/box'
-import { shouldForwardProp, system } from '@welcome-ui/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 import { Hint as HintWUI } from '@welcome-ui/hint'
 import { Label as WUILabel } from '@welcome-ui/label'
 import { Radio as ReakitRadio } from 'reakit/Radio'
-import { th } from '@xstyled/system'
 
 import { RadioProps } from './index'
 

--- a/packages/RadioGroup/styles.ts
+++ b/packages/RadioGroup/styles.ts
@@ -1,5 +1,6 @@
 import styled, { css } from '@xstyled/styled-components'
-import { system, WuiProps } from '@welcome-ui/system'
+import { system } from '@xstyled/system'
+import { WuiProps } from '@welcome-ui/system'
 
 export const Radios = styled.div<{
   flexDirection?: WuiProps['flexDirection']

--- a/packages/RadioGroup/styles.ts
+++ b/packages/RadioGroup/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system } from '@xstyled/system'
+import styled, { css, system } from '@xstyled/styled-components'
 import { WuiProps } from '@welcome-ui/system'
 
 export const Radios = styled.div<{

--- a/packages/RadioTab/styles.ts
+++ b/packages/RadioTab/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { Radio as ReakitRadio } from 'reakit/Radio'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles, DefaultFieldStylesProps, overflowEllipsis } from '@welcome-ui/utils'

--- a/packages/RadioTab/styles.ts
+++ b/packages/RadioTab/styles.ts
@@ -1,7 +1,7 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { Radio as ReakitRadio } from 'reakit/Radio'
-import { componentSystem, shouldForwardProp, system } from '@welcome-ui/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles, DefaultFieldStylesProps, overflowEllipsis } from '@welcome-ui/utils'
 import { WuiProps } from '@welcome-ui/system'
 
@@ -78,7 +78,7 @@ export const Label = styled.label<
     `};
     ${flexDirection === 'column' && columnStyles};
     ${flexDirection === 'row' && rowStyles};
-    ${componentSystem};
+    ${system};
     padding-top: 0;
     padding-bottom: 0;
   `

--- a/packages/Search/package.json
+++ b/packages/Search/package.json
@@ -47,7 +47,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Search/styles.ts
+++ b/packages/Search/styles.ts
@@ -1,15 +1,14 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { StyledIcon } from '@welcome-ui/icon'
-import { componentSystem, shouldForwardProp, wrapperSystem } from '@welcome-ui/system'
-import { centerContent, defaultFieldStyles, overflowEllipsis } from '@welcome-ui/utils'
-import { cardStyles } from '@welcome-ui/utils'
+import { shouldForwardProp } from '@welcome-ui/system'
+import { cardStyles, centerContent, defaultFieldStyles, overflowEllipsis } from '@welcome-ui/utils'
 
 import { SearchOptions } from './index'
 
 export const Wrapper = styled('div').withConfig({ shouldForwardProp })`
   position: relative;
-  ${wrapperSystem};
+  ${system};
 `
 
 export const InputWrapper = styled.div`
@@ -27,7 +26,7 @@ export const Input = styled('input').withConfig({ shouldForwardProp })<
     css`
       padding-left: ${th(`defaultFields.sizes.${size}.height`)};
     `};
-    ${componentSystem};
+    ${system};
 
     br {
       display: none;

--- a/packages/Search/styles.ts
+++ b/packages/Search/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { StyledIcon } from '@welcome-ui/icon'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { cardStyles, centerContent, defaultFieldStyles, overflowEllipsis } from '@welcome-ui/utils'

--- a/packages/Select/package.json
+++ b/packages/Select/package.json
@@ -48,7 +48,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Select/styles.ts
+++ b/packages/Select/styles.ts
@@ -1,8 +1,8 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { StyledIcon } from '@welcome-ui/icon'
 import { StyledTag } from '@welcome-ui/tag'
-import { componentSystem, shouldForwardProp, wrapperSystem } from '@welcome-ui/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import {
   cardStyles,
   centerContent,
@@ -13,12 +13,10 @@ import {
 
 import { SelectOptions } from './index'
 
-export const Wrapper = styled('div').withConfig({ shouldForwardProp })(
-  ({ connected }: { connected: boolean }) => css`
-    position: relative;
-    ${!connected && wrapperSystem};
-  `
-)
+export const Wrapper = styled('div').withConfig({ shouldForwardProp })`
+  position: relative;
+  ${system}
+`
 
 export const InputWrapper = styled.div`
   position: relative;
@@ -35,7 +33,7 @@ export const Input = styled('div').withConfig({ shouldForwardProp })(
       padding-left: ${th(`defaultFields.sizes.${size}.height`)};
     `};
     cursor: default;
-    ${componentSystem}
+    ${system}
     line-height: 1em;
 
     br {

--- a/packages/Select/styles.ts
+++ b/packages/Select/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { StyledIcon } from '@welcome-ui/icon'
 import { StyledTag } from '@welcome-ui/tag'
 import { shouldForwardProp } from '@welcome-ui/system'

--- a/packages/Stack/package.json
+++ b/packages/Stack/package.json
@@ -43,7 +43,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Swiper/package.json
+++ b/packages/Swiper/package.json
@@ -42,7 +42,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Swiper/styles.ts
+++ b/packages/Swiper/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 
 import { UseSwiperState } from '.'
 

--- a/packages/System/index.tsx
+++ b/packages/System/index.tsx
@@ -1,8 +1,21 @@
 import React from 'react'
-import { system, SystemProps } from '@xstyled/system'
+import { SystemProps, system as xstyledSystem } from '@xstyled/system'
 import { StyledConfig } from 'styled-components'
 
-export const filterSystemProps = (prop: string): boolean => !system.meta.props.includes(prop)
+// todo clean on v5
+export const system = () => {
+  console.warn(
+    'You must use "system" from @xstyled/system instead of @welcome-ui/system, it will be deprecated in welcome-ui v5'
+  )
+  return xstyledSystem
+}
+
+// todo clean on v5
+export const wrapperSystem = system
+// todo clean on v5
+export const componentSystem = system
+
+export const filterSystemProps = (prop: string): boolean => !xstyledSystem.meta.props.includes(prop)
 export const shouldForwardProp: StyledConfig['shouldForwardProp'] = (prop, defaultValidatorFn) =>
   defaultValidatorFn(prop)
 

--- a/packages/System/index.tsx
+++ b/packages/System/index.tsx
@@ -1,23 +1,115 @@
 import React from 'react'
-import { SystemProps, system as xstyledSystem } from '@xstyled/system'
+import { compose, Props, SystemProps } from '@xstyled/system'
+import { getPx, getTransition, getZIndex, style } from '@xstyled/styled-components'
+import * as S from '@xstyled/system'
 import { StyledConfig } from 'styled-components'
 
-// todo clean on v5
-export const system = () => {
-  console.warn(
-    'You must use "system" from @xstyled/system instead of @welcome-ui/system, it will be deprecated in welcome-ui v5'
-  )
-  return xstyledSystem
-}
+// Those are styles that were in v1 but not in v2
+const oldProps = compose(
+  style({ prop: 'opacity' }),
+  style({ prop: 'overflow' }),
+  style({ prop: 'transition', themeGet: getTransition }),
+  style({ prop: 'position' }),
+  style({ prop: 'zIndex', themeGet: getZIndex }),
+  style({ prop: 'top', themeGet: getPx }),
+  style({ prop: 'right', themeGet: getPx }),
+  style({ prop: 'bottom', themeGet: getPx }),
+  style({ prop: 'left', themeGet: getPx })
+)
 
-// todo clean on v5
-export const wrapperSystem = system
-// todo clean on v5
-export const componentSystem = system
+const SYSTEM_PROPS = Object.freeze([
+  S.backgrounds,
+  S.borders,
+  S.boxShadow,
+  S.color,
+  S.display,
+  S.flexboxes,
+  S.grids,
+  S.height,
+  S.maxHeight,
+  S.maxWidth,
+  S.minHeight,
+  S.minWidth,
+  S.space,
+  S.typography,
+  S.verticalAlign,
+  S.width,
+  oldProps,
+])
 
-export const filterSystemProps = (prop: string): boolean => !xstyledSystem.meta.props.includes(prop)
+const WRAPPER_PROPS = Object.freeze([
+  S.margin,
+  S.marginBottom,
+  S.marginLeft,
+  S.marginRight,
+  S.marginTop,
+  S.mx,
+  S.my,
+  S.width,
+  oldProps,
+])
+
+/**
+ * @deprecated use system from @xstyled/system instead
+ */
+export const system = compose<WuiSystemProps>(...SYSTEM_PROPS)
+/**
+ * @deprecated use system from @xstyled/system instead
+ */
+export const wrapperSystem = compose<WuiWrapperSystemProps>(...WRAPPER_PROPS)
+const componentProps = system.meta.props
+  .filter(prop => !wrapperSystem.meta.props.includes(prop))
+  .map(prop => {
+    if (prop === 'w') return S['width']
+    if (prop === 'h') return S['height']
+    return (S as Props)[prop]
+  })
+  .filter(Boolean)
+/**
+ * @deprecated use system from @xstyled/system instead
+ */
+export const componentSystem = compose(...componentProps)
+
+export const filterSystemProps = (prop: string): boolean => !system.meta.props.includes(prop)
 export const shouldForwardProp: StyledConfig['shouldForwardProp'] = (prop, defaultValidatorFn) =>
   defaultValidatorFn(prop)
+
+export type WuiOldProps = S.OpacityProps &
+  S.OverflowProps &
+  S.TransitionProps &
+  S.ZIndexProps &
+  S.TopProps &
+  S.RightProps &
+  S.BottomProps &
+  S.LeftProps
+
+export type WuiSystemProps = S.BackgroundsProps &
+  S.BorderProps &
+  S.BoxShadowProps &
+  S.ColorProps &
+  S.DisplayProps &
+  S.FlexboxesProps &
+  S.GridsProps &
+  S.HeightProps &
+  S.MaxHeightProps &
+  S.MaxWidthProps &
+  S.MinHeightProps &
+  S.MinWidthProps &
+  S.SpaceProps &
+  S.TypographyProps &
+  S.VerticalAlignProps &
+  S.WidthProps &
+  WuiOldProps
+
+export type WuiWrapperSystemProps = S.MarginProps &
+  S.MarginBottomProps &
+  S.MarginLeftProps &
+  S.MarginRightProps &
+  S.MarginTopProps &
+  S.MarginXProps &
+  S.MarginYProps &
+  S.WidthProps &
+  WuiOldProps
 
 export interface WuiTestProps {
   dataTestId?: string

--- a/packages/System/index.tsx
+++ b/packages/System/index.tsx
@@ -1,106 +1,10 @@
 import React from 'react'
-import { compose, Props, SystemProps } from '@xstyled/system'
-import { getPx, getTransition, getZIndex, style } from '@xstyled/styled-components'
-import * as S from '@xstyled/system'
+import { system, SystemProps } from '@xstyled/system'
 import { StyledConfig } from 'styled-components'
-
-// Those are styles that were in v1 but not in v2
-const oldProps = compose(
-  style({ prop: 'opacity' }),
-  style({ prop: 'overflow' }),
-  style({ prop: 'transition', themeGet: getTransition }),
-  style({ prop: 'position' }),
-  style({ prop: 'zIndex', themeGet: getZIndex }),
-  style({ prop: 'top', themeGet: getPx }),
-  style({ prop: 'right', themeGet: getPx }),
-  style({ prop: 'bottom', themeGet: getPx }),
-  style({ prop: 'left', themeGet: getPx })
-)
-
-const SYSTEM_PROPS = Object.freeze([
-  S.backgrounds,
-  S.borders,
-  S.boxShadow,
-  S.color,
-  S.display,
-  S.flexboxes,
-  S.grids,
-  S.height,
-  S.maxHeight,
-  S.maxWidth,
-  S.minHeight,
-  S.minWidth,
-  S.space,
-  S.typography,
-  S.verticalAlign,
-  S.width,
-  oldProps,
-])
-
-const WRAPPER_PROPS = Object.freeze([
-  S.margin,
-  S.marginBottom,
-  S.marginLeft,
-  S.marginRight,
-  S.marginTop,
-  S.mx,
-  S.my,
-  S.width,
-  oldProps,
-])
-
-export const system = compose<WuiSystemProps>(...SYSTEM_PROPS)
-export const wrapperSystem = compose<WuiWrapperSystemProps>(...WRAPPER_PROPS)
-const componentProps = system.meta.props
-  .filter(prop => !wrapperSystem.meta.props.includes(prop))
-  .map(prop => {
-    if (prop === 'w') return S['width']
-    if (prop === 'h') return S['height']
-    return (S as Props)[prop]
-  })
-  .filter(Boolean)
-export const componentSystem = compose(...componentProps)
 
 export const filterSystemProps = (prop: string): boolean => !system.meta.props.includes(prop)
 export const shouldForwardProp: StyledConfig['shouldForwardProp'] = (prop, defaultValidatorFn) =>
   defaultValidatorFn(prop)
-
-export type WuiOldProps = S.OpacityProps &
-  S.OverflowProps &
-  S.TransitionProps &
-  S.ZIndexProps &
-  S.TopProps &
-  S.RightProps &
-  S.BottomProps &
-  S.LeftProps
-
-export type WuiSystemProps = S.BackgroundsProps &
-  S.BorderProps &
-  S.BoxShadowProps &
-  S.ColorProps &
-  S.DisplayProps &
-  S.FlexboxesProps &
-  S.GridsProps &
-  S.HeightProps &
-  S.MaxHeightProps &
-  S.MaxWidthProps &
-  S.MinHeightProps &
-  S.MinWidthProps &
-  S.SpaceProps &
-  S.TypographyProps &
-  S.VerticalAlignProps &
-  S.WidthProps &
-  WuiOldProps
-
-export type WuiWrapperSystemProps = S.MarginProps &
-  S.MarginBottomProps &
-  S.MarginLeftProps &
-  S.MarginRightProps &
-  S.MarginTopProps &
-  S.MarginXProps &
-  S.MarginYProps &
-  S.WidthProps &
-  WuiOldProps
 
 export interface WuiTestProps {
   dataTestId?: string

--- a/packages/System/index.tsx
+++ b/packages/System/index.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
-import { compose, Props, SystemProps } from '@xstyled/system'
-import { getPx, getTransition, getZIndex, style } from '@xstyled/styled-components'
-import * as S from '@xstyled/system'
+import {
+  compose,
+  getPx,
+  getTransition,
+  getZIndex,
+  Props,
+  style,
+  SystemProps,
+} from '@xstyled/styled-components'
+import * as S from '@xstyled/styled-components'
 import { StyledConfig } from 'styled-components'
 
 // Those are styles that were in v1 but not in v2
@@ -50,11 +57,11 @@ const WRAPPER_PROPS = Object.freeze([
 ])
 
 /**
- * @deprecated use system from @xstyled/system instead
+ * @deprecated use system from @xstyled/syled-components instead
  */
 export const system = compose<WuiSystemProps>(...SYSTEM_PROPS)
 /**
- * @deprecated use system from @xstyled/system instead
+ * @deprecated use system from @xstyled/syled-components instead
  */
 export const wrapperSystem = compose<WuiWrapperSystemProps>(...WRAPPER_PROPS)
 const componentProps = system.meta.props
@@ -66,7 +73,7 @@ const componentProps = system.meta.props
   })
   .filter(Boolean)
 /**
- * @deprecated use system from @xstyled/system instead
+ * @deprecated use system from @xstyled/syled-components instead
  */
 export const componentSystem = compose(...componentProps)
 

--- a/packages/System/package.json
+++ b/packages/System/package.json
@@ -38,7 +38,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Table/package.json
+++ b/packages/Table/package.json
@@ -44,7 +44,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Table/styles.ts
+++ b/packages/Table/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { css, th } from '@xstyled/styled-components'
 import { Box } from '@welcome-ui/box'
 
 import { TableOptions } from './index'

--- a/packages/Tabs/styles.ts
+++ b/packages/Tabs/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { TabStateReturn } from 'reakit/Tab'
 
 import { ActiveBarStateReturn } from './ActiveBar'

--- a/packages/Tabs/styles.ts
+++ b/packages/Tabs/styles.ts
@@ -1,6 +1,5 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
 import { TabStateReturn } from 'reakit/Tab'
 
 import { ActiveBarStateReturn } from './ActiveBar'

--- a/packages/Tag/package.json
+++ b/packages/Tag/package.json
@@ -44,7 +44,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Tag/styles.ts
+++ b/packages/Tag/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { StyledIcon } from '@welcome-ui/icon'
 import { centerContent, getMax, overflowEllipsis } from '@welcome-ui/utils'
 import { WuiProps } from '@welcome-ui/system'

--- a/packages/Text/package.json
+++ b/packages/Text/package.json
@@ -42,7 +42,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Text/styles.ts
+++ b/packages/Text/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 
 import { TextOptions } from './index'
 

--- a/packages/Text/styles.ts
+++ b/packages/Text/styles.ts
@@ -1,6 +1,5 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
 
 import { TextOptions } from './index'
 

--- a/packages/Textarea/package.json
+++ b/packages/Textarea/package.json
@@ -43,7 +43,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Textarea/styles.ts
+++ b/packages/Textarea/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 

--- a/packages/Textarea/styles.ts
+++ b/packages/Textarea/styles.ts
@@ -1,6 +1,6 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
-import { shouldForwardProp, system } from '@welcome-ui/system'
+import { system, th } from '@xstyled/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 
 import { TextareaOptions } from './index'

--- a/packages/Toast/package.json
+++ b/packages/Toast/package.json
@@ -52,7 +52,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Toast/styles.ts
+++ b/packages/Toast/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import styled, { css, th } from '@xstyled/styled-components'
 import { Box } from '@welcome-ui/box'
 import { getVariantColor } from '@welcome-ui/utils'
 import { Alert } from '@welcome-ui/alert'

--- a/packages/Toggle/package.json
+++ b/packages/Toggle/package.json
@@ -44,7 +44,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Toggle/styles.ts
+++ b/packages/Toggle/styles.ts
@@ -1,7 +1,7 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { Checkbox as ReakitCheckbox } from 'reakit/Checkbox'
-import { shouldForwardProp, system } from '@welcome-ui/system'
+import { shouldForwardProp } from '@welcome-ui/system'
 
 import { ToggleOptions } from './index'
 

--- a/packages/Toggle/styles.ts
+++ b/packages/Toggle/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { Checkbox as ReakitCheckbox } from 'reakit/Checkbox'
 import { shouldForwardProp } from '@welcome-ui/system'
 

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -44,7 +44,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Tooltip/styles.ts
+++ b/packages/Tooltip/styles.ts
@@ -1,5 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
-import { system, th } from '@xstyled/system'
+import styled, { css, system, th } from '@xstyled/styled-components'
 import { Tooltip as ReakitTooltip } from 'reakit/Tooltip'
 import { filterSystemProps } from '@welcome-ui/system'
 

--- a/packages/Tooltip/styles.ts
+++ b/packages/Tooltip/styles.ts
@@ -1,7 +1,6 @@
 import styled, { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { system, th } from '@xstyled/system'
 import { Tooltip as ReakitTooltip } from 'reakit/Tooltip'
-import { system } from '@welcome-ui/system'
 import { filterSystemProps } from '@welcome-ui/system'
 
 export const Tooltip = styled(ReakitTooltip).withConfig({ shouldForwardProp: filterSystemProps })(

--- a/packages/Utils/card-styles.ts
+++ b/packages/Utils/card-styles.ts
@@ -1,5 +1,4 @@
-import { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { css, th } from '@xstyled/styled-components'
 
 export const cardStyles = (): ReturnType<typeof css> => css`
   ${th('defaultCards')};

--- a/packages/Utils/field-styles.ts
+++ b/packages/Utils/field-styles.ts
@@ -1,5 +1,4 @@
-import { css } from '@xstyled/styled-components'
-import { th } from '@xstyled/system'
+import { css, th } from '@xstyled/styled-components'
 
 import { getVariantColor, Variant } from './variants'
 

--- a/packages/Utils/package.json
+++ b/packages/Utils/package.json
@@ -38,7 +38,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"

--- a/packages/Utils/variants.ts
+++ b/packages/Utils/variants.ts
@@ -1,4 +1,4 @@
-import { th } from '@xstyled/system'
+import { th } from '@xstyled/styled-components'
 
 export type Variant = 'error' | 'focused' | 'info' | 'success' | 'warning'
 

--- a/packages/VariantIcon/package.json
+++ b/packages/VariantIcon/package.json
@@ -46,7 +46,6 @@
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.6.0",
-    "@xstyled/system": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1",
     "react-dom": "^16.10.2 || ^17.0.1",
     "styled-components": "^5.3.3"


### PR DESCRIPTION
We need to use `system` provided from `@xstyled/system` to maintain consistency

`@welcome-ui/system` no longer exports `system/componentSystem/wrapperSystem`

It's old code that needs to be cleaned up