### PR TITLE
fix: add styled system to UniversalLink

### DIFF
--- a/packages/UniversalLink/styles.ts
+++ b/packages/UniversalLink/styles.ts
@@ -1,7 +1,7 @@
 import styled from '@xstyled/styled-components'
 import { shouldForwardProp } from '@welcome-ui/system'
 
-export const UniversalLink = styled('a').withConfig({ shouldForwardProp })`
+export const UniversalLink = styled.aBox.withConfig({ shouldForwardProp })`
   color: inherit;
   text-decoration: none;
 `


### PR DESCRIPTION
`<Link color={{_: path === pathname ? 'light.900' : 'light.700', hover: 'light.900', focus: 'light.900'}} />`
This will work now
cf https://xstyled.dev/docs/hover-focus-other-states