### PR TITLE
feat: allow to use xstyled states

### DIFF
--- a/packages/Core/theme/core.ts
+++ b/packages/Core/theme/core.ts
@@ -1,5 +1,5 @@
 import merge from 'ramda/src/mergeDeepRight'
-import { rpxTransformers } from '@xstyled/system'
+import { defaultTheme, rpxTransformers } from '@xstyled/system'
 
 import { WuiTheme } from './types'
 import { colors } from './colors'
@@ -163,6 +163,9 @@ export const createTheme = (options: Record<string, unknown> = {}): WuiTheme => 
   theme.filedrops = getFiledrops(theme)
   theme.radios = getRadios(theme)
   theme.radioTabs = getRadioTabs(theme)
+
+  // states
+  theme.states = defaultTheme.states
 
   theme = merge(theme, rest) as WuiTheme
 


### PR DESCRIPTION
```jsx
<Box bg={{ _: 'primary.500', hover: 'dark.500' }}>Hover me</Box>
```

This will work now

cf https://xstyled.dev/docs/hover-focus-other-states