### PR TITLE
fix: toast issue with useReset prop to WuiProvider

### DIFF
--- a/packages/Core/utils/base.ts
+++ b/packages/Core/utils/base.ts
@@ -54,5 +54,10 @@ export const GlobalStyle = createGlobalStyle<{ useReset?: boolean }>(
     input[type='search']::-webkit-search-results-decoration {
       appearance: none;
     }
+
+    /* Fix to toast notification when useReset prop is add to WUI provider */
+    .Toaster__message-wrapper {
+      min-height: 'auto';
+    }
   `
 )


### PR DESCRIPTION
As explain on this issue https://github.com/WTTJ/welcome-ui/issues/1543, we have a visual issue with `Toast` package when we use `useReset` prop to `WuiProvider` (you can find a demo if you want to reproduce this bug on issue link).

After some research, it seems that it comes from the CSS property `min-height` with `0`value in reset style. This style applies to `Toaster__message-wrapper` classname. And that's why, it doesn't work.

Unfortunately `toasted-notes` package doesn't provide any method to customize this classname or any other parents classname. That's why, I add some style on GlobalStyle to be sure reset style doesn't apply to this classname.

I'm not satisfied about this fix because it very dependant of `toasted-notes` package (if after an update this classname change, it will break again). Also, this style file contains only global style and my custom style seems to not be in correct place.

I've tried to add my custom style to `Toast` package style but it didn't work because I can't access to this classname (parent of our children toast).

I'm open to any ideas to handle it in a better way. 
Maybe we can also discuss in future to replace  `toasted-notes`  package who seems not really maintained by his author 🤷 (replace it with a headless UI package?).