### PR TITLE
feat: helper for theme configuration

### DIFF
--- a/docs/components/Layouts/Docs/index.js
+++ b/docs/components/Layouts/Docs/index.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import { Box } from '@welcome-ui/box'
 
+import { ThemeHelper } from '../../ThemeHelper'
 import { ComponentsList } from '../../ComponentsList'
 import { Footer } from '../../Footer'
 
@@ -24,6 +25,7 @@ export function DocsLayout({ children }) {
           mx={{ xs: 'md', md: 'xl' }}
           pt="xl"
         />
+        <ThemeHelper />
       </S.Content>
     </Box>
   )

--- a/docs/components/ThemeConfiguration/index.js
+++ b/docs/components/ThemeConfiguration/index.js
@@ -1,0 +1,52 @@
+import { Box } from '@welcome-ui/box'
+import { Text } from '@welcome-ui/text'
+import { Fragment } from 'react'
+import { useThemeConfigurationContext } from '../../context/themeConfiguration'
+
+const FontWeightsContent = category => DisplayCategoryContent(category)
+
+const FontSizesContent = category => DisplayCategoryContent(category, { shouldConvertToPx: true })
+
+const SpacesContent = category => DisplayCategoryContent(category, { shouldConvertToPx: true })
+
+const ScreensContent = category => DisplayCategoryContent(category, { unit: 'px' })
+
+const DisplayCategoryContent = ({ category }, config = { shouldConvertToPx: false, unit: '' }) => {
+  const themeConfiguration = useThemeConfigurationContext()
+
+  return (
+    <>
+      {Object.entries(themeConfiguration[category]).map(([key, value], index) => (
+        <Fragment key={`${key}_${index}`}>
+          <Text variant="body2" color="sub.3" fontWeight="bold" my="xs">
+            {key}
+          </Text>
+          <Box display="flex" gap="md" mt="xs" my="xs">
+            <Text variant="body2" m="0">
+              {value}
+              {config.unit}
+            </Text>
+            {config.shouldConvertToPx && (
+              <Text variant="body2" color="primary.600" fontWeight="bold" m="0">
+                /* {themeConfiguration.toPx(value.replace('rem', ''))} */
+              </Text>
+            )}
+          </Box>
+        </Fragment>
+      ))}
+    </>
+  )
+}
+
+const categoriesComponents = {
+  fontSizes: FontSizesContent,
+  fontWeights: FontWeightsContent,
+  space: SpacesContent,
+  screens: ScreensContent,
+}
+
+export function ThemeConfiguration({ category }) {
+  const Component = categoriesComponents[category]
+
+  return <Component category={category} />
+}

