### PR TITLE
fix: omit html attributes overrided by xstyled

### DIFF
--- a/packages/DateTimePickerCommon/CustomInput.tsx
+++ b/packages/DateTimePickerCommon/CustomInput.tsx
@@ -20,7 +20,8 @@ export interface CustomInputOptions {
   value?: string | null
 }
 
-export type CustomInputProps = CustomInputOptions
+export type CustomInputProps = Omit<React.ComponentProps<'input'>, keyof CustomInputOptions> &
+  CustomInputOptions
 
 export const CustomInput = forwardRef<HTMLInputElement, CustomInputProps>(
   (

--- a/packages/DateTimePickerCommon/CustomInput.tsx
+++ b/packages/DateTimePickerCommon/CustomInput.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { IconWrapper } from '@welcome-ui/field'
 import { ClearButton } from '@welcome-ui/clear-button'
-import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 import { DefaultFieldStylesProps } from '@welcome-ui/utils'
 
 import * as S from './styles'
@@ -21,9 +20,9 @@ export interface CustomInputOptions {
   value?: string | null
 }
 
-export type CustomInputProps = CreateWuiProps<'input', CustomInputOptions>
+export type CustomInputProps = CustomInputOptions
 
-export const CustomInput = forwardRef<'input', CustomInputProps>(
+export const CustomInput = forwardRef<HTMLInputElement, CustomInputProps>(
   (
     { focused, handleBlur, handleFocus, icon, iconPlacement, onReset, size, value, ...rest },
     ref

--- a/packages/DropdownMenu/Item.tsx
+++ b/packages/DropdownMenu/Item.tsx
@@ -1,12 +1,13 @@
-import React from 'react'
-import { MenuItem, MenuItemOptions } from 'reakit/Menu'
-import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
+import React, { forwardRef } from 'react'
+import { MenuItem, MenuItemProps } from 'reakit/Menu'
+import { As } from '@welcome-ui/system'
 
 import * as S from './Item.styled'
 
-export type ItemProps = CreateWuiProps<'button', MenuItemOptions>
+export type ItemOptions = { as?: As }
+export type ItemProps = MenuItemProps & ItemOptions
 
-export const Item = forwardRef<'button', ItemProps>(({ as, children, ...props }, ref) => {
+export const Item = forwardRef<HTMLButtonElement, ItemProps>(({ as, children, ...props }, ref) => {
   return (
     <MenuItem type="button" {...props} ref={ref}>
       {menuItemProps => {

--- a/packages/EmojiPicker/index.tsx
+++ b/packages/EmojiPicker/index.tsx
@@ -122,7 +122,7 @@ const EmojiPickerComponent = forwardRef<'div', EmojiPickerProps>(
           <>
             <S.TabList aria-label={tabListAriaLabel} {...tabState}>
               {tabs.map(tab => (
-                <Tab id={tab.name} key={tab.name} type="button" {...tabState}>
+                <Tab id={tab.name} key={tab.name} {...tabState}>
                   {tab.name}
                 </Tab>
               ))}

--- a/packages/Popover/Trigger.tsx
+++ b/packages/Popover/Trigger.tsx
@@ -1,10 +1,9 @@
 import React, { useLayoutEffect, useRef } from 'react'
-import { PopoverDisclosure } from 'reakit/Popover'
-import { CreateWuiProps } from '@welcome-ui/system'
+import { PopoverDisclosure, PopoverProps } from 'reakit/Popover'
 
 import { UsePopoverStateReturn } from './usePopoverState'
 
-export type TriggerProps = CreateWuiProps<typeof PopoverDisclosure, UsePopoverStateReturn>
+export type TriggerProps = PopoverProps & UsePopoverStateReturn
 
 export const Trigger: React.FC<TriggerProps> = ({ triggerMethod = 'click', ...rest }) => {
   const hoverable = triggerMethod === 'hover'

--- a/packages/System/index.tsx
+++ b/packages/System/index.tsx
@@ -135,7 +135,7 @@ export type MergeProps<ComponentProps, Props, WuiProps> = RightJoinProps<Compone
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type CreateWuiProps<Component extends As, Props = {}> = MergeProps<
-  React.ComponentProps<Component>,
+  Omit<React.ComponentProps<Component>, keyof WuiProps>,
   Props,
   WuiProps & WuiTestProps & { as?: As }
 >

--- a/packages/Tabs/TabList.tsx
+++ b/packages/Tabs/TabList.tsx
@@ -1,12 +1,12 @@
 import React, { cloneElement, forwardRef, useRef, useState } from 'react'
 import {
   TabList as ReakitTabList,
-  TabListOptions as ReakitTabListOptions,
+  TabListProps as ReakitTabListProps,
   TabStateReturn,
 } from 'reakit/Tab'
 import flattenChildren from 'react-flatten-children'
 import { useForkRef } from '@welcome-ui/utils'
-import { CreateWuiProps } from '@welcome-ui/system'
+import { As } from '@welcome-ui/system'
 
 import { ActiveBar } from './ActiveBar'
 import * as S from './styles'
@@ -26,9 +26,8 @@ function useTrackActiveTabs(
   return [tabs, activeTab]
 }
 
-export type TabListOptions = Pick<TabStateReturn, 'orientation' | 'selectedId'> &
-  ReakitTabListOptions
-export type TabListProps = CreateWuiProps<'div', TabListOptions>
+export type TabListOptions = Pick<TabStateReturn, 'selectedId'> & { as?: As }
+export type TabListProps = ReakitTabListProps & TabListOptions
 
 /**
  * @name Tabs.TabList

--- a/packages/Tabs/TabPanel.tsx
+++ b/packages/Tabs/TabPanel.tsx
@@ -1,15 +1,15 @@
 import React, { forwardRef } from 'react'
 import {
-  TabPanelOptions as ReakitTabOptions,
   TabPanel as ReakitTabPanel,
+  TabPanelProps as ReakitTabPanelProps,
   TabStateReturn,
 } from 'reakit/Tab'
-import { CreateWuiProps } from '@welcome-ui/system'
+import { As } from '@welcome-ui/system'
 
 import * as S from './styles'
 
-export type TabPanelOptions = Pick<TabStateReturn, 'orientation'> & ReakitTabOptions
-export type TabPanelProps = CreateWuiProps<typeof ReakitTabPanel, TabPanelOptions>
+export type TabPanelOptions = Pick<TabStateReturn, 'orientation'> & { as?: As }
+export type TabPanelProps = ReakitTabPanelProps & TabPanelOptions
 
 /**
  * @name Tabs.TabPanel

--- a/packages/Tabs/index.tsx
+++ b/packages/Tabs/index.tsx
@@ -1,19 +1,20 @@
-import React from 'react'
-import { Tab as ReakitTab, TabOptions as ReakitTabOptions } from 'reakit/Tab'
-import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
+import React, { forwardRef } from 'react'
+import { Tab as ReakitTab, TabProps as ReakitTabProps } from 'reakit/Tab'
+import { As } from '@welcome-ui/system'
 
 import { TabList } from './TabList'
 import { TabPanel } from './TabPanel'
 import * as S from './styles'
 
-export type TabOptions = ReakitTabOptions
-export type TabProps = CreateWuiProps<'button', TabOptions>
+export type TabOptions = { as?: As }
+export type TabProps = ReakitTabProps & TabOptions
 
 /**
  * @name Tabs
  */
-export const TabComponent = forwardRef<'button', TabProps>((props, ref) => {
+export const TabComponent = forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
   const { as, children, id, ...rest } = props
+
   return (
     <ReakitTab id={id} ref={ref} {...rest}>
       {tabProps => (


### PR DESCRIPTION
[States](https://xstyled.dev/docs/hover-focus-other-states/) works with prop like `backgroundColor` but doesn't work with HTML prop like `color`.

```tsx
// before
type A = BoxProps['color'] // string -> React.ComponentProps<"div"> inject `color` prop as string (dom property)

// now
type B = BoxProps[’color'] // xstyled type
```


Also, all Reakit components have bad types, they must not use forwardRef from @welcome-ui/system because the system is not injected