--- a/docs/components/ThemeHelper.js
+++ b/docs/components/ThemeHelper.js
@@ -1,0 +1,81 @@
+import { Box } from '@welcome-ui/box'
+import { Modal, useModalState } from '@welcome-ui/modal'
+import { useThemeContext } from '../context/theme'
+
+import { Tab, useTabState } from '@welcome-ui/tabs'
+import { Text } from '@welcome-ui/text'
+import { useEffect, useState } from 'react'
+
+import { ThemeConfiguration } from './ThemeConfiguration'
+
+const KEY_CODE_HELP = 'KeyI'
+
+export function ThemeHelper() {
+  const modal = useModalState()
+  const currentTheme = useThemeContext()
+  const [hasBeenHydrated, setHasBeenHydrated] = useState(false)
+  const tabState = useTabState({ orientation: 'vertical' })
+
+  const categories = ['space', 'screens', 'fontSizes', 'fontWeights']
+  const [defaultTab] = categories
+  const title = `${currentTheme.at(0).toUpperCase()}${currentTheme.slice(1)} theme configuration`
+
+  // Workaround for hydration warning UI for Reakit dialog (fix in ariakit 2.0)
+  useEffect(() => {
+    setHasBeenHydrated(true)
+
+    const onKeyboardEvent = event => {
+      if (event.metaKey && event.code === KEY_CODE_HELP) modal.show()
+    }
+
+    window.addEventListener('keydown', onKeyboardEvent)
+
+    return () => window.removeEventListener('keydown', onKeyboardEvent)
+  }, [])
+
+  useEffect(() => {
+    tabState.select(defaultTab)
+  }, [currentTheme])
+
+  return (
+    <>
+      {hasBeenHydrated && (
+        <Modal {...modal} ariaLabel="theme configuration">
+          <Modal.Title>{title}</Modal.Title>
+          <Modal.Content>
+            <Box display="flex">
+              <Tab.List w={200} mr="lg" aria-label="Tabs" {...tabState}>
+                {categories.map(category => (
+                  <Tab key={category} {...tabState} id={category}>
+                    {category}
+                  </Tab>
+                ))}
+              </Tab.List>
+
+              {categories.map(category => (
+                <Tab.Panel key={category} {...tabState} tabId={category}>
+                  <Box
+                    display="grid"
+                    gridTemplateColumns="1fr 1fr"
+                    rowGap={8}
+                    columnGap={16}
+                    mb="md"
+                  >
+                    <Text variant="h5" mb="md" mt="0">
+                      Key
+                    </Text>
+                    <Text variant="h5" mb="md" mt="0">
+                      Value
+                    </Text>
+
+                    <ThemeConfiguration category={category} />
+                  </Box>
+                </Tab.Panel>
+              ))}
+            </Box>
+          </Modal.Content>
+        </Modal>
+      )}
+    </>
+  )
+}

--- a/docs/context/themeConfiguration.js
+++ b/docs/context/themeConfiguration.js
@@ -1,0 +1,31 @@
+import { createTheme } from '@welcome-ui/core'
+import { welcomeTheme } from '@welcome-ui/themes.welcome'
+import { darkTheme } from '@welcome-ui/themes.dark'
+import { welcomeDarkTheme } from '@welcome-ui/themes.welcome-dark'
+import { useThemeContext } from './theme'
+
+const themeConfiguration = currentTheme => {
+  const defaultTheme = createTheme()
+
+  return {
+    core: defaultTheme,
+    dark: {
+      ...defaultTheme,
+      darkTheme,
+    },
+    welcome: {
+      ...defaultTheme,
+      welcomeTheme,
+    },
+    welcomeDark: {
+      ...defaultTheme,
+      welcomeDarkTheme,
+    },
+  }[currentTheme]
+}
+
+export function useThemeConfigurationContext() {
+  const theme = useThemeContext()
+
+  return themeConfiguration(theme)
+}

--- a/packages/Core/theme/core.ts
+++ b/packages/Core/theme/core.ts
@@ -81,6 +81,7 @@ export const createTheme = (options: Record<string, unknown> = {}): WuiTheme => 
 
   theme.toEm = px => `${px / DEFAULT_FONT_SIZE}em`
   theme.toRem = px => `${px / DEFAULT_FONT_SIZE}rem`
+  theme.toPx = rem => `${rem * DEFAULT_FONT_SIZE}px`
 
   theme.colors = colors
 

--- a/packages/Core/theme/types.ts
+++ b/packages/Core/theme/types.ts
@@ -84,6 +84,7 @@ export interface WuiTheme extends XStyledTheme, StyledComponentsTheme {
   }
   toEm: (int: number) => string
   toRem: (int?: number) => string
+  toPx: (int?: number) => string
   colors: ThemeColors
   underline: ThemeUnderline
   borderWidths: ThemeBorderWidths


### PR DESCRIPTION
### Problem : 

It's a bit difficult to remember the value and convert rem value to pixel regarding spacing, screens, font sizes, font weight, etc. it's like constant mental gymnastics 🤸‍♀️ 

### Solution purposed : 

Create an helper to display converted values 🚀 and be relaxed now 😎
How to display the helper : `CMD + I`


https://user-images.githubusercontent.com/9429420/187430395-9ba4e2ed-a8c6-4e6b-91c4-5e13c1cc0305.mov

