### PR TITLE
refactor: remove xstyled [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Here you'll find all the core components you need to create a delightful webapp.
 1 - Install the **peer dependencies** listed below:
 
 ```bash
-yarn add @xstyled/styled-components react styled-components
+yarn add react styled-components
 ```
 
 2 - Install the the **core** component and any other components you need for your webapp e.g. if you need just a button…

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -5,12 +5,6 @@ module.exports = {
       'styled-components',
       {
         ssr: true,
-        topLevelImportPaths: [
-          '@xstyled/styled-components',
-          '@xstyled/styled-components/no-tags',
-          '@xstyled/styled-components/native',
-          '@xstyled/styled-components/primitives',
-        ],
       },
     ],
   ],

--- a/docs/components/App.js
+++ b/docs/components/App.js
@@ -1,4 +1,3 @@
-
 import React, { useEffect, useState } from 'react'
 import { createTheme, WuiProvider } from '@welcome-ui/core'
 import { MDXProvider } from '@mdx-js/react'
@@ -26,6 +25,8 @@ const getTheme = themeStorage => {
     return coreTheme
   }
 }
+
+console.log(createTheme(welcomeTheme))
 
 export function App({ component: Component, pageProps }) {
   const themeStorage = useThemeContext()

--- a/docs/components/Colors.js
+++ b/docs/components/Colors.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { withTheme } from '@xstyled/styled-components'
+import { withTheme } from 'styled-components'
 import { Card } from '@welcome-ui/card'
 import { Box } from '@welcome-ui/box'
 import { Grid } from '@welcome-ui/grid'

--- a/docs/components/ComponentsList/VersionSelector/index.js
+++ b/docs/components/ComponentsList/VersionSelector/index.js
@@ -23,7 +23,7 @@ export function VersionSelector() {
       options={versions}
       size="sm"
       value="v5"
-      w={150}
+      $w="150px"
     />
   )
 }

--- a/docs/components/ComponentsList/styles.js
+++ b/docs/components/ComponentsList/styles.js
@@ -1,4 +1,4 @@
-import styled, { th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 import { Link } from '@welcome-ui/link'
 
@@ -14,36 +14,40 @@ export const Li = styled.li`
   }
 `
 
-export const MainTitle = styled(Box)`
-  ${th('texts.subtitle-sm')};
-  text-transform: uppercase;
-  color: dark-300;
-  margin-top: xxl;
-  margin-bottom: lg;
-`
+export const MainTitle = styled(Box)(
+  ({ theme }) => css`
+    ${theme.texts['subtitle-sm']};
+    text-transform: uppercase;
+    color: ${theme.colors['dark-300']};
+    margin-top: ${theme.space.xxl};
+    margin-bottom: ${theme.space.lg};
+  `
+)
 
-export const Item = styled(Link)`
-  padding-bottom: xs;
-  margin-bottom: xs;
+export const Item = styled(Link)(
+  ({ theme }) => css`
+    padding-bottom: ${theme.space.xs};
+    margin-bottom: ${theme.space.xs};
 
-  > .wui-text {
-    font-weight: regular;
-    background-size: 0% 50% !important;
-  }
-
-  &:hover {
     > .wui-text {
-      color: dark-900;
-      background-size: 100% 50% !important;
+      font-weight: ${theme.fontWeights.regular};
+      background-size: 0% 50% !important;
     }
-  }
 
-  &[aria-current='page'] {
-    > .wui-text {
-      color: dark-900;
-      font-weight: bold;
-      background-size: 100% 50% !important;
-      background-position-y: 100%;
+    &:hover {
+      > .wui-text {
+        color: ${theme.colors['dark-900']};
+        background-size: 100% 50% !important;
+      }
     }
-  }
-`
+
+    &[aria-current='page'] {
+      > .wui-text {
+        color: ${theme.colors['dark-900']};
+        font-weight: ${theme.fontWeights.bold};
+        background-size: 100% 50% !important;
+        background-position-y: 100%;
+      }
+    }
+  `
+)

--- a/docs/components/Footer.js
+++ b/docs/components/Footer.js
@@ -12,33 +12,39 @@ export function Footer(props) {
   const theme = useThemeContext()
 
   return (
-    <Box alignItems="center" as="footer" display="flex" justifyContent="space-between" {...props}>
-      <Box display={{ xs: 'none', md: 'block' }}>
-        <Logo h={37} isDark w={63} />
+    <Box
+      $alignItems="center"
+      as="footer"
+      $display="flex"
+      $justifyContent="space-between"
+      {...props}
+    >
+      <Box $display={{ xs: 'none', md: 'block' }}>
+        <Logo $h="37px" isDark w="63px" />
       </Box>
-      <Box alignItems="center" display="flex">
-        Made with <HeartIcon color="primary-500" mx="sm" /> by{' '}
+      <Box $alignItems="center" $display="flex">
+        Made with <HeartIcon $color="primary-500" $mx="sm" /> by{' '}
         <Box
-          alignItems="center"
+          $alignItems="center"
           as="a"
-          display="flex"
+          $display="flex"
           href="https://www.welcometothejungle.com"
-          ml="sm"
+          $ml="sm"
           rel="noopener"
           target="_blank"
         >
-          <LogoWttj black={theme !== 'dark'} h={24} w={74} />
+          <LogoWttj black={theme !== 'dark'} $h="24px" w="74px" />
         </Box>
       </Box>
       <Button
         as="a"
-        h={25}
+        $h="25px"
         href="https://github.com/WTTJ/welcome-ui"
         rel="noopener"
         shape="circle"
         target="_blank"
         variant="secondary"
-        w={25}
+        $w="25px"
       >
         <GithubIcon />
       </Button>

--- a/docs/components/GlobalStyle.js
+++ b/docs/components/GlobalStyle.js
@@ -1,5 +1,5 @@
 import { defaultFieldStyles } from '@welcome-ui/utils'
-import { createGlobalStyle, th } from '@xstyled/styled-components'
+import { createGlobalStyle } from 'styled-components'
 
 export const GlobalStyle = createGlobalStyle`
   /* ALGOLIA DOCSEARCH */
@@ -8,18 +8,18 @@ export const GlobalStyle = createGlobalStyle`
     --docsearch-hit-shadow: none;
     --docsearch-key-shadow: none;
     --docsearch-footer-shadow: none;
-    --docsearch-highlight-color: ${th('colors.dark-900')};
-    --docsearch-primary-color: ${th('colors.dark-900')};
-    --docsearch-logo-color: ${th('colors.dark-100')};
+    --docsearch-highlight-color: ${({ theme }) => theme.colors['dark-900']};
+    --docsearch-primary-color: ${({ theme }) => theme.colors['dark-900']};
+    --docsearch-logo-color: ${({ theme }) => theme.colors['dark-100']};
   }
 
   .DocSearch {
     &-Button {
       margin: 0;
       width: 100%;
-      height: 30;
+      height: 30px;
       border-radius: 0;
-      padding: 0 sm;
+      padding: 0 ${({ theme }) => theme.space.sm};
       ${defaultFieldStyles({})};
       cursor: text;
       font-family: 'Work Sans';
@@ -29,20 +29,20 @@ export const GlobalStyle = createGlobalStyle`
       }
 
       &-Placeholder {
-        ${th('defaultFields.placeholder')};
+        ${({ theme }) => theme.defaultFields.placeholder};
         display: block;
       }
 
       &-Keys {
-        margin-top: xxs;
+        margin-top: ${({ theme }) => theme.space.xxs};
         display: flex;
       }
 
       &-Key {
         border-radius: none;
-        ${th('tags.default')};
-        ${th('tags.variants.default')};
-        background: ${th('tags.variants.default.backgroundColor')};
+        ${({ theme }) => theme.tags.default};
+        ${({ theme }) => theme.tags.variants.default};
+        background: ${({ theme }) => theme.tags.variants.default.backgroundColor};
       }
     }
   }

--- a/docs/components/Header/NavBar/styles.js
+++ b/docs/components/Header/NavBar/styles.js
@@ -1,40 +1,43 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { system } from '@welcome-ui/system'
 
-export const NavBar = styled.ul`
-  display: inline-flex;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  ${system};
+export const NavBar = styled.ul(
+  ({ theme }) => css`
+    display: inline-flex;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    ${system};
 
-  li {
-    margin-left: lg;
+    li {
+      margin-left: ${theme.space.lg};
 
-    &:first-child {
-      margin-left: 0;
+      &:first-child {
+        margin-left: 0;
+      }
     }
-  }
-`
+  `
+)
 
 const activeItem = css`
   opacity: 1;
-  color: dark-900;
+  color: ${({ theme }) => theme.colors['dark-900']};
 
-  @media (min-width: md) {
+  @media (min-width: ${({ theme }) => theme.breakpoints.md}px) {
     opacity: 1;
     color: white;
   }
 `
 
 export const Item = styled.a(
-  ({ isActive }) => css`
-    ${th('texts.subtitle-md')};
+  ({ isActive, theme }) => css`
+    ${theme.texts['subtitle-md']};
     text-transform: uppercase;
-    color: dark-500;
-    transition: medium;
+    color: ${theme.colors['dark-500']};
+    transition: ${theme.transitions.medium};
     text-decoration: none;
 
-    @media (min-width: md) {
+    @media (min-width: ${theme.breakpoints.md}px) {
       color: white;
       opacity: 0.7;
     }

--- a/docs/components/Header/ThemeSelector.js
+++ b/docs/components/Header/ThemeSelector.js
@@ -26,7 +26,7 @@ export function ThemeSelector(props) {
 
   return (
     <>
-      <DropdownMenu.Trigger as={Button} h={30} shape="circle" w={30} {...menu} {...props}>
+      <DropdownMenu.Trigger as={Button} $h="30px" shape="circle" $w="30px" {...menu} {...props}>
         <SunIcon />
       </DropdownMenu.Trigger>
       <DropdownMenu {...menu} aria-label="Theme selector">

--- a/docs/components/Header/ThemeSelector.js
+++ b/docs/components/Header/ThemeSelector.js
@@ -32,16 +32,18 @@ export function ThemeSelector(props) {
       <DropdownMenu {...menu} aria-label="Theme selector">
         {options?.map(({ icon: Icon, label, value, isBeta }) => (
           <DropdownMenu.Item
-            color={theme === value ? 'dark-900' : undefined}
-            fontWeight={theme === value ? 'bold' : undefined}
+            $color={theme === value ? 'dark-900' : undefined}
+            $fontWeight={theme === value ? 'bold' : undefined}
             key={value}
             onClick={() => handleSetTheme(value)}
             {...menu}
           >
-            <Icon mr="md" size="sm" />
+            <Icon $mr="md" size="sm" />
             <Box>{label}</Box>
             {isBeta && (
-              <Badge size="sm" ml="xs">beta</Badge>
+              <Badge size="sm" $ml="xs">
+                beta
+              </Badge>
             )}
           </DropdownMenu.Item>
         ))}

--- a/docs/components/Header/index.js
+++ b/docs/components/Header/index.js
@@ -67,13 +67,13 @@ export function Header() {
           <InformationIcon $color="light-900" />
         </Button>
       </Box>
-      <NavBar $display={{ xs: 'none', md: 'flex' }} />
+      <NavBar $display={{ sm: 'none', md: 'flex' }} />
       {hasBeenHydrated && (
         <>
           <Drawer.Trigger
             {...mobileMenuDrawer}
             as={Button}
-            $display={{ md: 'none' }}
+            $display={{ _: 'inherit', md: 'none' }}
             shape="circle"
             size="sm"
           >

--- a/docs/components/Header/index.js
+++ b/docs/components/Header/index.js
@@ -40,13 +40,13 @@ export function Header() {
 
   return (
     <S.Header variant={variant}>
-      <Box alignItems="center" display="flex">
+      <Box $alignItems="center" $display="flex">
         <NextLink href="/" passHref>
-          <Box alignItems="center" alt="Homepage" as="a" display="flex">
-            <Logo h={37} isDark={variant === 'gray'} w={63} />
+          <Box $alignItems="center" alt="Homepage" as="a" $display="flex">
+            <Logo $h="37px" isDark={variant === 'gray'} $w="63px" />
           </Box>
         </NextLink>
-        <Box ml="lg" w={{ xs: 180, md: 220 }}>
+        <Box $ml="lg" $w={{ xs: '180px', md: '220px' }}>
           <DocSearch
             apiKey="32543c62b03cbc6b714a873dca1feec4"
             appId="1ZI5OZ0946"
@@ -55,18 +55,25 @@ export function Header() {
             placeholder="Search the docs"
           />
         </Box>
-        <ThemeSelector ml="lg" />
-        <Button onClick={openThemeHelper} h={30} shape="circle" ml="xxs" variant="ghost" w={30}>
-          <InformationIcon color="light-900" />
+        <ThemeSelector $ml="lg" />
+        <Button
+          onClick={openThemeHelper}
+          $h="30px"
+          shape="circle"
+          $ml="xxs"
+          variant="ghost"
+          $w="30px"
+        >
+          <InformationIcon $color="light-900" />
         </Button>
       </Box>
-      <NavBar display={{ xs: 'none', md: 'flex' }} />
+      <NavBar $display={{ xs: 'none', md: 'flex' }} />
       {hasBeenHydrated && (
         <>
           <Drawer.Trigger
             {...mobileMenuDrawer}
             as={Button}
-            display={{ md: 'none' }}
+            $display={{ md: 'none' }}
             shape="circle"
             size="sm"
           >
@@ -74,7 +81,7 @@ export function Header() {
           </Drawer.Trigger>
           <Drawer.Backdrop {...mobileMenuDrawer} backdropVisible={false}>
             <S.MenuMobileDrawer aria-label="Menu backdrop" {...mobileMenuDrawer}>
-              <NavBar isMobileMenu mb="lg" />
+              <NavBar isMobileMenu $mb="lg" />
               <ComponentsList onClick={() => mobileMenuDrawer.hide()} />
             </S.MenuMobileDrawer>
           </Drawer.Backdrop>

--- a/docs/components/Header/styles.js
+++ b/docs/components/Header/styles.js
@@ -1,4 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Drawer as WUIDrawer } from '@welcome-ui/drawer'
 
 import { Item } from './NavBar/styles'
@@ -6,7 +6,7 @@ import { Item } from './NavBar/styles'
 export const headerHeight = '3.75rem' // 60
 
 export const Header = styled.header(
-  ({ variant = 'black' }) => css`
+  ({ variant = 'black', theme }) => css`
     position: sticky;
     display: flex;
     align-items: center;
@@ -14,27 +14,27 @@ export const Header = styled.header(
     width: 100%;
     height: ${headerHeight};
     background-color: black;
-    font-size: md;
-    padding: 0 md;
+    font-size: ${theme.fontSizes.md};
+    padding: 0 ${theme.space.md};
     top: 0;
     width: 100%;
     z-index: 2;
 
-    @media (min-width: md) {
-      padding: 0 lg;
+    @media (min-width: ${theme.breakpoints.md}px) {
+      padding: 0 ${theme.space.lg};
     }
 
     ${variant === 'gray' &&
     css`
-      background-color: nude-200;
+      background-color: ${theme.colors['nude-200']};
 
       ${Item} {
         opacity: 1;
-        color: dark-900;
+        color: ${theme.colors['dark-900']};
 
         &.active,
         &:hover {
-          @media (min-width: md) {
+          @media (min-width: ${theme.breakpoints.md}px) {
             opacity: 0.7;
           }
         }
@@ -43,12 +43,14 @@ export const Header = styled.header(
   `
 )
 
-export const MenuMobileDrawer = styled(WUIDrawer)`
-  top: ${`calc(${headerHeight} - 1px)`} !important;
-  width: 100% !important;
-  padding: lg;
+export const MenuMobileDrawer = styled(WUIDrawer)(
+  ({ theme }) => css`
+    top: ${`calc(${headerHeight} - 1px)`} !important;
+    width: 100% !important;
+    padding: ${theme.space.lg};
 
-  @media (min-width: md) {
-    display: none;
-  }
-`
+    @media (min-width: ${theme.breakpoints.md}px) {
+      display: none;
+    }
+  `
+)

--- a/docs/components/Homepage/Components.js
+++ b/docs/components/Homepage/Components.js
@@ -1,4 +1,3 @@
-
 import React from 'react'
 import { Alert } from '@welcome-ui/alert'
 import { Avatar } from '@welcome-ui/avatar'
@@ -113,9 +112,9 @@ function Component({ children, description, link, title }) {
 export function Components() {
   return (
     <Box
-      display="grid"
-      gap="xxl"
-      gridTemplateColumns={{ xs: '1fr', md: '1fr 1fr', lg: '1fr 1fr 1fr' }}
+      $display="grid"
+      $gap="xxl"
+      $gridTemplateColumns={{ xs: '1fr', md: '1fr 1fr', lg: '1fr 1fr 1fr' }}
     >
       {components.map(component => (
         <Component key={component.title} {...component} />

--- a/docs/components/Homepage/Expectations.js
+++ b/docs/components/Homepage/Expectations.js
@@ -68,7 +68,7 @@ function Expectation({ description, icon: Icon, title }) {
   return (
     <Card $w="100%">
       <Card.Body>
-        <Icon $color="dark-900" size={30} />
+        <Icon $color="dark-900" size="30px" />
         <Text $mb="md" $mt="lg" $textTransform="uppercase" variant="h6">
           {title}
         </Text>

--- a/docs/components/Homepage/Expectations.js
+++ b/docs/components/Homepage/Expectations.js
@@ -66,13 +66,13 @@ const expectations = [
 
 function Expectation({ description, icon: Icon, title }) {
   return (
-    <Card w="100%">
+    <Card $w="100%">
       <Card.Body>
-        <Icon color="dark-900" size={30} />
-        <Text mb="md" mt="lg" textTransform="uppercase" variant="h6">
+        <Icon $color="dark-900" size={30} />
+        <Text $mb="md" $mt="lg" $textTransform="uppercase" variant="h6">
           {title}
         </Text>
-        <Text m="0" variant="sm">
+        <Text $m="0" variant="sm">
           {description}
         </Text>
       </Card.Body>
@@ -83,9 +83,9 @@ function Expectation({ description, icon: Icon, title }) {
 export function Expectations() {
   return (
     <Box
-      display="grid"
-      gap="lg"
-      gridTemplateColumns={{ xs: '1fr', md: '1fr 1fr 1fr', lg: '1fr 1fr 1fr 1fr' }}
+      $display="grid"
+      $gap="lg"
+      $gridTemplateColumns={{ xs: '1fr', md: '1fr 1fr 1fr', lg: '1fr 1fr 1fr 1fr' }}
     >
       {expectations.map(expectation => (
         <Expectation key={expectation.title} {...expectation} />

--- a/docs/components/Homepage/Section.js
+++ b/docs/components/Homepage/Section.js
@@ -1,11 +1,10 @@
-
 import React from 'react'
 import { Box } from '@welcome-ui/box'
 
 export function Section({ children, ...rest }) {
   return (
-    <Box as="section" py={{ xs: 'xxl', md: 90 }} {...rest}>
-      <Box margin="0 auto" maxWidth={1200} position="relative" px="lg">
+    <Box as="section" $py={{ xs: 'xxl', md: '90px' }} {...rest}>
+      <Box $m="0 auto" $maxW={1200} $position="relative" $px="lg">
         {children}
       </Box>
     </Box>

--- a/docs/components/Homepage/Stats.js
+++ b/docs/components/Homepage/Stats.js
@@ -13,7 +13,7 @@ const stats = [
       </>
     ),
     number: '50+',
-    icon: <CodeBlockIcon h={24} w={24} />,
+    icon: <CodeBlockIcon $h="24px" $w="24px" />,
   },
   {
     name: (
@@ -42,39 +42,39 @@ const stats = [
 export function Stats() {
   return (
     <Box
-      backgroundColor="light-900"
-      borderRadius={64}
-      display="flex"
-      justifyContent="space-between"
-      maxWidth={470}
-      px={{ xs: 'xxl', md: '4xl' }}
-      py="xxl"
-      w="100%"
+      $backgroundColor="light-900"
+      $borderRadius="64px"
+      $display="flex"
+      $justifyContent="space-between"
+      $maxW="470px"
+      $px={{ xs: 'xxl', md: '4xl' }}
+      $py="xxl"
+      $w="100%"
     >
       {stats?.map(stat => (
         <Box
-          alignItems="center"
-          display="flex"
-          flexDirection="column"
+          $alignItems="center"
+          $display="flex"
+          $flexDirection="column"
           key={stat.number}
-          textAlign="center"
+          $textAlign="center"
         >
           <Box
-            alignItems="center"
-            backgroundColor="dark-900"
-            borderRadius={55}
-            color="light-900"
-            display="flex"
-            h={55}
-            justifyContent="center"
-            w={55}
+            $alignItems="center"
+            $backgroundColor="dark-900"
+            $borderRadius="55px"
+            $color="light-900"
+            $display="flex"
+            $h="55px"
+            $justifyContent="center"
+            $w="55px"
           >
             {stat.icon}
           </Box>
-          <Text as="span" mt="lg" variant="h3">
+          <Text as="span" $mt="lg" variant="h3">
             {stat.number}
           </Text>
-          <Text as="span" mt="sm" variant="sm">
+          <Text as="span" $mt="sm" variant="sm">
             {stat.name}
           </Text>
         </Box>

--- a/docs/components/IconsList/Item.styles.js
+++ b/docs/components/IconsList/Item.styles.js
@@ -1,31 +1,33 @@
 import { Box } from '@welcome-ui/box'
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 
-export const Content = styled(Box)`
-  background-color: light-900;
-  border-color: border;
-  border-width: sm;
-  border-style: solid;
-  border-radius: lg;
-  padding: lg sm;
-  width: 100%;
-  text-align: center;
-  transition: medium;
-`
+export const Content = styled(Box)(
+  ({ theme }) => css`
+    background-color: ${theme.colors['light-900']};
+    border-color: border;
+    border-width: ${theme.space.sm};
+    border-style: solid;
+    border-radius: ${theme.space.lg};
+    padding: ${theme.space.lg} ${theme.space.sm};
+    width: 100%;
+    text-align: center;
+    transition: ${theme.transitions.medium};
+  `
+)
 
 export const Item = styled(Box)(
-  ({ copied }) => css`
+  ({ copied, theme }) => css`
     align-items: center;
     display: flex;
     flex-direction: column;
     cursor: pointer;
-    color: dark-900;
+    color: ${theme.colors['dark-900']};
 
     ${!copied &&
     css`
       &:hover {
         ${Content} {
-          border-color: dark-400;
+          border-color: ${theme.colors['dark-400']};
         }
       }
     `}
@@ -33,8 +35,8 @@ export const Item = styled(Box)(
     ${copied &&
     css`
       ${Content} {
-        background-color: success-100;
-        border-color: success-100;
+        background-color: ${theme.colors['success-100']};
+        border-color: ${theme.colors['success-100']};
       }
     `}
   `

--- a/docs/components/Illustration404.js
+++ b/docs/components/Illustration404.js
@@ -7,7 +7,7 @@ const Illustration404 = memo(function Illustration() {
   const theme = useThemeContext()
   const imageSource = theme === 'dark' ? '/illustration-404-white.png' : '/illustration-404.png'
 
-  return <Box as="img" maxWidth={500} src={imageSource} w="100%" />
+  return <Box as="img" $maxW="500px" src={imageSource} $w="100%" />
 })
 
 export default Illustration404

--- a/docs/components/Layouts/Docs/index.js
+++ b/docs/components/Layouts/Docs/index.js
@@ -10,19 +10,19 @@ import * as S from './styles'
 
 export function DocsLayout({ children }) {
   return (
-    <Box display="flex">
+    <Box $display="flex">
       <S.Navigation>
         <ComponentsList />
       </S.Navigation>
       <S.Content>
         {children}
         <Footer
-          borderTop="1px solid"
-          borderTopColor="nude-200"
-          mb="md"
-          mt="3xl"
-          mx={{ xs: 'md', md: 'xl' }}
-          pt="xl"
+          $borderTop="1px solid"
+          $borderTopColor="nude-200"
+          $mb="md"
+          $mt="3xl"
+          $mx={{ xs: 'md', md: 'xl' }}
+          $pt="xl"
         />
       </S.Content>
     </Box>

--- a/docs/components/Layouts/Docs/styles.js
+++ b/docs/components/Layouts/Docs/styles.js
@@ -1,38 +1,42 @@
-import styled, { th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 
 import { headerHeight } from '../../Header/styles'
 
 const navigationWidth = '16.875rem' // 270
 
-export const Navigation = styled.nav`
-  display: none;
-  position: fixed;
-  width: ${navigationWidth};
-  top: ${headerHeight};
-  left: 0;
-  bottom: 0;
-  background-color: light-900;
-  border-right: 1px solid ${th('colors.border')};
-  padding: lg;
-  overflow: auto;
+export const Navigation = styled.nav(
+  ({ theme }) => css`
+    display: none;
+    position: fixed;
+    width: ${navigationWidth};
+    top: ${headerHeight};
+    left: 0;
+    bottom: 0;
+    background-color: ${theme.colors['light-900']};
+    border-right: 1px solid ${theme.colors.border};
+    padding: ${theme.space.lg};
+    overflow: auto;
 
-  @media (min-width: md) {
-    display: block;
-  }
-`
+    @media (min-width: ${theme.breakpoints.md}px) {
+      display: block;
+    }
+  `
+)
 
-export const Content = styled.main`
-  width: 100%;
-  min-height: ${`calc(100vh - ${headerHeight})`};
+export const Content = styled.main(
+  ({ theme }) => css`
+    width: 100%;
+    min-height: ${`calc(100vh - ${headerHeight})`};
 
-  > :not(footer) {
-    max-width: 970;
-    padding-left: md;
-    padding-right: md;
-    margin: 0 auto;
-  }
+    > :not(footer) {
+      max-width: 970;
+      padding-left: ${theme.space.md};
+      padding-right: ${theme.space.md};
+      margin: 0 auto;
+    }
 
-  @media (min-width: md) {
-    padding-left: ${navigationWidth};
-  }
-`
+    @media (min-width: ${theme.breakpoints.md}px) {
+      padding-left: ${navigationWidth};
+    }
+  `
+)

--- a/docs/components/Layouts/index.js
+++ b/docs/components/Layouts/index.js
@@ -31,7 +31,7 @@ function Layout({ children }) {
 
 export function Layouts({ children }) {
   return (
-    <Box backgroundColor="light-900">
+    <Box $backgroundColor="light-900">
       <Header />
       <Layout>{children}</Layout>
     </Box>

--- a/docs/components/Logo.js
+++ b/docs/components/Logo.js
@@ -1,10 +1,9 @@
-
 import React from 'react'
 import { Box } from '@welcome-ui/box'
 
-export function Logo({ h, isDark, w }) {
+export function Logo({ $h, isDark, $w }) {
   return (
-    <Box as="svg" h={h} viewBox="0 0 101 59" w={w}>
+    <Box as="svg" $h={$h} viewBox="0 0 101 59" $w={$w}>
       <title>WUI logo</title>
       <g fill="none" fillRule="nonzero">
         <path

--- a/docs/components/Mdx/Code/CopyButton.js
+++ b/docs/components/Mdx/Code/CopyButton.js
@@ -5,13 +5,13 @@ import React from 'react'
 export function CopyButton({ copied, copy }) {
   return (
     <Button
-      mr="sm"
-      mt="lg"
+      $mr="sm"
+      $mt="lg"
       onClick={copy}
-      position="absolute"
-      right={0}
+      $position="absolute"
+      $right="0"
       size="xs"
-      top={0}
+      $top="0"
       variant="secondary-info"
     >
       {copied ? 'Copied!' : 'Copy'}

--- a/docs/components/Mdx/Code/index.js
+++ b/docs/components/Mdx/Code/index.js
@@ -196,10 +196,10 @@ export const Code = ({
       <LiveProvider {...liveProviderProps}>
         <Card
           className="codeEditor"
-          display="flex"
-          flexDirection="column"
-          mt="md"
-          overflow="visible"
+          $display="flex"
+          $flexDirection="column"
+          $mt="md"
+          $overflow="visible"
         >
           <Box p="xl">
             <LivePreview />
@@ -207,26 +207,26 @@ export const Code = ({
           {withCode === true && (
             <S.ShowEditor>
               <Button
-                border="none"
-                h={25}
+                $border="none"
+                $h="25px"
                 onClick={toggleEditor}
                 shape="circle"
                 variant="tertiary"
-                w={25}
+                $w="25px"
               >
                 <Icons.ChevronIcon />
               </Button>
               {isCopyable && (
                 <Button
                   border="none"
-                  h={25}
-                  ml="sm"
+                  $h="25px"
+                  $ml="sm"
                   onClick={copy}
                   shape="circle"
                   variant="tertiary"
-                  w={25}
+                  $w="25px"
                 >
-                  {copied ? <Icons.CheckIcon color="success-500" /> : <Icons.CopyIcon />}
+                  {copied ? <Icons.CheckIcon $color="success-500" /> : <Icons.CopyIcon />}
                 </Button>
               )}
             </S.ShowEditor>
@@ -249,7 +249,7 @@ export const Code = ({
 
   return (
     <Box>
-      <Box mt="lg" overflow="auto">
+      <Box $mt="lg" $overflow="auto">
         <LiveProvider disabled {...liveProviderProps}>
           <S.LiveEditor>
             <S.LiveEditorContent isCopyable={isCopyable} style={liveEditorStyle} />

--- a/docs/components/Mdx/Code/styles.js
+++ b/docs/components/Mdx/Code/styles.js
@@ -1,15 +1,17 @@
-import styled, { css, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { LiveEditor as ReactLiveEditor, LiveError as ReactLiveError } from 'react-live'
 import { Box } from '@welcome-ui/box'
 
-export const LiveEditor = styled(Box)`
-  position: relative;
-  background-color: black;
-  border: 1px solid ${th('colors.dark-200')};
-  border-radius: md;
-  overflow: hidden;
-  padding: md;
-`
+export const LiveEditor = styled(Box)(
+  ({ theme }) => css`
+    position: relative;
+    background-color: black;
+    border: 1px solid ${theme.colors['dark-200']};
+    border-radius: ${theme.space.md};
+    overflow: hidden;
+    padding: ${theme.space.md};
+  `
+)
 
 export const LiveEditorContent = styled(ReactLiveEditor)(
   ({ isCopyable }) => css`
@@ -30,43 +32,49 @@ export const LiveEditorContent = styled(ReactLiveEditor)(
   `
 )
 
-export const LiveError = styled(ReactLiveError)`
-  background-color: danger-100;
-  border-color: danger-500;
-  border-width: sm;
-  border-style: solid;
-  color: danger-500;
-  padding: md;
-  white-space: pre-wrap;
-  border-radius: md;
-  font-size: sm;
-  line-height: h4;
-  margin: sm 0 lg;
-`
+export const LiveError = styled(ReactLiveError)(
+  ({ theme }) => css`
+    background-color: ${theme.colors['danger-100']};
+    border-color: ${theme.colors['danger-500']};
+    border-width: ${theme.borderWidths.sm};
+    border-style: solid;
+    color: ${theme.colors['danger-500']};
+    padding: ${theme.space.md};
+    white-space: pre-wrap;
+    border-radius: ${theme.space.md};
+    font-size: ${theme.fontSizes.sm};
+    line-height: ${theme.lineHeights.h4};
+    margin: ${theme.space.sm} 0 ${theme.space.lg};
+  `
+)
 
-export const ShowEditor = styled.div`
-  background-color: nude-200;
-  padding: sm lg;
-  border-top: 1px solid ${th.color('border')};
-`
+export const ShowEditor = styled.div(
+  ({ theme }) => css`
+    background-color: ${theme.colors['nude-200']};
+    padding: ${theme.space.sm} ${theme.space.lg};
+    border-top: 1px solid ${theme.colors.border};
+  `
+)
 
 export const CodeContent = styled.div`
   > * {
     &:not(:last-child) {
-      margin-bottom: md;
+      margin-bottom: ${({ theme }) => theme.space.md};
     }
   }
 `
 
-export const CodeContentRow = styled.div`
-  display: flex;
-  align-items: center;
-  margin-bottom: -md;
-  margin-right: -md;
-  flex-wrap: wrap;
+export const CodeContentRow = styled.div(
+  ({ theme }) => css`
+    display: flex;
+    align-items: center;
+    margin-bottom: -${theme.space.md};
+    margin-right: -${theme.space.md};
+    flex-wrap: wrap;
 
-  > * {
-    margin-bottom: md;
-    margin-right: md;
-  }
-`
+    > * {
+      margin-bottom: ${theme.space.md};
+      margin-right: ${theme.space.md};
+    }
+  `
+)

--- a/docs/components/Mdx/Dependencies/Item.js
+++ b/docs/components/Mdx/Dependencies/Item.js
@@ -17,16 +17,16 @@ export function Item({ dependency, version }) {
     <Box
       as="a"
       href={`https://npmjs.com/package/${dependency}/v/${baseVersion}`}
-      mb="md"
-      mr="md"
+      $mb="md"
+      $mr="md"
       rel="nofollow"
       target="_npm"
-      textDecoration="none"
+      $textDecoration="none"
     >
-      <Tag backgroundColor="light-900" key={dependency}>
+      <Tag $backgroundColor="light-900" key={dependency}>
         {`${dependency} [${version}]`}
         {!copied && <CopyIcon onClick={handleCopy} size="sm" />}
-        {copied && <CheckIcon color="success-500" size="sm" />}
+        {copied && <CheckIcon $color="success-500" size="sm" />}
       </Tag>
     </Box>
   )

--- a/docs/components/Mdx/Dependencies/index.js
+++ b/docs/components/Mdx/Dependencies/index.js
@@ -1,4 +1,3 @@
-
 import React from 'react'
 import { Box } from '@welcome-ui/box'
 import { Card } from '@welcome-ui/card'
@@ -12,9 +11,9 @@ export function Dependencies({ dependencies }) {
 
   return (
     <Box>
-      <Card mt="sm">
+      <Card $mt="sm">
         <Card.Body>
-          <Box display="flex" flexWrap="wrap" mb="-md">
+          <Box $display="flex" $flexWrap="wrap" $mb="-md">
             {Object.entries(dependencies).map(([dependency, version]) => {
               return <Item dependency={dependency} key={dependency} version={version} />
             })}

--- a/docs/components/Mdx/Headings/styles.js
+++ b/docs/components/Mdx/Headings/styles.js
@@ -1,12 +1,15 @@
-import styled, { system } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Text } from '@welcome-ui/text'
+import { system } from '@welcome-ui/system'
 
-export const Link = styled.a`
-  opacity: 0;
-  color: primary-600;
-  text-decoration: none;
-  transition: medium;
-`
+export const Link = styled.a(
+  ({ theme }) => css`
+    opacity: 0;
+    color: ${theme.colors['primary-600']};
+    text-decoration: none;
+    transition: ${theme.transitions.medium};
+  `
+)
 export const Title = styled(Text)`
   ${system};
 

--- a/docs/components/Mdx/InlineCode.js
+++ b/docs/components/Mdx/InlineCode.js
@@ -1,9 +1,11 @@
-import styled from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 
-export const InlineCode = styled.code`
-  background-color: transparent;
-  font-family: inherit;
-  font-size: inherit;
-  font-weight: bold;
-  color: sub-3;
-`
+export const InlineCode = styled.code(
+  ({ theme }) => css`
+    background-color: transparent;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: ${theme.fontWeights.bold};
+    color: ${theme.colors['sub-3']};
+  `
+)

--- a/docs/components/Mdx/Pagination/index.js
+++ b/docs/components/Mdx/Pagination/index.js
@@ -12,30 +12,30 @@ export function Pagination() {
   const { next, previous } = useGetPreviousAndNextLinks('getting-started')
 
   return (
-    <Box display="flex" justifyContent="space-between" pt={{ xs: 'xxl', md: "4xl" }} w="100%">
+    <Box $display="flex" $justifyContent="space-between" $pt={{ xs: 'xxl', md: '4xl' }} $w="100%">
       <Box>
         {previous && (
           <>
-            <Text fontWeight="bold" mb="sm" variant="sm">
+            <Text $fontWeight="bold" $mb="sm" variant="sm">
               Previous
             </Text>
             <NextLink href={previous.route} passHref>
               <S.Link>
-                <LeftIcon mr="sm" /> {previous.name}
+                <LeftIcon $mr="sm" /> {previous.name}
               </S.Link>
             </NextLink>
           </>
         )}
       </Box>
-      <Box textAlign="right">
+      <Box $textAlign="right">
         {next && (
           <>
-            <Text fontWeight="bold" mb="sm" variant="sm">
+            <Text $fontWeight="bold" $mb="sm" variant="sm">
               Next
             </Text>
             <NextLink href={next.route} passHref>
               <S.Link isNext>
-                {next.name} <RightIcon ml="sm" />
+                {next.name} <RightIcon $ml="sm" />
               </S.Link>
             </NextLink>
           </>

--- a/docs/components/Mdx/Pagination/styles.js
+++ b/docs/components/Mdx/Pagination/styles.js
@@ -1,23 +1,23 @@
-import styled, { css, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 
 export const Link = styled.a(
-  ({ isNext }) => css`
-    ${th('texts.h5')};
+  ({ isNext, theme }) => css`
+    ${theme.texts.h5};
     display: flex;
     align-items: center;
     text-decoration: none;
-    color: sub-3;
-    transition: medium;
+    color: ${theme.colors['sub-3']};
+    transition: ${theme.transitions.medium};
 
     &:hover {
       ${!isNext &&
       css`
-        padding-left: sm;
+        padding-left: ${theme.space.sm};
       `};
 
       ${isNext &&
       css`
-        padding-right: sm;
+        padding-right: ${theme.space.sm};
       `};
     }
   `

--- a/docs/components/Mdx/Pre.js
+++ b/docs/components/Mdx/Pre.js
@@ -1,13 +1,15 @@
-import styled from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 
-export const Pre = styled.pre`
-  font-size: sm;
-  line-height: 1.5;
-  font-family: texts;
+export const Pre = styled.pre(
+  ({ theme }) => css`
+    font-size: ${theme.fontSizes.sm};
+    line-height: 1.5;
+    font-family: ${theme.textsFontFamily.texts};
 
-  > div {
-    width: 100%;
-    overflow-wrap: break-word;
-    white-space: pre-wrap;
-  }
-`
+    > div {
+      width: 100%;
+      overflow-wrap: break-word;
+      white-space: pre-wrap;
+    }
+  `
+)

--- a/docs/components/Mdx/Props.js
+++ b/docs/components/Mdx/Props.js
@@ -81,7 +81,7 @@ export function Props({ propTypes }) {
     <Box>
       <Card mt="xxl">
         <Card.Body color="dark-900">
-          <Table marginBottom="-lg" marginTop="-lg">
+          <Table $mb="-lg" $mt="-lg">
             <Table.Thead>
               <Table.Tr>
                 <Table.Th>Name</Table.Th>

--- a/docs/components/Mdx/Showcase/Item.js
+++ b/docs/components/Mdx/Showcase/Item.js
@@ -12,16 +12,16 @@ export function Item({ content, name }) {
   }
 
   return (
-    <Box alignItems="center" display="flex" pb="md">
-      <Text m="0" variant="xs" w={{ xs: 50, md: 64 }}>
+    <Box $alignItems="center" $display="flex" $pb="md">
+      <Text $m="0" variant="xs" $w={{ xs: 50, md: 64 }}>
         {name}
       </Text>
-      <Box alignItems="center" display="flex" flex="1">
-        <Text lines={1} m="0" mr="sm" color="dark-900">
+      <Box $alignItems="center" $display="flex" $flex="1">
+        <Text lines={1} $m="0" $mr="sm" $color="dark-900">
           {content}
         </Text>
-        {copied && <CheckIcon color="success-500" flex="0 0 auto" size="sm" />}
-        {!copied && <CopyIcon cursor="pointer" flex="0 0 auto" size="sm" onClick={handleCopy} />}
+        {copied && <CheckIcon $color="success-500" $flex="0 0 auto" size="sm" />}
+        {!copied && <CopyIcon $cursor="pointer" $flex="0 0 auto" size="sm" onClick={handleCopy} />}
       </Box>
     </Box>
   )

--- a/docs/components/Mdx/Showcase/index.js
+++ b/docs/components/Mdx/Showcase/index.js
@@ -18,13 +18,13 @@ export function Showcase({
   version,
 }) {
   return (
-    <Box backgroundColor="nude-100" maxW="100% !important">
-      <Box m="0 auto" maxW={970} px={{ md: 'md' }} py={{ xs: 'xxl', md: '4xl' }}>
-        <H1 mb="0" pb="sm" pt="0">
+    <Box $backgroundColor="nude-100" $maxW="100% !important">
+      <Box $m="0 auto" $maxW="970px" $px={{ md: 'md' }} $py={{ xs: 'xxl', md: '4xl' }}>
+        <H1 $mb="0" $pb="sm" $pt="0">
           {pageName || component}
         </H1>
         {description && <Text variant="body1">{description}</Text>}
-        <Box mt="4xl">
+        <Box $mt="4xl">
           <Item content={version} name="version" />
           <Item content={`yarn add ${name}`} name="install" />
           <Item content={`import { ${component} } from '${name}'`} name="usage" />
@@ -33,7 +33,7 @@ export function Showcase({
             <Item content={customUsage} name={customInstall ? 'usage' : 'or usage'} />
           )}
         </Box>
-        <Box mt="xxl">
+        <Box $mt="xxl">
           <Button
             alt="npm package"
             as="a"
@@ -49,7 +49,7 @@ export function Showcase({
           <Button
             as="a"
             href={`https://github.com/WTTJ/welcome-ui/tree/master/packages/${component}`}
-            ml="md"
+            $ml="md"
             size="sm"
             target="_blank"
             alt="github"

--- a/docs/components/Mdx/Showcase/index.js
+++ b/docs/components/Mdx/Showcase/index.js
@@ -23,7 +23,7 @@ export function Showcase({
         <H1 $mb="0" $pb="sm" $pt="0">
           {pageName || component}
         </H1>
-        {description && <Text variant="body1">{description}</Text>}
+        {description && <Text variant="lg">{description}</Text>}
         <Box $mt="4xl">
           <Item content={version} name="version" />
           <Item content={`yarn add ${name}`} name="install" />

--- a/docs/components/Mdx/index.js
+++ b/docs/components/Mdx/index.js
@@ -28,16 +28,16 @@ export const MDXComponents = {
   tr: Table.Tr,
   tbody: Table.Tbody,
   a: ({ href, ...props }) => <Link href={href} {...props} />,
-  p: props => <Text as="p" lineHeight="1.5" pt="lg" {...props} />,
-  strong: props => <Box as="strong" fontWeight="bold" {...props} />,
+  p: props => <Text as="p" $lineHeight="1.5" $pt="lg" {...props} />,
+  strong: props => <Box as="strong" $fontWeight="bold" {...props} />,
   ul: props => (
-    <Box mb="sm">
-      <Box as="ul" mb="0" mt="md" {...props} />
+    <Box $mb="sm">
+      <Box as="ul" $mb="0" $mt="md" {...props} />
     </Box>
   ),
   ol: props => (
-    <Box mb="sm">
-      <Box as="ol" mb="0" mt="md" {...props} />
+    <Box $mb="sm">
+      <Box as="ol" $mb="0" $mt="md" {...props} />
     </Box>
   ),
   li: props => <Box as="li" pb={4} {...props} />,

--- a/docs/components/Spacing.js
+++ b/docs/components/Spacing.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { withTheme } from '@xstyled/styled-components'
+import { withTheme } from 'styled-components'
 import { Table } from '@welcome-ui/table'
 import { Box } from '@welcome-ui/box'
 

--- a/docs/components/ThemeConfiguration/index.js
+++ b/docs/components/ThemeConfiguration/index.js
@@ -23,7 +23,7 @@ const DisplayCategoryContent = (
     <>
       {Object.entries(themeConfiguration[category]).map(([key, value], index) => (
         <Fragment key={`${key}_${index}`}>
-          <Text variant="body2" $color="sub-3" $fontWeight="bold" $my="xs">
+          <Text variant="md" $color="sub-3" $fontWeight="bold" $my="xs">
             {key}
           </Text>
           <Box $display="flex" $gap="md" $mt="xs" $my="xs">
@@ -37,12 +37,12 @@ const DisplayCategoryContent = (
                 $borderColor="dark-200"
               />
             )}
-            <Text variant="body2" $m="0">
+            <Text variant="md" $m="0">
               {value}
               {config.unit}
             </Text>
             {config.shouldConvertToPx && (
-              <Text variant="body2" $color="primary-600" $fontWeight="bold" $m="0">
+              <Text variant="md" $color="primary-600" $fontWeight="bold" $m="0">
                 /* {themeConfiguration.toPx(value.replace('rem', ''))} */
               </Text>
             )}

--- a/docs/components/ThemeConfiguration/index.js
+++ b/docs/components/ThemeConfiguration/index.js
@@ -13,33 +13,36 @@ const ScreensContent = category => DisplayCategoryContent(category, { unit: 'px'
 
 const ColorsContent = category => DisplayCategoryContent(category, { shouldShowColor: true })
 
-const DisplayCategoryContent = ({ category }, config = { shouldConvertToPx: false, unit: '', shouldShowColor: false }) => {
+const DisplayCategoryContent = (
+  { category },
+  config = { shouldConvertToPx: false, unit: '', shouldShowColor: false }
+) => {
   const themeConfiguration = useThemeConfigurationContext()
 
   return (
     <>
       {Object.entries(themeConfiguration[category]).map(([key, value], index) => (
         <Fragment key={`${key}_${index}`}>
-          <Text variant="body2" color="sub-3" fontWeight="bold" my="xs">
+          <Text variant="body2" $color="sub-3" $fontWeight="bold" $my="xs">
             {key}
           </Text>
-          <Box display="flex" gap="md" mt="xs" my="xs">
-          {config.shouldShowColor && (
+          <Box $display="flex" $gap="md" $mt="xs" $my="xs">
+            {config.shouldShowColor && (
               <Box
-                w={30}
-                h={10}
-                mt="xs"
-                backgroundColor={key}
-                border={key.startsWith('light-') ? "1px solid" : 'none'}
-                borderColor="dark-200"
+                $w="30px"
+                $h="10px"
+                $mt="xs"
+                $backgroundColor={key}
+                $border={key.startsWith('light-') ? '1px solid' : 'none'}
+                $borderColor="dark-200"
               />
             )}
-            <Text variant="body2" m="0">
+            <Text variant="body2" $m="0">
               {value}
               {config.unit}
             </Text>
             {config.shouldConvertToPx && (
-              <Text variant="body2" color="primary-600" fontWeight="bold" m="0">
+              <Text variant="body2" $color="primary-600" $fontWeight="bold" $m="0">
                 /* {themeConfiguration.toPx(value.replace('rem', ''))} */
               </Text>
             )}

--- a/docs/components/ThemeHelper.js
+++ b/docs/components/ThemeHelper.js
@@ -41,9 +41,9 @@ export function ThemeHelper({ modal }) {
       {hasBeenHydrated && (
         <Modal {...modal} ariaLabel="theme configuration" title={title}>
           <Modal.Header title={title} subtitle="Documentation for the core theme entries" />
-          <Modal.Content mt="xl">
-            <Box display="flex">
-              <Tab.List w={200} mr="lg" aria-label="Tabs" {...tabState}>
+          <Modal.Content $mt="xl">
+            <Box $display="flex">
+              <Tab.List $w="200px" $mr="lg" aria-label="Tabs" {...tabState}>
                 {categories.map(category => (
                   <Tab key={category} {...tabState} id={category}>
                     {category}
@@ -54,16 +54,16 @@ export function ThemeHelper({ modal }) {
               {categories.map(category => (
                 <Tab.Panel key={category} {...tabState} tabId={category}>
                   <Box
-                    display="grid"
-                    gridTemplateColumns="1fr 1fr"
-                    rowGap={8}
-                    columnGap={16}
-                    mb="md"
+                    $display="grid"
+                    $gridTemplateColumns="1fr 1fr"
+                    $rowGap="8px"
+                    $columnGap="16px"
+                    $mb="md"
                   >
-                    <Text variant="h5" mb="md" mt="0">
+                    <Text variant="h5" $mb="md" $mt="0">
                       Key
                     </Text>
-                    <Text variant="h5" mb="md" mt="0">
+                    <Text variant="h5" $mb="md" $mt="0">
                       Value
                     </Text>
                     <ThemeConfiguration category={category} />

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,7 +36,6 @@
     "@mdx-js/loader": "1.6.22",
     "@mdx-js/react": "1.6.22",
     "@next/mdx": "^12.3.1",
-    "@xstyled/styled-components": "^3.7.0",
     "date-fns": "^2.28.0",
     "lodash.merge": "^4.6.2",
     "next": "^12.1.4",

--- a/docs/pages/blog.js
+++ b/docs/pages/blog.js
@@ -2,6 +2,7 @@
 /* eslint-disable react/jsx-max-depth */
 /* eslint-disable react/display-name */
 import React from 'react'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 import { Text } from '@welcome-ui/text'
 import { Button } from '@welcome-ui/button'
@@ -11,7 +12,6 @@ import { Link } from '@welcome-ui/link'
 import { Tag } from '@welcome-ui/tag'
 import { Stack } from '@welcome-ui/stack'
 import { RightIcon } from '@welcome-ui/icons'
-import styled, { th } from '@xstyled/styled-components'
 import { Avatar } from '@welcome-ui/avatar'
 
 const posts = [
@@ -41,26 +41,32 @@ const posts = [
   },
 ]
 
-const Title = styled(Link)`
-  ${th('texts.h5')};
-  display: inline;
+const Title = styled(Link)(
+  ({ theme }) => css`
+    ${theme.texts.h5};
+    display: inline;
+  `
+)
+
+const List = styled(Box)`
+  list-style-type: none;
 `
 
 export default function Blog() {
   return (
-    <Box margin="0 auto" maxWidth={800} p={{ xs: 'xl', md: '5xl' }}>
-      <Text color="sub-3" textAlign="center" variant="subtitle-md">
+    <Box $m="0 auto" $maxW="800px" $p={{ xs: 'xl', md: '5xl' }}>
+      <Text $color="sub-3" $textAlign="center" variant="subtitle-md">
         Blog
       </Text>
-      <Text mt="0" textAlign="center" variant="h1">
+      <Text $mt="0" $textAlign="center" variant="h1">
         The latest about us
       </Text>
-      <Box as="ul" listStyleType="none" m="0" mt="6xl" p="0">
+      <List as="ul" $m="0" $mt="6xl" $p="0">
         {posts.map(({ authors, date, description, link, tags, title }) => (
-          <Box as="li" key={link} mb="3xl">
+          <Box as="li" key={link} $mb="3xl">
             <Card>
               <Card.Body>
-                <Stack direction="row" mb="xl" spacing="xxs">
+                <Stack direction="row" $mb="xl" spacing="xxs">
                   {tags?.map(tag => (
                     <Tag key={`${link}_${tag}`} size="sm" variant="7">
                       {tag}
@@ -72,15 +78,15 @@ export default function Blog() {
                     {title}
                   </Title>
                 </NextLink>
-                <Box alignItems={{ md: 'flex-end' }} display={{ md: 'flex' }}>
+                <Box $alignItems={{ md: 'flex-end' }} $display={{ md: 'flex' }}>
                   <div>
-                    <Text mt="md">{description}</Text>
+                    <Text $mt="md">{description}</Text>
                     <Stack direction="row" mb="xxs">
                       {authors?.map(({ name, url }, idx) => (
                         <Avatar key={`${link}_authors_${idx}`} name={name} src={url} />
                       ))}
                     </Stack>
-                    <Text as="span" fontWeight="bold" mb="xl" variant="sm">
+                    <Text as="span" $fontWeight="bold" $mb="xl" variant="sm">
                       {authors?.map(({ name }, idx) => (
                         <>
                           {idx !== 0 && ', '}
@@ -88,16 +94,16 @@ export default function Blog() {
                         </>
                       ))}
                     </Text>
-                    <Text mb="0" variant="xs">
+                    <Text $mb="0" variant="xs">
                       {date.toDateString()}
                     </Text>
                   </div>
                   <NextLink href={link} passHref>
                     <Button
                       as="a"
-                      flexShrink="0"
-                      ml={{ md: 'xl' }}
-                      mt={{ xs: 'xl', md: 0 }}
+                      $flexShrink="0"
+                      $ml={{ md: 'xl' }}
+                      $mt={{ xs: 'xl', md: 0 }}
                       rel="noopener"
                       size="sm"
                       target="_blank"
@@ -110,7 +116,7 @@ export default function Blog() {
             </Card>
           </Box>
         ))}
-      </Box>
+      </List>
     </Box>
   )
 }

--- a/docs/pages/components/box.mdx
+++ b/docs/pages/components/box.mdx
@@ -19,7 +19,7 @@ You can create a simple card item using Boxes (and a couple of other components)
 
 ```jsx
 <Box display="flex" w="100%" justifyContent="center" alignItems="center" backgroundColor="nude-100">
-  <Box backgroundColor="light-900" borderRadius="sm" boxShadow="sm" margin="xl" maxWidth={360}>
+  <Box backgroundColor="light-900" borderRadius="sm" boxShadow="sm" $m="xl" maxWidth={360}>
     <Box
       as="img"
       src="https://images.unsplash.com/photo-1610020468144-a6f4771a1982?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=600&q=80"

--- a/docs/pages/components/card.mdx
+++ b/docs/pages/components/card.mdx
@@ -60,7 +60,7 @@ A picture card, if you add a `backgroundImage` on Card, it's displayed on cover.
   alignItems="flex-end"
 >
   <Box
-    padding="xl"
+    $p="xl"
     w="100%"
     background="linear-gradient(0deg, rgba(0,0, 0, 0.7) 0%, rgba(0,0,0,0) 100%)"
   >

--- a/docs/pages/components/toast.mdx
+++ b/docs/pages/components/toast.mdx
@@ -38,7 +38,7 @@ function() {
       borderStyle="solid"
       borderColor="nude-300"
       borderRadius="sm"
-      padding="sm"
+      $p="sm"
       color="dark-900"
     >
       Lorem ipsum dolor sit amet
@@ -71,7 +71,7 @@ function() {
       borderStyle="solid"
       borderColor="nude-300"
       borderRadius="sm"
-      padding="sm"
+      $p="sm"
       color="dark-900"
     >
       Lorem ipsum dolor sit amet

--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -16,50 +16,50 @@ import { LogoWttj } from '../components/LogoWttj'
 export default function Home() {
   return (
     <main>
-      <Section backgroundColor="nude-200">
-        <Text as="span" textTransform="uppercase" variant="subtitle-md" color="dark-900">
+      <Section $backgroundColor="nude-200">
+        <Text as="span" $textTransform="uppercase" variant="subtitle-md" $color="dark-900">
           Welcome UI
         </Text>
-        <Text maxWidth={820} mb="xl" mt="sm" variant="h1">
+        <Text $maxW="820px" $mb="xl" $mt="sm" variant="h1">
           All the components you need to create a delightful React webapp
         </Text>
-        <Text maxWidth={640} variant="lg">
+        <Text $maxW="640px" variant="lg">
           Welcome UI is a customizable design system library made with react, typescript,
           styled-components, reakit and a lot of love 💛
         </Text>
         <NextLink href="/installation" passHref>
-          <Button as="a" mt="3xl" size="lg">
+          <Button as="a" $mt="3xl" size="lg">
             <span>Install amazing components</span>
             <RightIcon />
           </Button>
         </NextLink>
       </Section>
       <Section>
-        <Text mb="xl" mt="0" variant="h4">
+        <Text $mb="xl" $mt="0" variant="h4">
           Some of our components
         </Text>
         <Components />
       </Section>
-      <Section backgroundColor="nude-200">
+      <Section $backgroundColor="nude-200">
         <Box
-          alignItems="center"
-          display="flex"
-          flexDirection={{ xs: 'column', lg: 'row' }}
-          justifyContent="space-between"
+          $alignItems="center"
+          $display="flex"
+          $flexDirection={{ xs: 'column', lg: 'row' }}
+          $justifyContent="space-between"
         >
-          <Box flex="0 0 auto" maxWidth={{ md: 600 }} mb={{ xs: '5xl', lg: 0 }}>
-            <Text as="span" textTransform="uppercase" variant="subtitle-md" color="dark-900">
+          <Box $flex="0 0 auto" $maxW={{ md: '600px' }} $mb={{ xs: '5xl', lg: '0' }}>
+            <Text as="span" $textTransform="uppercase" variant="subtitle-md" $color="dark-900">
               Open source
             </Text>
-            <Text as="h2" mb="xl" mt="sm" variant="h1">
+            <Text as="h2" $mb="xl" $mt="sm" variant="h1">
               Contribute!
             </Text>
-            <Text maxWidth={640} variant="lg">
+            <Text maxW="640px" variant="lg">
               Welcome UI is open-sourced on GitHub. Contributions, feedback and issues are welcome –
               we want you to be a part of this great project.
             </Text>
             <NextLink href="https://github.com/WTTJ/welcome-ui" passHref>
-              <Button as="a" mt="3xl" size="lg" target="_blank" variant="secondary">
+              <Button as="a" $mt="3xl" size="lg" target="_blank" variant="secondary">
                 <GithubIcon size="lg" />
                 <span>Contribute on Github</span>
               </Button>
@@ -69,65 +69,65 @@ export default function Home() {
         </Box>
       </Section>
       <Section>
-        <Text as="h2" maxWidth={500} mb="xl" mt="0" variant="h1">
+        <Text as="h2" $maxW="500px" $mb="xl" $mt="0" variant="h1">
           All you’d expect from a design system...
         </Text>
-        <Text maxWidth={640} mb="5xl" variant="lg">
+        <Text $maxW="640px" $mb="5xl" variant="lg">
           ...and a lot more!
         </Text>
         <Expectations />
       </Section>
-      <Section backgroundColor="nude-200">
-        <Text as="span" textTransform="uppercase" variant="subtitle-md" color="dark-900">
+      <Section $backgroundColor="nude-200">
+        <Text as="span" $textTransform="uppercase" variant="subtitle-md" $color="dark-900">
           Example
         </Text>
-        <Text as="h2" mb="xl" mt="sm" variant="h1">
+        <Text as="h2" $mb="xl" $mt="sm" variant="h1">
           Going straight to the point!
         </Text>
-        <Text maxWidth={450} variant="lg">
+        <Text $maxW="450px" variant="lg">
           Leave the UI code to our team and focus on building your astonishing project.
         </Text>
         <Box
           allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
           as="iframe"
-          border="0"
-          h={{ xs: 300, md: 600 }}
-          mt="3xl"
+          $border="0"
+          $h={{ xs: '300px', md: '600px' }}
+          $mt="3xl"
           sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
           src="https://codesandbox.io/embed/homepage-example-mcypy?autoresize=1&hidenavigation=1&initialpath=src&module=%2Fsrc%2FExample.tsx&theme=dark&view=split"
           title="homepage-example"
-          w="100%"
+          $w="100%"
         />
       </Section>
-      <Section backgroundColor="black" color="white" pt={{ xs: '3xl', md: '6xl' }}>
-        <Box textAlign="center" w="100%">
-          <LogoWttj h={67} w={210} />
+      <Section $backgroundColor="black" $color="white" $pt={{ xs: '3xl', md: '6xl' }}>
+        <Box $textAlign="center" $w="100%">
+          <LogoWttj h="67px" $w="210px" />
         </Box>
         <Text
           as="span"
-          color="white"
-          mb="0"
-          mt="5xl"
-          textTransform="uppercase"
+          $color="white"
+          $mb="0"
+          $mt="5xl"
+          $textTransform="uppercase"
           variant="subtitle-md"
         >
           Who we are?
         </Text>
-        <Text as="h2" color="white" maxWidth={950} mb="xl" mt="sm" variant="h1">
+        <Text as="h2" $color="white" $maxW="950px" $mb="xl" $mt="sm" variant="h1">
           The new experience at work
         </Text>
-        <Text color="white" maxWidth={640} variant="lg">
+        <Text $color="white" $maxW="640px" variant="lg">
           Welcome to the Jungle build products that transform every step of the experience at work.
         </Text>
-        <Box display={{ md: 'flex' }} mt="5xl">
+        <Box $display={{ md: 'flex' }} $mt="5xl">
           <NextLink href="https://www.welcometothejungle.com/en/companies/wttj/jobs" passHref>
-            <Button as="a" mr="md" size="lg" target="_blank">
+            <Button as="a" $mr="md" size="lg" target="_blank">
               <span>We are recruiting</span>
               <HeartIcon size="lg" />
             </Button>
           </NextLink>
           <NextLink href="https://www.welcometothejungle.com/en" passHref>
-            <Button as="a" mt={{ xs: 'md', md: 0 }} size="lg" target="_blank" variant="ghost">
+            <Button as="a" $mt={{ xs: 'md', md: '0' }} size="lg" target="_blank" variant="ghost">
               <span>Visit our website</span>
               <RightIcon size="lg" />
             </Button>
@@ -135,16 +135,16 @@ export default function Home() {
         </Box>
         <Box
           as="img"
-          bottom={-90}
-          display={{ xs: 'none', lg: 'block' }}
-          maxWidth={400}
-          position="absolute"
-          right="0"
+          $bottom="-90px"
+          $display={{ xs: 'none', lg: 'block' }}
+          $maxW="400px"
+          $position="absolute"
+          $right="0"
           src="illustration.png"
-          w="100%"
+          $w="100%"
         />
       </Section>
-      <Section as="div" py="3xl" zIndex="1">
+      <Section as="div" $py="3xl" $zIndex="1">
         <Footer />
       </Section>
     </main>

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "jest": "29.3.1",
     "jest-environment-jsdom": "29.3.1",
     "jest-styled-components": "7.1.1",
-    "jsx-to-styled": "^1.5.2",
+    "jsx-to-styled": "^1.5.3",
     "lerna": "^3.22.1",
     "lerna-update-wizard": "^0.17.8",
     "lodash.difference": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "jest": "29.3.1",
     "jest-environment-jsdom": "29.3.1",
     "jest-styled-components": "7.1.1",
+    "jsx-to-styled": "^1.5.2",
     "lerna": "^3.22.1",
     "lerna-update-wizard": "^0.17.8",
     "lodash.difference": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "@types/styled-components": "^5.1.25",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
-    "@xstyled/styled-components": "^3.7.0",
     "aws-sdk": "^2.1255.0",
     "babel-jest": "29.3.1",
     "babel-plugin-annotate-pure-calls": "^0.4.0",

--- a/packages/Accordion/package.json
+++ b/packages/Accordion/package.json
@@ -39,11 +39,11 @@
   },
   "dependencies": {
     "@welcome-ui/icons": "^5.0.0-alpha.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react-animate-height": "^3.0.5",
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Accordion/package.json
+++ b/packages/Accordion/package.json
@@ -39,12 +39,11 @@
   },
   "dependencies": {
     "@welcome-ui/icons": "^5.0.0-alpha.0",
-    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react-animate-height": "^3.0.5",
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Accordion/styles.ts
+++ b/packages/Accordion/styles.ts
@@ -2,26 +2,28 @@ import styled, { css } from 'styled-components'
 import { DisclosureContent, Disclosure as ReakitDisclosure } from 'reakit/Disclosure'
 import { Box } from '@welcome-ui/box'
 
-export const Accordion = styled(Box)`
-  ${props => props.theme.accordions.wrapper};
-  transition: medium;
+export const Accordion = styled(Box)(
+  ({ theme }) => css`
+    ${theme.accordions.wrapper};
+    transition: ${theme.transitions.medium};
 
-  &:hover {
-    border-color: dark-400;
-  }
-`
+    &:hover {
+      border-color: ${theme.colors['dark-400']};
+    }
+  `
+)
 
 export const Icon = styled(Box)<{ visible: boolean }>(
   ({ theme, visible }) => css`
     flex-shrink: 0;
     ${theme.accordions.icon};
     transform: ${visible ? 'rotate3d(0, 0, 1, 90deg)' : 'rotate3d(0)'};
-    transition: medium;
-    width: 24;
-    height: 24;
+    transition: ${theme.transitions.medium};
+    width: 24px;
+    height: 24px;
     color: inherit;
     display: flex;
-    border-radius: 12;
+    border-radius: 12px;
 
     & *:first-child {
       margin: auto;
@@ -40,13 +42,13 @@ export const Disclosure = styled(ReakitDisclosure)(
       display: flex;
       justify-content: space-between;
       align-items: center;
-      gap: xxl;
+      gap: ${theme.spaces.xxl};
 
       &:focus,
       &:hover {
         cursor: pointer;
         ${Icon} {
-          background-color: dark-100;
+          background-color: ${theme.colors['dark-100']};
         }
       }
 
@@ -63,7 +65,7 @@ export const Content = styled(DisclosureContent)(
   ({ theme, visible }) => css`
     ${theme.accordions.content};
     padding-inline: ${theme.accordions.padding};
-    color: dark-700;
+    color: ${theme.colors['dark-700']};
 
     ${visible &&
     css`

--- a/packages/Accordion/styles.ts
+++ b/packages/Accordion/styles.ts
@@ -1,10 +1,9 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { DisclosureContent, Disclosure as ReakitDisclosure } from 'reakit/Disclosure'
 import { Box } from '@welcome-ui/box'
 
-export const Accordion = styled.div`
-  ${th('accordions.wrapper')};
-  ${system}
+export const Accordion = styled(Box)`
+  ${props => props.theme.accordions.wrapper};
   transition: medium;
 
   &:hover {
@@ -13,9 +12,9 @@ export const Accordion = styled.div`
 `
 
 export const Icon = styled(Box)<{ visible: boolean }>(
-  ({ visible }) => css`
+  ({ theme, visible }) => css`
     flex-shrink: 0;
-    ${th('accordions.icon')};
+    ${theme.accordions.icon};
     transform: ${visible ? 'rotate3d(0, 0, 1, 90deg)' : 'rotate3d(0)'};
     transition: medium;
     width: 24;
@@ -30,42 +29,45 @@ export const Icon = styled(Box)<{ visible: boolean }>(
   `
 )
 
-export const Disclosure = styled(ReakitDisclosure)`
-  ${th('accordions.title')};
-  width: 100%;
-  padding: ${th('accordions.padding')};
-  background-color: transparent;
-  border: 0;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: xxl;
+export const Disclosure = styled(ReakitDisclosure)(
+  ({ theme }) =>
+    css`
+      ${theme.accordions.title};
+      width: 100%;
+      padding: ${theme.accordions.padding};
+      background-color: transparent;
+      border: 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: xxl;
 
-  &:focus,
-  &:hover {
-    cursor: pointer;
-    ${Icon} {
-      background-color: dark-100;
-    }
-  }
+      &:focus,
+      &:hover {
+        cursor: pointer;
+        ${Icon} {
+          background-color: dark-100;
+        }
+      }
 
-  &:focus {
-    outline: 0;
-    ${Icon} {
-      color: inherit;
-    }
-  }
-`
+      &:focus {
+        outline: 0;
+        ${Icon} {
+          color: inherit;
+        }
+      }
+    `
+)
 
 export const Content = styled(DisclosureContent)(
-  ({ visible }) => css`
-    ${th('accordions.content')};
-    padding-inline: ${th('accordions.padding')};
+  ({ theme, visible }) => css`
+    ${theme.accordions.content};
+    padding-inline: ${theme.accordions.padding};
     color: dark-700;
 
     ${visible &&
     css`
-      padding-bottom: ${th('accordions.padding')};
+      padding-bottom: ${theme.accordions.padding};
     `}
   `
 )

--- a/packages/Accordion/tsconfig.json
+++ b/packages/Accordion/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Alert/index.tsx
+++ b/packages/Alert/index.tsx
@@ -35,10 +35,10 @@ const AlertComponent = forwardRef<'div', AlertProps>(
 
     return (
       <S.Alert ref={ref} size={size} variant={variant} {...rest}>
-        <VariantIcon icon={icon} pr="md" variant={variant} />
-        <Box h="fit-content" m="auto">
+        <VariantIcon $pr="md" icon={icon} variant={variant} />
+        <Box $h="fit-content" $m="auto">
           {buttonChild ? (
-            <Stack alignItems="center" direction="row" justifyContent="space-between">
+            <Stack $alignItems="center" $justifyContent="space-between" direction="row">
               <div>{content}</div>
               {buttonChild}
             </Stack>

--- a/packages/Alert/package.json
+++ b/packages/Alert/package.json
@@ -40,11 +40,11 @@
   "dependencies": {
     "@welcome-ui/box": "^5.0.0-alpha.0",
     "@welcome-ui/stack": "^5.0.0-alpha.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0",
     "@welcome-ui/text": "^5.0.0-alpha.0",
     "@welcome-ui/variant-icon": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Alert/package.json
+++ b/packages/Alert/package.json
@@ -40,12 +40,11 @@
   "dependencies": {
     "@welcome-ui/box": "^5.0.0-alpha.0",
     "@welcome-ui/stack": "^5.0.0-alpha.0",
-    "@welcome-ui/system": "^5.0.0-alpha.0",
     "@welcome-ui/text": "^5.0.0-alpha.0",
     "@welcome-ui/variant-icon": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Alert/styles.ts
+++ b/packages/Alert/styles.ts
@@ -21,7 +21,7 @@ export const Title = styled(Text).attrs(({ variant }: AlertOptions) => ({
     display: flex;
     align-items: center;
     margin: 0;
-    margin-bottom: sm;
+    margin-bottom: ${theme.space.sm};
     height: 100%;
     ${theme.alerts.title[alertVariant]};
 

--- a/packages/Alert/styles.ts
+++ b/packages/Alert/styles.ts
@@ -1,15 +1,14 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 import { Text } from '@welcome-ui/text'
 
 import { AlertOptions } from '.'
 
 export const Alert = styled(Box)<AlertOptions>(
-  ({ size, variant }) => css`
-    ${th('alerts.default')};
-    ${th(`alerts.${variant}`)};
-    ${th(`alerts.sizes.${size}`)};
-    ${system}
+  ({ size, theme, variant }) => css`
+    ${theme.alerts.default};
+    ${theme.alerts[variant]};
+    ${theme.alerts.sizes[size]};
   `
 )
 
@@ -17,15 +16,14 @@ export const Title = styled(Text).attrs(({ variant }: AlertOptions) => ({
   variant: 'h5',
   // We're renaming the prop because it'll be overridden by Text's variant
   alertVariant: variant,
-}))(
-  ({ alertVariant }) => css`
+}))<{ alertVariant: AlertOptions['variant'] }>(
+  ({ alertVariant, theme }) => css`
     display: flex;
     align-items: center;
     margin: 0;
     margin-bottom: sm;
     height: 100%;
-    ${th(`alerts.title.${alertVariant}`)};
-    ${system}
+    ${theme.alerts.title[alertVariant]};
 
     &:only-child {
       margin-bottom: 0;

--- a/packages/Alert/tsconfig.json
+++ b/packages/Alert/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/AspectRatio/package.json
+++ b/packages/AspectRatio/package.json
@@ -41,7 +41,6 @@
     "@welcome-ui/box": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/AspectRatio/package.json
+++ b/packages/AspectRatio/package.json
@@ -38,7 +38,8 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "@welcome-ui/box": "^5.0.0-alpha.0"
+    "@welcome-ui/box": "^5.0.0-alpha.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",

--- a/packages/AspectRatio/styles.ts
+++ b/packages/AspectRatio/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 
 import { AspectRatioOptions } from '.'

--- a/packages/AspectRatio/tsconfig.json
+++ b/packages/AspectRatio/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Avatar/index.tsx
+++ b/packages/Avatar/index.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react'
 import { Box } from '@welcome-ui/box'
 import { ShapeOptions } from '@welcome-ui/shape'
-import { useTheme } from '@xstyled/styled-components'
+import { useTheme } from 'styled-components'
 import { WuiTheme } from '@welcome-ui/core'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 

--- a/packages/Avatar/index.tsx
+++ b/packages/Avatar/index.tsx
@@ -42,7 +42,7 @@ export const Avatar: React.FC<AvatarProps> = memo(
       const backgroundColor = color || getSeededColor(theme.colors, name)
       const avatarSize = theme.avatars.sizes[size]
       const avatarFontSize =
-        $fontSize || `calc(${$w ? theme.toRem($w as number) : avatarSize} / 2.5)`
+        $fontSize || `calc(${$w ? theme.toRem($w as unknown as number) : avatarSize} / 2.5)`
 
       return (
         <S.Avatar

--- a/packages/Avatar/index.tsx
+++ b/packages/Avatar/index.tsx
@@ -26,14 +26,14 @@ export const Avatar: React.FC<AvatarProps> = memo(
     (
       {
         color,
-        fontSize,
+        $fontSize,
         getInitials = defaultGetInitials,
-        h,
+        $h,
         name,
         shape = 'circle',
         size = 'md',
         src,
-        w,
+        $w,
         ...rest
       },
       ref
@@ -41,23 +41,24 @@ export const Avatar: React.FC<AvatarProps> = memo(
       const theme = useTheme()
       const backgroundColor = color || getSeededColor(theme.colors, name)
       const avatarSize = theme.avatars.sizes[size]
-      const avatarFontSize = fontSize || `calc(${w ? theme.toRem(w as number) : avatarSize} / 2.5)`
+      const avatarFontSize =
+        $fontSize || `calc(${$w ? theme.toRem($w as number) : avatarSize} / 2.5)`
 
       return (
         <S.Avatar
           aria-label={name}
           backgroundColor={backgroundColor}
-          h={h || avatarSize}
+          h={$h || avatarSize}
           ref={ref}
           role="img"
           shape={shape}
-          w={w || avatarSize}
+          w={$w || avatarSize}
           {...rest}
         >
           {src && <img alt={name} src={src} />}
           {!src && (
             <Box>
-              <S.Text fontSize={avatarFontSize} m={0}>
+              <S.Text $fontSize={avatarFontSize} $m="0px">
                 {getInitials(name)}
               </S.Text>
             </Box>

--- a/packages/Avatar/package.json
+++ b/packages/Avatar/package.json
@@ -44,7 +44,6 @@
     "@welcome-ui/text": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Avatar/styles.ts
+++ b/packages/Avatar/styles.ts
@@ -1,4 +1,4 @@
-import styled, { th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Shape } from '@welcome-ui/shape'
 import { Text as TextWUI } from '@welcome-ui/text'
 
@@ -6,6 +6,8 @@ export const Avatar = styled(Shape)`
   flex-shrink: 0;
 `
 
-export const Text = styled(TextWUI)`
-  ${th('avatars.text')};
-`
+export const Text = styled(TextWUI)(
+  ({ theme }) => css`
+    ${theme.avatars.text}
+  `
+)

--- a/packages/Avatar/tsconfig.json
+++ b/packages/Avatar/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Badge/styles.ts
+++ b/packages/Badge/styles.ts
@@ -1,5 +1,5 @@
-import { WuiProps } from '@welcome-ui/system'
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { system, WuiProps } from '@welcome-ui/system'
 
 import { BadgeOptions } from './index'
 
@@ -8,10 +8,10 @@ export type StyledBadgeProps = Pick<BadgeOptions, 'disabled' | 'shape' | 'size' 
 }
 
 export const Badge = styled.div<StyledBadgeProps & WuiProps>(
-  ({ disabled, length, shape, size, variant }) => css`
-    ${th('badges.default')};
-    ${th(`badges.variants.${variant}`)};
-    ${th(`badges.sizes.${size}`)};
+  ({ disabled, length, shape, size, theme, variant }) => css`
+    ${theme.badges.default};
+    ${theme.badges.variants[variant]};
+    ${theme.badges.sizes[size]};
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -19,12 +19,12 @@ export const Badge = styled.div<StyledBadgeProps & WuiProps>(
 
     ${disabled &&
     css`
-      ${th(`badges.disabled.${variant}`)};
+      ${theme.badges.disabled[variant]};
     `}
 
     ${length === 1 &&
     css`
-      width: ${th(`badges.sizes.${size}.height`)};
+      width: ${theme.badges.sizes[size].height};
     `}
 
     ${shape === 'square' &&

--- a/packages/Badge/tsconfig.json
+++ b/packages/Badge/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Box/index.tsx
+++ b/packages/Box/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import { x } from '@xstyled/styled-components'
-import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
+import styled from 'styled-components'
+import { CreateWuiProps, forwardRef, system, WuiProps } from '@welcome-ui/system'
 
 export type BoxProps = CreateWuiProps<'div'>
 
+const StyledBox = styled.div<WuiProps>(system)
+
 export const Box = forwardRef<'div', BoxProps>((props, ref) => {
-  return <x.div ref={ref} {...props} />
+  return <StyledBox ref={ref} {...props} />
 })

--- a/packages/Box/package.json
+++ b/packages/Box/package.json
@@ -37,11 +37,8 @@
   "bugs": {
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
-  "dependencies": {
-    "@welcome-ui/system": "^5.0.0-alpha.0"
-  },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Box/package.json
+++ b/packages/Box/package.json
@@ -37,8 +37,10 @@
   "bugs": {
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
+  "dependencies": {
+    "@welcome-ui/system": "^5.0.0-alpha.0"
+  },
   "peerDependencies": {
-    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Box/tsconfig.json
+++ b/packages/Box/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Breadcrumb/Item.styles.ts
+++ b/packages/Breadcrumb/Item.styles.ts
@@ -1,33 +1,36 @@
-import styled, { css, th } from '@xstyled/styled-components'
-import { shouldForwardProp } from '@welcome-ui/system'
+import styled, { css } from 'styled-components'
+import { system } from '@welcome-ui/system'
 
 interface ItemProps {
   isActive: boolean
 }
 
-export const Item = styled.aBox.withConfig({ shouldForwardProp })<ItemProps>(
-  ({ isActive }) => css`
-    ${th('breadcrumbs.item.default')};
+export const Item = styled.a<ItemProps>(
+  ({ isActive, theme }) => css`
+    ${theme.breadcrumbs.item.default};
     align-items: center;
     transition: medium;
     direction: initial;
+    ${system};
 
     ${!isActive &&
     css`
       &:hover {
-        ${th('breadcrumbs.item.hover')};
+        ${theme.breadcrumbs.item.hover};
       }
     `};
 
     ${isActive &&
     css`
-      ${th('breadcrumbs.item.active')};
+      ${theme.breadcrumbs.item.active};
     `}
   `
 )
 
-export const Separator = styled.span`
-  ${th('breadcrumbs.separator')};
-  display: flex;
-  align-items: center;
-`
+export const Separator = styled.span(
+  ({ theme }) => css`
+    ${theme.breadcrumbs.separator};
+    display: flex;
+    align-items: center;
+  `
+)

--- a/packages/Breadcrumb/Item.tsx
+++ b/packages/Breadcrumb/Item.tsx
@@ -19,11 +19,11 @@ export const Item = forwardRef<'a', ItemProps>(
   ({ children, dataTestId, isActive, separator, ...rest }) => {
     return (
       <Box
+        $display="inline-flex"
+        $flex="0 0 auto"
         aria-label="breadcrumb"
         as="li"
         data-testid={dataTestId}
-        display="inline-flex"
-        flex="0 0 auto"
       >
         {separator && <S.Separator role="presentation">{separator}</S.Separator>}
         <S.Item aria-current={isActive ? 'page' : undefined} isActive={isActive} {...rest}>

--- a/packages/Breadcrumb/index.tsx
+++ b/packages/Breadcrumb/index.tsx
@@ -21,7 +21,7 @@ export type Colors = WuiTheme['colors']
 export interface BreadcrumbOptions {
   children: React.ReactNode | React.ReactNode[]
   /** color from theme, add for scroll gradient on mobile */
-  gradientBackground?: Colors
+  gradientBackground?: keyof Colors
   /** set clickable or not the last child */
   lastChildNotClickable?: boolean
   separator?: string | React.ReactNode
@@ -124,13 +124,13 @@ export const BreadcrumbComponent = forwardRef<'div', BreadcrumbProps>(
     return (
       <S.Breadcrumb as="nav" ref={ref} {...rest}>
         {isOverflowing && (
-          <S.StartGradient gradientBackground={gradientBackground as Colors} ref={startGradient} />
+          <S.StartGradient gradientBackground={gradientBackground} ref={startGradient} />
         )}
         <S.List dir="rtl" onScroll={onListScroll} ref={listRef}>
           {clones.reverse()}
         </S.List>
         {isOverflowing && (
-          <S.EndGradient gradientBackground={gradientBackground as Colors} ref={endGradient} />
+          <S.EndGradient gradientBackground={gradientBackground} ref={endGradient} />
         )}
       </S.Breadcrumb>
     )

--- a/packages/Breadcrumb/package.json
+++ b/packages/Breadcrumb/package.json
@@ -45,7 +45,6 @@
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Breadcrumb/styles.ts
+++ b/packages/Breadcrumb/styles.ts
@@ -1,18 +1,17 @@
-import styled, { css, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 import { hexToRGBA } from '@welcome-ui/utils'
-import { WuiTheme } from '@welcome-ui/core'
 
 import { Colors } from './index'
 
 interface GradientProps {
-  gradientBackground: Colors
+  gradientBackground: keyof Colors
 }
 
 export const StartGradient = styled.span<GradientProps>(
   ({ gradientBackground, theme }) => css`
     left: 0;
-    background-image: ${gradient(theme as WuiTheme, gradientBackground)};
+    background-image: ${gradient(theme.colors[gradientBackground])};
     transform-origin: left;
   `
 )
@@ -20,25 +19,27 @@ export const StartGradient = styled.span<GradientProps>(
 export const EndGradient = styled.span<GradientProps>(
   ({ gradientBackground, theme }) => css`
     right: 0;
-    background-image: ${gradient(theme as WuiTheme, gradientBackground, 'left')};
+    background-image: ${gradient(theme.colors[gradientBackground], 'left')};
     transform-origin: right;
   `
 )
 
-export const Breadcrumb = styled(Box)`
-  ${th('breadcrumbs.list')};
-  height: 100%;
-  position: relative;
-  overflow-x: hidden;
+export const Breadcrumb = styled(Box)(
+  ({ theme }) => css`
+    ${theme.breadcrumbs.list};
+    height: 100%;
+    position: relative;
+    overflow-x: hidden;
 
-  ${StartGradient},
-  ${EndGradient} {
-    position: absolute;
-    bottom: 0;
-    top: 0;
-    width: 30;
-  }
-`
+    ${StartGradient},
+    ${EndGradient} {
+      position: absolute;
+      bottom: 0;
+      top: 0;
+      width: 30;
+    }
+  `
+)
 
 export const List = styled.ol`
   display: inline-flex;
@@ -52,8 +53,7 @@ export const List = styled.ol`
   white-space: nowrap;
 `
 
-const gradient = (theme: WuiTheme, gradientBackground: Colors, position = 'right') => {
-  const gradientColor = th(`colors.${gradientBackground}`)({ theme }) as string
-  const transparent = hexToRGBA(gradientColor, 0)
-  return `linear-gradient(to ${position}, ${gradientColor}, ${transparent} 100%)`
+const gradient = (color: string, position = 'right') => {
+  const transparent = hexToRGBA(color, 0)
+  return `linear-gradient(to ${position}, ${color}, ${transparent} 100%)`
 }

--- a/packages/Breadcrumb/tsconfig.json
+++ b/packages/Breadcrumb/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Button/package.json
+++ b/packages/Button/package.json
@@ -39,12 +39,11 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "@welcome-ui/system": "^5.0.0-alpha.0",
     "@welcome-ui/utils": "^5.0.0-alpha.0",
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Button/styles.ts
+++ b/packages/Button/styles.ts
@@ -1,73 +1,70 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Button as ReakitButton } from 'reakit/Button'
-import { shouldForwardProp } from '@welcome-ui/system'
 import { hideFocusRingsDataAttribute } from '@welcome-ui/utils'
+import { system } from '@welcome-ui/system'
 
 import { ButtonOptions } from './index'
 
-const shapeStyles = (size: ButtonOptions['size'], shape: ButtonOptions['shape'] = 'square') => css`
-  width: ${th(`buttons.sizes.${size}.height`)};
-  padding: 0;
-  ${shape === 'circle' &&
-  css`
-    border-radius: ${th(`buttons.sizes.${size}.height`)};
-  `};
-`
+export const Button = styled(ReakitButton)<ButtonOptions>(
+  ({ disabled, shape, size = 'md', theme, variant }) => {
+    const variantStyles = theme.buttons[variant]
+    const sizeStyles = theme.buttons.sizes[size]
 
-export const Button = styled(ReakitButton).withConfig({ shouldForwardProp })<ButtonOptions>(
-  ({ disabled, shape, size = 'md', variant }) => css`
-    ${th(`buttons.${variant}`)};
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: auto;
-    ${th(`buttons.sizes.${size}`)};
-    text-decoration: none;
-    text-align: center;
-    white-space: nowrap;
-    cursor: pointer;
-    outline: none !important; /* important for firefox */
-    border-width: sm;
-    border-style: solid;
-    appearance: none;
-    overflow: hidden;
-    transition: medium;
-    ${shape && shapeStyles(size, shape)};
-    ${system};
+    const shapeStyles = css`
+      width: ${theme.buttons.sizes[size].height};
+      padding: 0;
 
-    & > svg:only-child {
-      width: ${th(`buttons.icon.only.${size}`)};
-      height: ${th(`buttons.icon.only.${size}`)};
-    }
+      ${shape === 'circle' &&
+      css`
+        border-radius: ${theme.buttons.sizes[size].height};
+      `};
+    `
 
-    & > svg:not(:only-child) {
-      width: ${th(`buttons.icon.default.${size}`)};
-      height: ${th(`buttons.icon.default.${size}`)};
-    }
+    return css`
+      ${variantStyles};
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: auto;
+      ${sizeStyles};
+      text-decoration: none;
+      text-align: center;
+      white-space: nowrap;
+      cursor: pointer;
+      outline: none !important; /* important for firefox */
+      border-width: sm;
+      border-style: solid;
+      appearance: none;
+      overflow: hidden;
+      transition: medium;
+      ${shape && shapeStyles}
+      ${system};
 
-    & > *:not(:only-child):not(:last-child) {
-      margin-right: sm;
-    }
-
-    ${!disabled &&
-    css`
-      [${hideFocusRingsDataAttribute}] &:focus {
-        box-shadow: none;
+      & > *:not(:only-child):not(:last-child) {
+        margin-right: sm;
       }
-      &:focus {
-        ${th(`buttons.focus.${variant || 'primary'}`)};
-      }
-      &:hover {
-        ${th(`buttons.hover.${variant || 'primary'}`)};
-      }
-      &:active {
-        ${th(`buttons.active.${variant || 'primary'}`)};
-      }
-    `};
 
-    &[disabled] {
-      cursor: not-allowed;
-    }
-  `
+      ${!disabled &&
+      variant !== 'disabled' &&
+      css`
+        [${hideFocusRingsDataAttribute}] &:focus {
+          box-shadow: none;
+        }
+        &:focus {
+          ${theme.buttons.focus[variant || 'primary']};
+        }
+        &:hover {
+          ${theme.buttons.hover[variant || 'primary']};
+        }
+        &:active {
+          ${theme.buttons.active[variant || 'primary']};
+        }
+      `};
+
+      &[disabled] {
+        cursor: not-allowed;
+      }
+    `
+  }
 )

--- a/packages/Button/styles.ts
+++ b/packages/Button/styles.ts
@@ -33,16 +33,16 @@ export const Button = styled(ReakitButton)<ButtonOptions>(
       white-space: nowrap;
       cursor: pointer;
       outline: none !important; /* important for firefox */
-      border-width: sm;
+      border-width: ${theme.borderWidths.sm};
       border-style: solid;
       appearance: none;
       overflow: hidden;
-      transition: medium;
+      transition: ${theme.transitions.medium};
       ${shape && shapeStyles}
       ${system};
 
       & > *:not(:only-child):not(:last-child) {
-        margin-right: sm;
+        margin-right: ${theme.spaces.sm};
       }
 
       ${!disabled &&

--- a/packages/Button/tsconfig.json
+++ b/packages/Button/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/ButtonGroup/package.json
+++ b/packages/ButtonGroup/package.json
@@ -38,11 +38,10 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
+    "@welcome-ui/button": "^5.0.0-alpha.0",
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@welcome-ui/button": "^4.0.0-alpha.3",
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/ButtonGroup/styles.ts
+++ b/packages/ButtonGroup/styles.ts
@@ -1,4 +1,5 @@
-import styled, { system } from '@xstyled/styled-components'
+import styled from 'styled-components'
+import { system } from '@welcome-ui/system'
 
 export const ButtonGroup = styled.div`
   display: inline-flex;

--- a/packages/ButtonGroup/tsconfig.json
+++ b/packages/ButtonGroup/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Card/Cover.styles.ts
+++ b/packages/Card/Cover.styles.ts
@@ -1,8 +1,8 @@
-import styled, { system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Shape } from '@welcome-ui/shape'
 
-export const Cover = styled(Shape)`
-  ${th('cards.cover')};
-
-  ${system}
-`
+export const Cover = styled(Shape)(
+  ({ theme }) => css`
+    ${theme.cards.cover};
+  `
+)

--- a/packages/Card/package.json
+++ b/packages/Card/package.json
@@ -44,7 +44,6 @@
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Card/styles.ts
+++ b/packages/Card/styles.ts
@@ -1,18 +1,16 @@
-import styled, { system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 import { cardStyles } from '@welcome-ui/utils'
 
-export const Card = styled(Box)`
-  ${cardStyles};
-  ${th('cards.default')};
-  background-size: cover;
-  background-position: center;
-
-  ${system}
-`
+export const Card = styled(Box)(
+  ({ theme }) => css`
+    ${cardStyles};
+    ${theme.cards.default};
+    background-size: cover;
+    background-position: center;
+  `
+)
 
 export const Body = styled(Box)`
   padding: lg;
-
-  ${system}
 `

--- a/packages/Card/styles.ts
+++ b/packages/Card/styles.ts
@@ -12,5 +12,5 @@ export const Card = styled(Box)(
 )
 
 export const Body = styled(Box)`
-  padding: lg;
+  padding: ${({ theme }) => theme.spaces.lg};
 `

--- a/packages/Card/tsconfig.json
+++ b/packages/Card/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Checkbox/package.json
+++ b/packages/Checkbox/package.json
@@ -43,7 +43,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Checkbox/styles.ts
+++ b/packages/Checkbox/styles.ts
@@ -15,7 +15,7 @@ export const Checkbox = styled(ReakitCheckbox)<CheckboxProps>(
     padding: 0;
     order: ${$order};
     cursor: pointer;
-    transition: medium;
+    transition: ${theme.transitions.medium};
     overflow: hidden;
     ${system};
 
@@ -34,7 +34,7 @@ export const Checkbox = styled(ReakitCheckbox)<CheckboxProps>(
         width: 10;
         margin: auto;
         text-align: center;
-        transition: medium;
+        transition: ${theme.transitions.medium};
       }
     }
 

--- a/packages/Checkbox/styles.ts
+++ b/packages/Checkbox/styles.ts
@@ -1,21 +1,19 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Checkbox as ReakitCheckbox } from 'reakit/Checkbox'
-import { shouldForwardProp } from '@welcome-ui/system'
+import { system } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 
 import { CheckboxProps } from './index'
 
 /* /!\ WARNING /!\ Don't add style after pseudo selector, it won't apply because of the dynamic color injected in the fill of the content */
 
-export const Checkbox = styled(ReakitCheckbox).withConfig({
-  shouldForwardProp,
-})<CheckboxProps>(
-  ({ order = '-1', size, theme, variant }) => css`
+export const Checkbox = styled(ReakitCheckbox)<CheckboxProps>(
+  ({ $order = '-1', size, theme, variant }) => css`
     ${defaultFieldStyles({ size, variant })};
-    ${th('checkboxes.default')}
+    ${theme.checkboxes.default}
     position: relative;
     padding: 0;
-    order: ${order};
+    order: ${$order};
     cursor: pointer;
     transition: medium;
     overflow: hidden;
@@ -23,7 +21,7 @@ export const Checkbox = styled(ReakitCheckbox).withConfig({
 
     &[aria-checked='true'] {
       &:not([disabled]) {
-        ${th('checkboxes.checked')};
+        ${theme.checkboxes.checked};
       }
 
       &::after {
@@ -41,7 +39,7 @@ export const Checkbox = styled(ReakitCheckbox).withConfig({
     }
 
     &[disabled] {
-      ${th('checkboxes.disabled')}
+      ${theme.checkboxes.disabled}
     }
   `
 )

--- a/packages/Checkbox/tsconfig.json
+++ b/packages/Checkbox/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/ClearButton/package.json
+++ b/packages/ClearButton/package.json
@@ -43,7 +43,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/ClearButton/styles.ts
+++ b/packages/ClearButton/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css, keyframes, th } from '@xstyled/styled-components'
+import styled, { css, keyframes } from 'styled-components'
 import { Button } from '@welcome-ui/button'
 
 const fade = keyframes`
@@ -14,10 +14,12 @@ const fadeRule = css`
   ${fade}
 `
 
-export const ClearButton = styled(Button)`
-  pointer-events: auto;
-  animation: ${th('transitions.medium')};
-  animation-name: ${fadeRule};
-  width: 16;
-  height: 16;
-`
+export const ClearButton = styled(Button)(
+  ({ theme }) => css`
+    pointer-events: auto;
+    animation: ${theme.transitions.medium};
+    animation-name: ${fadeRule};
+    width: 16;
+    height: 16;
+  `
+)

--- a/packages/ClearButton/styles.ts
+++ b/packages/ClearButton/styles.ts
@@ -19,7 +19,7 @@ export const ClearButton = styled(Button)(
     pointer-events: auto;
     animation: ${theme.transitions.medium};
     animation-name: ${fadeRule};
-    width: 16;
-    height: 16;
+    width: 16px;
+    height: 16px;
   `
 )

--- a/packages/ClearButton/tsconfig.json
+++ b/packages/ClearButton/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/CloseButton/package.json
+++ b/packages/CloseButton/package.json
@@ -43,7 +43,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/CloseButton/styles.ts
+++ b/packages/CloseButton/styles.ts
@@ -1,9 +1,11 @@
-import styled, { th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Button } from '@welcome-ui/button'
 
-export const CloseButton = styled(Button)`
-  & > svg:only-child {
-    width: ${th('space.md')};
-    height: ${th('space.md')};
-  }
-`
+export const CloseButton = styled(Button)(
+  ({ theme }) => css`
+    & > svg:only-child {
+      width: ${theme.space.md};
+      height: ${theme.space.md};
+    }
+  `
+)

--- a/packages/CloseButton/tsconfig.json
+++ b/packages/CloseButton/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Copy/tsconfig.json
+++ b/packages/Copy/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Core/WuiProvider.tsx
+++ b/packages/Core/WuiProvider.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ThemeProvider } from '@xstyled/styled-components'
+import { ThemeProvider } from 'styled-components'
 import { HideFocusRingsRoot } from '@welcome-ui/utils'
 
 import { WuiTheme } from './theme/types'

--- a/packages/Core/package.json
+++ b/packages/Core/package.json
@@ -42,7 +42,6 @@
     "ramda": "^0.28.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Core/theme/accordions.ts
+++ b/packages/Core/theme/accordions.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/alerts.ts
+++ b/packages/Core/theme/alerts.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/alerts.ts
+++ b/packages/Core/theme/alerts.ts
@@ -11,7 +11,7 @@ type AttributesState = CSSObject
 export type ThemeAlerts = {
   sizes: Record<Sizes, { padding?: string }>
   default: CSSObject
-  title: Record<State, { color: string }>
+  title: Record<State, CSSObject>
 } & Record<State, AttributesState>
 
 export const getAlerts = (theme: WuiTheme): ThemeAlerts => {

--- a/packages/Core/theme/avatars.ts
+++ b/packages/Core/theme/avatars.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/badges.ts
+++ b/packages/Core/theme/badges.ts
@@ -1,8 +1,8 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 
-export type ThemeAccordions = {
+export type ThemeBadges = {
   default: CSSObject
   variants: {
     default: CSSObject
@@ -18,7 +18,7 @@ export type ThemeAccordions = {
   }
 }
 
-export const getBadges = (theme: WuiTheme): ThemeAccordions => {
+export const getBadges = (theme: WuiTheme): ThemeBadges => {
   const { colors, fonts, fontWeights, space, texts, toRem } = theme
 
   return {

--- a/packages/Core/theme/breadcrumbs.ts
+++ b/packages/Core/theme/breadcrumbs.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/buttons.ts
+++ b/packages/Core/theme/buttons.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 import { hexToRGBA } from '@welcome-ui/utils'
 
 import { ThemeFocus } from './focus'

--- a/packages/Core/theme/buttons.ts
+++ b/packages/Core/theme/buttons.ts
@@ -28,11 +28,11 @@ type Icon = 'only' | 'default'
 
 export type ThemeButtons = Record<Variant, CommonAttributesButton> &
   Record<'hover', Record<Variant, CommonAttributesButton>> &
-  Record<'focus', Record<Variant, unknown>> &
+  Record<'focus', Record<Variant, CSSObject>> &
   Record<'active', Record<Variant, CommonAttributesButton>> &
   Record<'disabled', CommonAttributesButton & { '&:focus': ReturnType<ThemeFocus> }> &
   Record<'sizes', Record<Size, SizeAttributesButton>> &
-  Record<'icon', Record<Icon, unknown>>
+  Record<'icon', Record<Icon, Record<Size, unknown>>>
 
 export const getButtons = (theme: WuiTheme): ThemeButtons => {
   const { colors, focus, fontWeights, radii, space, texts, toRem } = theme

--- a/packages/Core/theme/cards.ts
+++ b/packages/Core/theme/cards.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/checkboxes.ts
+++ b/packages/Core/theme/checkboxes.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/core.ts
+++ b/packages/Core/theme/core.ts
@@ -1,5 +1,4 @@
 import merge from 'ramda/src/mergeDeepRight'
-import { defaultTheme, rpxTransformers } from '@xstyled/styled-components'
 
 import { WuiTheme } from './types'
 import { colors } from './colors'
@@ -58,6 +57,7 @@ import { getToasts } from './toasts'
 import { getPaginations } from './paginations'
 import { getTabs } from './tabs'
 import { getBadges } from './badges'
+import { states } from './states'
 
 const DEFAULT_FONT_SIZE = 16
 const DEFAULT_FONT_FAMILY = 'Work Sans'
@@ -77,8 +77,6 @@ export const createTheme = (options: Record<string, unknown> = {}): WuiTheme => 
   } = options
 
   let theme = {} as WuiTheme
-
-  theme.transformers = { ...rpxTransformers }
 
   theme.toEm = px => `${px / DEFAULT_FONT_SIZE}em`
   theme.toRem = px => `${px / DEFAULT_FONT_SIZE}rem`
@@ -152,6 +150,7 @@ export const createTheme = (options: Record<string, unknown> = {}): WuiTheme => 
   theme.swipers = getSwipers(theme)
   theme.labels = getLabels(theme)
   theme.popovers = getPopovers(theme)
+
   // fields
   theme.defaultFields = getDefaultFields(theme)
   theme.hints = getHints(theme)
@@ -165,7 +164,7 @@ export const createTheme = (options: Record<string, unknown> = {}): WuiTheme => 
   theme.sliders = getSliders(theme)
 
   // states
-  theme.states = defaultTheme.states
+  theme.states = states
 
   theme = merge(theme, rest) as WuiTheme
 

--- a/packages/Core/theme/core.ts
+++ b/packages/Core/theme/core.ts
@@ -104,7 +104,9 @@ export const createTheme = (options: Record<string, unknown> = {}): WuiTheme => 
 
   theme.screens = screens
 
+  // todo remove theme.space
   theme.space = getSpace(theme)
+  theme.spaces = getSpace(theme)
 
   theme.inset = theme.space
 

--- a/packages/Core/theme/core.ts
+++ b/packages/Core/theme/core.ts
@@ -100,7 +100,9 @@ export const createTheme = (options: Record<string, unknown> = {}): WuiTheme => 
 
   theme.borderWidths = borderWidths
 
+  // todo remove theme.screens
   theme.screens = screens
+  theme.breakpoints = screens
 
   // todo remove theme.space
   theme.space = getSpace(theme)

--- a/packages/Core/theme/dateTimePickerCommon.ts
+++ b/packages/Core/theme/dateTimePickerCommon.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/defaultCards.ts
+++ b/packages/Core/theme/defaultCards.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { ThemeBorderWidths } from './borders'
 import { ThemeColors } from './colors'

--- a/packages/Core/theme/defaultFields.ts
+++ b/packages/Core/theme/defaultFields.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 import { Size } from '@welcome-ui/utils'
 
 import { ThemeFocus } from './focus'

--- a/packages/Core/theme/drawers.ts
+++ b/packages/Core/theme/drawers.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/dropdownMenu.ts
+++ b/packages/Core/theme/dropdownMenu.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/filedrops.ts
+++ b/packages/Core/theme/filedrops.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/filedrops.ts
+++ b/packages/Core/theme/filedrops.ts
@@ -4,8 +4,8 @@ import { WuiTheme } from './types'
 
 export type ThemeFiledrops = {
   default: CSSObject
-  dragAccept: Record<string, unknown>
-  dragReject: Record<string, unknown>
+  dragAccept: CSSObject
+  dragReject: CSSObject
   disabled: CSSObject
 }
 

--- a/packages/Core/theme/focus.ts
+++ b/packages/Core/theme/focus.ts
@@ -1,5 +1,5 @@
+import { CSSObject } from 'styled-components'
 import { hexToRGBA } from '@welcome-ui/utils'
-import { CSSObject } from '@xstyled/styled-components'
 
 import { ThemeColors } from './colors'
 

--- a/packages/Core/theme/hints.ts
+++ b/packages/Core/theme/hints.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/labels.ts
+++ b/packages/Core/theme/labels.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/links.ts
+++ b/packages/Core/theme/links.ts
@@ -1,5 +1,4 @@
-import { css } from '@xstyled/styled-components'
-import { CSSObject } from '@xstyled/styled-components'
+import { css, CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/modals.ts
+++ b/packages/Core/theme/modals.ts
@@ -7,12 +7,12 @@ type Sizes = 'xs' | 'sm' | 'md' | 'lg' | 'auto'
 export type ThemeModals = {
   backdrop: CSSObject
   default: CSSObject
-  header: CSSObject
+  header: CSSObject & { subtitle: CSSObject }
   content: CSSObject
   footer: CSSObject
   gutter: string
   sizes: Record<Sizes, { width?: string }>
-  cover: Record<string, unknown>
+  cover: CSSObject
 }
 
 export const getModals = (theme: WuiTheme): ThemeModals => {
@@ -33,7 +33,7 @@ export const getModals = (theme: WuiTheme): ThemeModals => {
       subtitle: {
         color: colors['dark-700'],
         variant: 'sm',
-        margin: 0,
+        margin: '0',
       },
     },
     content: {

--- a/packages/Core/theme/modals.ts
+++ b/packages/Core/theme/modals.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/paginations.ts
+++ b/packages/Core/theme/paginations.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/popovers.ts
+++ b/packages/Core/theme/popovers.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/radios.ts
+++ b/packages/Core/theme/radios.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/radiosTabs.ts
+++ b/packages/Core/theme/radiosTabs.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/selection.ts
+++ b/packages/Core/theme/selection.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/sliders.ts
+++ b/packages/Core/theme/sliders.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/space.ts
+++ b/packages/Core/theme/space.ts
@@ -13,8 +13,8 @@ export type ThemeSpace = {
   '5xl': string
   '6xl': string
   '7xl': string
-  [key: string]: string
-  [key: number]: string
+  // [key: string]: string
+  // [key: number]: string
 }
 
 export const getSpace = (theme: WuiTheme): ThemeSpace => {

--- a/packages/Core/theme/states.ts
+++ b/packages/Core/theme/states.ts
@@ -1,0 +1,16 @@
+export const states = {
+  first: '&:first-child',
+  last: '&:last-child',
+  odd: '&:odd',
+  even: '&:even',
+  visited: '&:visited',
+  checked: '&:checked',
+  focusWithin: '&:focus-within',
+  hover: '&:hover',
+  focus: '&:focus',
+  active: '&:active',
+  disabled: '&:disabled, &[aria-disabled=true]',
+  placeholder: '&::placeholder',
+}
+
+export type ThemeStates = typeof states

--- a/packages/Core/theme/swipers.ts
+++ b/packages/Core/theme/swipers.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/tables.ts
+++ b/packages/Core/theme/tables.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/tabs.ts
+++ b/packages/Core/theme/tabs.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/tags.ts
+++ b/packages/Core/theme/tags.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/textareas.ts
+++ b/packages/Core/theme/textareas.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/toasts.ts
+++ b/packages/Core/theme/toasts.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 import { getTexts } from './typography'

--- a/packages/Core/theme/toggles.ts
+++ b/packages/Core/theme/toggles.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/tooltips.ts
+++ b/packages/Core/theme/tooltips.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/theme/transitions.ts
+++ b/packages/Core/theme/transitions.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 export type ThemeTimingFunction = {
   primary: CSSObject['transition-timing-function']

--- a/packages/Core/theme/types.ts
+++ b/packages/Core/theme/types.ts
@@ -74,6 +74,7 @@ export interface WuiTheme {
   letterSpacings: ThemeLetterSpacings
   fonts: ThemeFonts
   screens: ThemeScreens
+  breakpoints: ThemeScreens
   space: ThemeSpace
   spaces: ThemeSpace
   inset: ThemeSpace

--- a/packages/Core/theme/types.ts
+++ b/packages/Core/theme/types.ts
@@ -1,9 +1,4 @@
-import {
-  CSSObject,
-  CSSScalar,
-  ITheme as StyledComponentDefaultTheme,
-  DefaultTheme as XStyledDefaultTheme,
-} from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { ThemeAccordions } from './accordions'
 import { ThemeAlerts } from './alerts'
@@ -53,36 +48,17 @@ import {
   ThemeLetterSpacings,
   ThemeLineHeights,
   ThemeTexts,
+  ThemeTextsFontColors,
   ThemeTextsFontFamily,
   ThemeTextsFontWeights,
   ThemeTextsTextTransform,
 } from './typography'
 import { ThemeUnderline } from './underline'
+import { ThemeSliders } from './sliders'
+import { ThemeBadges } from './badges'
+import { ThemeStates } from './states'
 
-type OverrideKeys =
-  | 'colors'
-  | 'radii'
-  | 'borderWidths'
-  | 'fontSizes'
-  | 'lineHeights'
-  | 'fontWeights'
-  | 'letterSpacings'
-  | 'fonts'
-  | 'sizes'
-  | 'screens'
-  | 'space'
-  | 'spaces'
-  | 'shadows'
-  | 'texts'
-
-type XStyledTheme = Omit<XStyledDefaultTheme, OverrideKeys>
-type StyledComponentsTheme = Omit<StyledComponentDefaultTheme, OverrideKeys>
-
-export interface WuiTheme extends XStyledTheme, StyledComponentsTheme {
-  transformers: {
-    px: (value: CSSScalar) => CSSScalar
-    border: (value: CSSScalar) => CSSScalar
-  }
+export interface WuiTheme {
   toEm: (int: number) => string
   toRem: (int?: number) => string
   toPx: (int?: number) => string
@@ -110,6 +86,7 @@ export interface WuiTheme extends XStyledTheme, StyledComponentsTheme {
   focus: ThemeFocus
   defaultCards: ThemeDefaultCards
   textsFontWeights: ThemeTextsFontWeights
+  textsFontColors: ThemeTextsFontColors
   textsFontFamily: ThemeTextsFontFamily
   textsTextTransform: ThemeTextsTextTransform
   alerts: ThemeAlerts
@@ -120,6 +97,7 @@ export interface WuiTheme extends XStyledTheme, StyledComponentsTheme {
   paginations: ThemePaginations
   tabs: ThemeTabs
   tags: ThemeTags
+  badges: ThemeBadges
   texts: ThemeTexts
   tooltips: CSSObject
   links: ThemeLinks
@@ -134,6 +112,8 @@ export interface WuiTheme extends XStyledTheme, StyledComponentsTheme {
   labels: ThemeLabels
   popovers: ThemePopovers
   sizes: ThemeSizes
+  sliders: ThemeSliders
+  states: ThemeStates
   // fields
   defaultFields: ThemeDefaultFields
   hints: ThemeHints

--- a/packages/Core/theme/types.ts
+++ b/packages/Core/theme/types.ts
@@ -71,6 +71,7 @@ type OverrideKeys =
   | 'sizes'
   | 'screens'
   | 'space'
+  | 'spaces'
   | 'shadows'
   | 'texts'
 
@@ -98,6 +99,7 @@ export interface WuiTheme extends XStyledTheme, StyledComponentsTheme {
   fonts: ThemeFonts
   screens: ThemeScreens
   space: ThemeSpace
+  spaces: ThemeSpace
   inset: ThemeSpace
   icons: ThemeIcons
   radii: ThemeRadii

--- a/packages/Core/theme/typography.ts
+++ b/packages/Core/theme/typography.ts
@@ -1,4 +1,4 @@
-import { CSSObject } from '@xstyled/styled-components'
+import { CSSObject } from 'styled-components'
 
 import { WuiTheme } from './types'
 

--- a/packages/Core/tsconfig.json
+++ b/packages/Core/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["index.ts", "../../types"]
 }

--- a/packages/Core/utils/base.ts
+++ b/packages/Core/utils/base.ts
@@ -1,4 +1,4 @@
-import { createGlobalStyle, css, th } from '@xstyled/styled-components'
+import { createGlobalStyle, css } from 'styled-components'
 
 import { fonts } from './font'
 import { normalizeStyle, resetStyles } from './reset'
@@ -31,7 +31,7 @@ function baseFonts() {
 }
 
 export const GlobalStyle = createGlobalStyle<{ useReset?: boolean }>(
-  ({ useReset }) => css`
+  ({ theme, useReset }) => css`
     ${normalizeStyle};
     ${workSans}
     ${fonts()};
@@ -43,7 +43,7 @@ export const GlobalStyle = createGlobalStyle<{ useReset?: boolean }>(
     }
 
     ::selection {
-      ${th('selection')};
+      ${theme.selection};
     }
 
     /* for firefox */

--- a/packages/Core/utils/font.ts
+++ b/packages/Core/utils/font.ts
@@ -1,4 +1,4 @@
-import { css } from '@xstyled/styled-components'
+import { css } from 'styled-components'
 
 import { WuiTheme } from '../theme/types'
 

--- a/packages/Core/utils/reset.ts
+++ b/packages/Core/utils/reset.ts
@@ -1,4 +1,4 @@
-import { css } from '@xstyled/styled-components'
+import { css } from 'styled-components'
 
 /* stylelint-disable */
 export const resetStyles = css`

--- a/packages/Core/utils/work-sans.ts
+++ b/packages/Core/utils/work-sans.ts
@@ -1,4 +1,4 @@
-import { css } from '@xstyled/styled-components'
+import { css } from 'styled-components'
 
 /* Taken from https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600&display=swap */
 export const workSans = css`

--- a/packages/DatePicker/package.json
+++ b/packages/DatePicker/package.json
@@ -45,7 +45,6 @@
     "react-datepicker": "^4.7.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/DatePicker/tsconfig.json
+++ b/packages/DatePicker/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/DateTimePicker/package.json
+++ b/packages/DateTimePicker/package.json
@@ -51,7 +51,6 @@
     "react-datepicker": "^4.7.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/DateTimePicker/styles.ts
+++ b/packages/DateTimePicker/styles.ts
@@ -1,4 +1,5 @@
-import styled, { css, system } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { system } from '@welcome-ui/system'
 import { StyledDatePicker, StyledTimePicker } from '@welcome-ui/date-time-picker-common'
 
 const focusStyles = css`

--- a/packages/DateTimePicker/tsconfig.json
+++ b/packages/DateTimePicker/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/DateTimePickerCommon/CustomPopper.tsx
+++ b/packages/DateTimePickerCommon/CustomPopper.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import styled, { css, CSSObject, th } from '@xstyled/styled-components'
+import styled, { css, CSSObject } from 'styled-components'
+import { system } from '@welcome-ui/system'
 import { cardStyles } from '@welcome-ui/utils'
 
 import { datePickerStyles } from './datePickerStyles'
@@ -18,8 +19,8 @@ export const CustomPopper = ({
   return <StyledCustomPopper popperStyles={popperProps}>{children}</StyledCustomPopper>
 }
 
-const StyledCustomPopper = styled.div(
-  ({ popperStyles }: { popperStyles: CSSObject }) => css`
+const StyledCustomPopper = styled.div<{ popperStyles: CSSObject }>(
+  ({ popperStyles, theme }) => css`
     ${datePickerStyles};
     .react-datepicker-popper {
       ${popperStyles};
@@ -87,7 +88,7 @@ const StyledCustomPopper = styled.div(
     }
 
     .react-datepicker__day--today {
-      ${th('dateTimePickerCommon.item.today')};
+      ${theme.dateTimePickerCommon.item.today};
     }
 
     .react-datepicker__day:hover,
@@ -129,9 +130,9 @@ const StyledCustomPopper = styled.div(
     .react-datepicker__month-text--selected,
     .react-datepicker__month-text--in-selecting-range,
     .react-datepicker__month-text--in-range {
-      ${th('dateTimePickerCommon.item.selected')};
+      ${theme.dateTimePickerCommon.item.selected};
       &:hover {
-        ${th('dateTimePickerCommon.item.selected')};
+        ${theme.dateTimePickerCommon.item.selected};
       }
     }
 
@@ -146,5 +147,7 @@ const StyledCustomPopper = styled.div(
     .react-datepicker-year-header {
       font-weight: medium;
     }
+
+    ${system};
   `
 )

--- a/packages/DateTimePickerCommon/datePickerStyles.ts
+++ b/packages/DateTimePickerCommon/datePickerStyles.ts
@@ -1,4 +1,4 @@
-import { css } from '@xstyled/styled-components'
+import { css } from 'styled-components'
 
 export const datePickerStyles = css`
   .react-datepicker-popper[data-placement^='bottom'] .react-datepicker__triangle,

--- a/packages/DateTimePickerCommon/package.json
+++ b/packages/DateTimePickerCommon/package.json
@@ -51,7 +51,6 @@
     "react-datepicker": "^4.7.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/DateTimePickerCommon/styles.ts
+++ b/packages/DateTimePickerCommon/styles.ts
@@ -1,10 +1,10 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css, DefaultTheme } from 'styled-components'
 import ReactDatePicker, { ReactDatePickerProps } from 'react-datepicker'
 import { IconWrapper } from '@welcome-ui/field'
 import { StyledIcon } from '@welcome-ui/icon'
 import { StyledButton } from '@welcome-ui/button'
 import { StyledClearButton } from '@welcome-ui/clear-button'
-import { shouldForwardProp } from '@welcome-ui/system'
+import { system } from '@welcome-ui/system'
 import { StyledSelect } from '@welcome-ui/select'
 import { defaultFieldStyles, DefaultFieldStylesProps } from '@welcome-ui/utils'
 
@@ -27,17 +27,21 @@ export const StyledTimePicker = styled(ReactDatePicker)<DefaultFieldStylesProps>
   `
 )
 
-const iconPlacementStyles = (placement: IconPlacement, size: DefaultFieldStylesProps['size']) => {
+const iconPlacementStyles = (
+  placement: IconPlacement,
+  size: DefaultFieldStylesProps['size'],
+  theme: DefaultTheme
+) => {
   if (placement === 'right') {
     return css`
       ${StyledDatePicker}, ${StyledTimePicker} {
-        padding-right: ${`calc(1.5 * ${th(`defaultFields.sizes.${size}.height`)})`};
+        padding-right: ${`calc(1.5 * ${theme.defaultFields.sizes[size].height}`};
       }
 
       ${IconWrapper} {
         &:not(:last-child) {
-          right: ${th(`defaultFields.sizes.${size}.height`)};
-          width: ${`calc(0.5 * ${th(`defaultFields.sizes.${size}.height`)})`};
+          right: ${theme.defaultFields.sizes[size].height};
+          width: ${`calc(0.5 * ${theme.defaultFields.sizes[size].height}`};
           justify-content: flex-end;
         }
 
@@ -50,38 +54,31 @@ const iconPlacementStyles = (placement: IconPlacement, size: DefaultFieldStylesP
   if (placement === 'left') {
     return css`
       ${StyledDatePicker}, ${StyledTimePicker} {
-        padding-left: ${th(`defaultFields.sizes.${size}.height`)};
+        padding-left: ${theme.defaultFields.sizes[size].height};
       }
     `
   }
 }
 
-export const CustomInput = styled('div').withConfig({ shouldForwardProp })(
-  ({
-    focused,
-    icon,
-    iconPlacement,
-    size,
-  }: {
-    focused: Focused
-    icon: Icon
-    iconPlacement: IconPlacement
-    size: DefaultFieldStylesProps['size']
-  }) => {
-    return css`
-      position: relative;
-      ${StyledDatePicker}, ${StyledTimePicker} {
-        padding-right: ${th(`defaultFields.sizes.${size}.height`)};
-      }
+export const CustomInput = styled('div')<{
+  focused: Focused
+  icon: Icon
+  iconPlacement: IconPlacement
+  size: DefaultFieldStylesProps['size']
+}>(({ focused, icon, iconPlacement, size, theme }) => {
+  return css`
+    position: relative;
+    ${StyledDatePicker}, ${StyledTimePicker} {
+      padding-right: ${theme.defaultFields.sizes[size].height};
+    }
 
-      ${icon && iconPlacementStyles(iconPlacement, size)};
+    ${icon && iconPlacementStyles(iconPlacement, size, theme)};
 
-      ${StyledClearButton} {
-        z-index: ${focused ? 1 : null};
-      }
-    `
-  }
-)
+    ${StyledClearButton} {
+      z-index: ${focused ? 1 : null};
+    }
+  `
+})
 
 export const CustomHeader = styled.div`
   display: flex;

--- a/packages/DateTimePickerCommon/tsconfig.json
+++ b/packages/DateTimePickerCommon/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Drawer/index.tsx
+++ b/packages/Drawer/index.tsx
@@ -11,10 +11,9 @@ import {
 } from 'reakit/Dialog'
 import { SealedInitialState } from 'reakit-utils/ts/useSealedState'
 import { Box, BoxProps } from '@welcome-ui/box'
-import { CloseButton, CloseButtonProps } from '@welcome-ui/close-button'
+import { CloseButtonProps } from '@welcome-ui/close-button'
 import { Text, TextProps } from '@welcome-ui/text'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
-import { useTheme } from 'styled-components'
 
 import * as S from './styles'
 
@@ -91,7 +90,6 @@ export type CloseOptions = { hide: VoidFunction }
 export type CloseProps = CloseOptions & CloseButtonProps
 
 export const Close: React.FC<CloseProps> = ({ $zIndex = '2', hide, ...props }) => {
-  const { drawers } = useTheme()
   return (
     <Box
       $display="flex"
@@ -102,15 +100,14 @@ export const Close: React.FC<CloseProps> = ({ $zIndex = '2', hide, ...props }) =
       $w="auto"
       $zIndex={$zIndex}
     >
-      <CloseButton {...drawers.closeButton} onClick={hide} {...props} />
+      <S.CloseButton onClick={hide} {...props} />
     </Box>
   )
 }
 
 export const Title: React.FC<TextProps> = ({ $zIndex = '1', children, ...props }) => {
-  const { drawers } = useTheme()
   return (
-    <Box
+    <S.Title
       $alignItems="center"
       $display="flex"
       $justifyContent="space-between"
@@ -118,28 +115,24 @@ export const Title: React.FC<TextProps> = ({ $zIndex = '1', children, ...props }
       $top={{ xs: 0, md: 'auto' }}
       $w="100%"
       $zIndex={$zIndex}
-      {...drawers.title}
       {...props}
     >
       <Text $m="0" $w="100%" variant="h3">
         {children}
       </Text>
-    </Box>
+    </S.Title>
   )
 }
 
 export const Content: React.FC<BoxProps> = props => {
-  const { drawers } = useTheme()
-  return <Box {...drawers.content} $flex="1" $overflowY={{ md: 'auto' }} {...props} />
+  return <S.Content $flex="1" $overflowY={{ md: 'auto' }} {...props} />
 }
 
 export const Footer: React.FC<BoxProps> = props => {
-  const { drawers } = useTheme()
   return (
-    <Box
+    <S.Footer
       $bottom={{ xs: '0', md: 'auto' }}
       $position={{ xs: 'sticky', md: 'static' }}
-      {...drawers.footer}
       $w="100%"
       {...props}
     />

--- a/packages/Drawer/index.tsx
+++ b/packages/Drawer/index.tsx
@@ -14,12 +14,13 @@ import { Box, BoxProps } from '@welcome-ui/box'
 import { CloseButton, CloseButtonProps } from '@welcome-ui/close-button'
 import { Text, TextProps } from '@welcome-ui/text'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
-import { useTheme } from '@xstyled/styled-components'
+import { useTheme } from 'styled-components'
 
 import * as S from './styles'
 
 export type Placement = 'top' | 'right' | 'bottom' | 'left'
-export type Size = 'sm' | 'md' | 'lg' | 'auto' | string
+export type DrawerSize = 'sm' | 'md' | 'lg'
+export type Size = DrawerSize | 'auto' | string
 
 export interface DrawerOptions {
   placement?: Placement
@@ -89,38 +90,38 @@ export const DrawerBackdrop: React.FC<DrawerBackdropProps> = ({
 export type CloseOptions = { hide: VoidFunction }
 export type CloseProps = CloseOptions & CloseButtonProps
 
-export const Close: React.FC<CloseProps> = ({ hide, zIndex = '2', ...props }) => {
+export const Close: React.FC<CloseProps> = ({ $zIndex = '2', hide, ...props }) => {
   const { drawers } = useTheme()
   return (
     <Box
-      display="flex"
-      h="0"
-      justifyContent="flex-end"
-      position="sticky"
-      top="0"
-      w="auto"
-      zIndex={zIndex}
+      $display="flex"
+      $h="0"
+      $justifyContent="flex-end"
+      $position="sticky"
+      $top="0"
+      $w="auto"
+      $zIndex={$zIndex}
     >
       <CloseButton {...drawers.closeButton} onClick={hide} {...props} />
     </Box>
   )
 }
 
-export const Title: React.FC<TextProps> = ({ children, zIndex = '1', ...props }) => {
+export const Title: React.FC<TextProps> = ({ $zIndex = '1', children, ...props }) => {
   const { drawers } = useTheme()
   return (
     <Box
-      alignItems="center"
-      display="flex"
-      justifyContent="space-between"
-      position={{ xs: 'sticky', md: 'static' }}
-      top={{ xs: 0, md: 'auto' }}
-      w="100%"
-      zIndex={zIndex}
+      $alignItems="center"
+      $display="flex"
+      $justifyContent="space-between"
+      $position={{ xs: 'sticky', md: 'static' }}
+      $top={{ xs: 0, md: 'auto' }}
+      $w="100%"
+      $zIndex={$zIndex}
       {...drawers.title}
       {...props}
     >
-      <Text m="0" variant="h3" w="100%">
+      <Text $m="0" $w="100%" variant="h3">
         {children}
       </Text>
     </Box>
@@ -129,17 +130,17 @@ export const Title: React.FC<TextProps> = ({ children, zIndex = '1', ...props })
 
 export const Content: React.FC<BoxProps> = props => {
   const { drawers } = useTheme()
-  return <Box {...drawers.content} flex="1" overflowY={{ md: 'auto' }} {...props} />
+  return <Box {...drawers.content} $flex="1" $overflowY={{ md: 'auto' }} {...props} />
 }
 
 export const Footer: React.FC<BoxProps> = props => {
   const { drawers } = useTheme()
   return (
     <Box
-      bottom={{ xs: 0, md: 'auto' }}
-      position={{ xs: 'sticky', md: 'static' }}
+      $bottom={{ xs: '0', md: 'auto' }}
+      $position={{ xs: 'sticky', md: 'static' }}
       {...drawers.footer}
-      w="100%"
+      $w="100%"
       {...props}
     />
   )

--- a/packages/Drawer/package.json
+++ b/packages/Drawer/package.json
@@ -46,7 +46,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Drawer/styles.ts
+++ b/packages/Drawer/styles.ts
@@ -1,9 +1,9 @@
-import styled, { css, th } from '@xstyled/styled-components'
+import styled, { css, DefaultTheme } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 import { cardStyles } from '@welcome-ui/utils'
 import { DialogBackdrop } from 'reakit/Dialog'
 
-import { DrawerOptions, Placement, Size } from '.'
+import { DrawerOptions, DrawerSize, Placement, Size } from '.'
 
 type DrawerWrapperProps = {
   hideOnClickOutside: boolean
@@ -14,8 +14,8 @@ type DrawerWrapperProps = {
 export const Backdrop = styled(DialogBackdrop).withConfig({
   shouldForwardProp: prop => !['hideOnClickOutside'].includes(prop),
 })<DrawerWrapperProps>(
-  ({ hideOnClickOutside }) => css`
-    ${th('drawers.backdrop')};
+  ({ hideOnClickOutside, theme }) => css`
+    ${theme.drawers.backdrop};
     display: flex;
     align-items: center;
     justify-content: center;
@@ -25,7 +25,7 @@ export const Backdrop = styled(DialogBackdrop).withConfig({
     left: 0;
     bottom: 0;
     opacity: 0;
-    transition: fast;
+    transition: ${theme.transitions.fast};
     ${hideOnClickOutside &&
     css`
       cursor: pointer;
@@ -73,12 +73,12 @@ const getPlacementStyle = (placement: Placement) => {
 }
 
 const SIZES = ['sm', 'md', 'lg']
-const getSizeStyle = (size: Size, placement: Placement) => {
+const getSizeStyle = (size: Size, placement: Placement, theme: DefaultTheme) => {
   switch (placement) {
     case 'top':
     case 'bottom':
       if (SIZES.includes(size)) {
-        return th(`drawers.sizes.vertical.${size}`)
+        return theme.drawers.sizes.vertical[size as DrawerSize]
       }
       return {
         height: size,
@@ -86,7 +86,7 @@ const getSizeStyle = (size: Size, placement: Placement) => {
     case 'right':
     case 'left':
       if (SIZES.includes(size)) {
-        return th(`drawers.sizes.horizontal.${size}`)
+        return theme.drawers.sizes.horizontal[size as DrawerSize]
       }
       return {
         width: size,
@@ -95,11 +95,11 @@ const getSizeStyle = (size: Size, placement: Placement) => {
 }
 
 export const Drawer = styled(Box)<DrawerOptions>(
-  ({ placement, size }) => css`
+  ({ placement, size, theme }) => css`
     ${cardStyles};
-    ${th('drawers.default')};
+    ${theme.drawers.default};
     ${getPlacementStyle(placement)}
-    ${getSizeStyle(size, placement)}
+    ${getSizeStyle(size, placement, theme)}
     position: absolute;
     display: flex;
     flex-direction: column;
@@ -158,10 +158,10 @@ const getBackdropWrapperPlacementStyle = (placement: Placement) => {
 export const NoBackdropWrapper = styled(DialogBackdrop).withConfig({
   shouldForwardProp: prop => !['hideOnClickOutside'].includes(prop),
 })<DrawerWrapperProps>(
-  ({ hideOnClickOutside, placement, size }) => css`
-    ${th('drawers.backdrop')};
+  ({ hideOnClickOutside, placement, size, theme }) => css`
+    ${theme.drawers.backdrop};
     ${getBackdropWrapperPlacementStyle(placement)}
-    ${getSizeStyle(size, placement)}
+    ${getSizeStyle(size, placement, theme)}
     background-color: transparent;
     display: flex;
     align-items: center;
@@ -170,7 +170,7 @@ export const NoBackdropWrapper = styled(DialogBackdrop).withConfig({
     max-width: 100%;
     max-height: 100%;
     opacity: 0;
-    transition: fast;
+    transition: ${theme.transitions.fast};
     ${hideOnClickOutside &&
     css`
       cursor: pointer;

--- a/packages/Drawer/styles.ts
+++ b/packages/Drawer/styles.ts
@@ -1,6 +1,7 @@
 import styled, { css, DefaultTheme } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 import { cardStyles } from '@welcome-ui/utils'
+import { CloseButton as WUICloseButton } from '@welcome-ui/close-button'
 import { DialogBackdrop } from 'reakit/Dialog'
 
 import { DrawerOptions, DrawerSize, Placement, Size } from '.'
@@ -180,5 +181,29 @@ export const NoBackdropWrapper = styled(DialogBackdrop).withConfig({
     &[data-enter] {
       opacity: 1;
     }
+  `
+)
+
+export const Title = styled(Box)(
+  ({ theme }) => css`
+    ${theme.drawers.title}
+  `
+)
+
+export const Content = styled(Box)(
+  ({ theme }) => css`
+    ${theme.drawers.content}
+  `
+)
+
+export const Footer = styled(Box)(
+  ({ theme }) => css`
+    ${theme.drawers.footer}
+  `
+)
+
+export const CloseButton = styled(WUICloseButton)(
+  ({ theme }) => css`
+    ${theme.drawers.closeButton}
   `
 )

--- a/packages/Drawer/styles.ts
+++ b/packages/Drawer/styles.ts
@@ -106,7 +106,7 @@ export const Drawer = styled(Box)<DrawerOptions>(
     flex-direction: column;
     max-width: 100%;
     max-height: 100%;
-    transition: medium;
+    transition: ${theme.transitions.medium};
     cursor: auto;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
@@ -122,7 +122,7 @@ export const Drawer = styled(Box)<DrawerOptions>(
     }
 
     &[data-leave] {
-      transition: fast;
+      transition: ${theme.transitions.fast};
     }
   `
 )

--- a/packages/Drawer/tsconfig.json
+++ b/packages/Drawer/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/DropdownMenu/Arrow.styled.ts
+++ b/packages/DropdownMenu/Arrow.styled.ts
@@ -1,18 +1,17 @@
-import styled, { css, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { MenuArrow } from 'reakit/Menu'
+import { system } from '@welcome-ui/system'
 
-export const Arrow = styled(MenuArrow)`
-  display: flex;
-  z-index: 2;
-  color: ${th('defaultCards.backgroundColor')};
+export const Arrow = styled(MenuArrow)(
+  ({ theme }) => css`
+    display: flex;
+    z-index: 2;
+    color: ${theme.defaultCards.backgroundColor};
 
-  #stroke {
-    color: ${th('defaultCards.borderColor')};
-  }
-`
+    #stroke {
+      color: ${theme.defaultCards.borderColor};
+    }
 
-export const ArrowItem = styled.svgBox<{ $transform: string }>(
-  ({ $transform }) => css`
-    transform: ${$transform};
+    ${system}
   `
 )

--- a/packages/DropdownMenu/Arrow.tsx
+++ b/packages/DropdownMenu/Arrow.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { MenuArrowOptions } from 'reakit/Menu'
+import { Box } from '@welcome-ui/box'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 
 import * as S from './Arrow.styled'
@@ -20,16 +21,17 @@ export const Arrow = forwardRef<'div', ArrowProps>((props, ref) => {
 
   return (
     <S.Arrow {...props} ref={ref}>
-      <S.ArrowItem
+      <Box
+        $h="30px"
         $transform={transform}
-        h={30}
+        $w="30px"
+        as="svg"
         viewBox="0 0 30 30"
-        w={30}
         xmlns="http://www.w3.org/2000/svg"
       >
         <path d="M7 30L15 22L23 30H7Z" fill="currentColor" fillRule="nonzero" id="stroke" />
         <path d="M8 30L15 23L22 30H8Z" fill="currentColor" fillRule="nonzero" />
-      </S.ArrowItem>
+      </Box>
     </S.Arrow>
   )
 })

--- a/packages/DropdownMenu/Item.styled.ts
+++ b/packages/DropdownMenu/Item.styled.ts
@@ -1,24 +1,27 @@
-import styled, { system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { system, WuiProps } from '@welcome-ui/system'
 
-export const Item = styled.button`
-  ${th('dropdownMenu.item')};
-  display: flex;
-  align-items: center;
-  width: 100%;
-  border: 0;
-  appearance: none;
-  cursor: pointer;
-  transition: medium;
-  text-decoration: none;
-
-  &[type='button'] {
+export const Item = styled.button<WuiProps>(
+  ({ theme }) => css`
+    ${theme.dropdownMenu.item};
+    display: flex;
+    align-items: center;
+    width: 100%;
+    border: 0;
     appearance: none;
-  }
+    cursor: pointer;
+    transition: medium;
+    text-decoration: none;
 
-  &:hover,
-  &:focus {
-    outline: none !important; /* important for firefox */
-  }
+    &[type='button'] {
+      appearance: none;
+    }
 
-  ${system}
-`
+    &:hover,
+    &:focus {
+      outline: none !important; /* important for firefox */
+    }
+
+    ${system}
+  `
+)

--- a/packages/DropdownMenu/Item.styled.ts
+++ b/packages/DropdownMenu/Item.styled.ts
@@ -10,7 +10,7 @@ export const Item = styled.button<WuiProps>(
     border: 0;
     appearance: none;
     cursor: pointer;
-    transition: medium;
+    transition: ${theme.transitions.medium};
     text-decoration: none;
 
     &[type='button'] {

--- a/packages/DropdownMenu/Separator.styled.ts
+++ b/packages/DropdownMenu/Separator.styled.ts
@@ -1,8 +1,12 @@
-import styled, { th } from '@xstyled/styled-components'
+import styled, { css } from '@xstyled/styled-components'
+import { system } from '@welcome-ui/system'
 
-export const Separator = styled.hr`
-  ${th('dropdownMenu.separator')};
-  border: 0;
-  height: 1px;
-  margin: 0;
-`
+export const Separator = styled.hr(
+  ({ theme }) => css`
+    ${theme.dropdownMenu.separator};
+    border: 0;
+    height: 1px;
+    margin: 0;
+    ${system}
+  `
+)

--- a/packages/DropdownMenu/Separator.styled.ts
+++ b/packages/DropdownMenu/Separator.styled.ts
@@ -1,4 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { system } from '@welcome-ui/system'
 
 export const Separator = styled.hr(

--- a/packages/DropdownMenu/package.json
+++ b/packages/DropdownMenu/package.json
@@ -44,7 +44,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/DropdownMenu/styles.ts
+++ b/packages/DropdownMenu/styles.ts
@@ -1,20 +1,23 @@
-import styled, { system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { system } from '@welcome-ui/system'
 import { cardStyles } from '@welcome-ui/utils'
 import { Box } from '@welcome-ui/box'
 
-export const Inner = styled(Box)`
-  ${cardStyles};
-  ${th('dropdownMenu.inner')};
-  z-index: 1;
-  transition: opacity 200ms;
+export const Inner = styled(Box)(
+  ({ theme }) => css`
+    ${cardStyles};
+    ${theme.dropdownMenu.inner};
+    z-index: 1;
+    transition: opacity 200ms;
 
-  &:focus {
-    outline: none !important; /* important for firefox */
-  }
+    &:focus {
+      outline: none !important; /* important for firefox */
+    }
 
-  &[hidden] {
-    display: none;
-  }
+    &[hidden] {
+      display: none;
+    }
 
-  ${system}
-`
+    ${system}
+  `
+)

--- a/packages/DropdownMenu/tsconfig.json
+++ b/packages/DropdownMenu/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Emoji/tsconfig.json
+++ b/packages/Emoji/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/EmojiPicker/List.tsx
+++ b/packages/EmojiPicker/List.tsx
@@ -236,7 +236,7 @@ export const List: React.FC<ListProps> = ({
 
   return (
     <Box ref={wrapperRef}>
-      <Box mx="xl" pb="sm" pt="xl">
+      <Box $mx="xl" $pb="sm" $pt="xl">
         <InputText
           autoFocus
           data-testid="emoji-search-input"
@@ -268,7 +268,13 @@ export const List: React.FC<ListProps> = ({
         </FixedSizeList>
       )}
       {!hasRows && (
-        <Box alignItems="center" display="flex" h={HEIGHT} justifyContent="center" w={WIDTH}>
+        <Box
+          $alignItems="center"
+          $display="flex"
+          $h={`${HEIGHT}px`}
+          $justifyContent="center"
+          $w={`${WIDTH}px`}
+        >
           {emptyList}
         </Box>
       )}
@@ -295,13 +301,13 @@ const EmojiRow: React.FC<EmojiRowProps> = ({ data, index, style }) => {
   if (typeof row[0] === 'string') {
     return (
       <Text
-        alignItems="center"
+        $alignItems="center"
+        $color="light-100"
+        $display="flex"
+        $px="xl"
+        $textTransform="uppercase"
         as="span"
-        color="light-100"
-        display="flex"
-        px="xl"
         style={style}
-        textTransform="uppercase"
         variant="subtitle-sm"
       >
         {row[0]}
@@ -310,7 +316,7 @@ const EmojiRow: React.FC<EmojiRowProps> = ({ data, index, style }) => {
   }
 
   return (
-    <Box display="flex" px="lg" style={style}>
+    <Box $display="flex" $px="lg" style={style}>
       {row.map(emoji => {
         const alias = getEmojiAlias(emoji)
         // We want `null` instead of false to prevent to add the attribute to be in the DOM
@@ -324,6 +330,7 @@ const EmojiRow: React.FC<EmojiRowProps> = ({ data, index, style }) => {
 
         return (
           <S.EmojiButton
+            $w={`${100 / NB_EMOJIS_PER_ROW}%`}
             data-active={isActive}
             data-testid={`emoji-${alias}`}
             key={alias}
@@ -331,7 +338,6 @@ const EmojiRow: React.FC<EmojiRowProps> = ({ data, index, style }) => {
             onMouseMove={() => data.onMouseMove(emoji)}
             tabIndex={-1}
             type="button"
-            w={`${100 / NB_EMOJIS_PER_ROW}%`}
           >
             <Emoji emoji={emojiImage} />
           </S.EmojiButton>

--- a/packages/EmojiPicker/Panel.tsx
+++ b/packages/EmojiPicker/Panel.tsx
@@ -7,7 +7,7 @@ type PanelProps = { children?: React.ReactNode }
 
 export const Panel: React.FC<PanelProps> = ({ children }) => {
   return (
-    <Box display="grid" minHeight={HEIGHT} minWidth={WIDTH}>
+    <Box $display="grid" $minH={`${HEIGHT}px`} $minW={`${WIDTH}px`}>
       {children}
     </Box>
   )

--- a/packages/EmojiPicker/package.json
+++ b/packages/EmojiPicker/package.json
@@ -55,7 +55,6 @@
     "react-window": "^1.8.8"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/EmojiPicker/styles.ts
+++ b/packages/EmojiPicker/styles.ts
@@ -4,52 +4,58 @@ import { Tab } from '@welcome-ui/tabs'
 import { Popover as WUIPopover } from '@welcome-ui/popover'
 import { Box } from '@welcome-ui/box'
 
-export const Popover = styled(WUIPopover)`
-  background-color: light-900;
-  border-width: sm;
-  border-style: solid;
-  border-color: border;
-  color: dark-900;
-  ${system};
-`
+export const Popover = styled(WUIPopover)(
+  ({ theme }) => css`
+    background-color: ${theme.colors['light-900']};
+    border-width: ${theme.spaces.sm};
+    border-style: solid;
+    border-color: border;
+    color: ${theme.colors['dark-900']};
+    ${system};
+  `
+)
 
-export const TabList = styled(Tab.List)`
-  padding: 0 md;
+export const TabList = styled(Tab.List)(
+  ({ theme }) => css`
+  padding: 0 ${theme.spaces.md};
   /* Remove margin from Tab.List */
-  margin-bottom: -xl;
+  margin-bottom: -{theme.spaces.xl};
   ${system};
 `
+)
 
-export const EmojiButton = styled.button<WuiProps>`
-  padding: 0;
-  border: 0;
-  background: none;
-  border-radius: 4;
-  transition: fast;
-  /*
+export const EmojiButton = styled.button<WuiProps>(
+  ({ theme }) => css`
+    padding: 0;
+    border: 0;
+    background: none;
+    border-radius: 4px;
+    transition: ${theme.transitions.fast};
+    /*
    * Taken from slack's emoji picker
    * The delay prevents flickering when hovering
    */
-  transition-property: background;
-  transition-timing-function: ease-out;
-  transition-delay: 0.05s;
-  cursor: pointer;
+    transition-property: background;
+    transition-timing-function: ease-out;
+    transition-delay: 0.05s;
+    cursor: pointer;
 
-  &[data-active] {
-    outline: none;
-    &:nth-child(3n) {
-      background-color: sub-4;
+    &[data-active] {
+      outline: none;
+      &:nth-child(3n) {
+        background-color: ${theme.colors['sub-4']};
+      }
+      &:nth-child(3n + 1) {
+        background-color: ${theme.colors['sub-1']};
+      }
+      &:nth-child(3n + 2) {
+        background-color: ${theme.colors['sub-5']};
+      }
     }
-    &:nth-child(3n + 1) {
-      background-color: sub-1;
-    }
-    &:nth-child(3n + 2) {
-      background-color: sub-5;
-    }
-  }
 
-  ${system};
-`
+    ${system};
+  `
+)
 export const Tooltip = styled(Box)(
   ({ theme }) => css`
     ${theme.tooltips};

--- a/packages/EmojiPicker/styles.ts
+++ b/packages/EmojiPicker/styles.ts
@@ -1,4 +1,5 @@
-import styled, { system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { system, WuiProps } from '@welcome-ui/system'
 import { Tab } from '@welcome-ui/tabs'
 import { Popover as WUIPopover } from '@welcome-ui/popover'
 import { Box } from '@welcome-ui/box'
@@ -19,9 +20,7 @@ export const TabList = styled(Tab.List)`
   ${system};
 `
 
-export const EmojiButton = styled.buttonBox.attrs({
-  as: 'button',
-})`
+export const EmojiButton = styled.button<WuiProps>`
   padding: 0;
   border: 0;
   background: none;
@@ -35,6 +34,7 @@ export const EmojiButton = styled.buttonBox.attrs({
   transition-timing-function: ease-out;
   transition-delay: 0.05s;
   cursor: pointer;
+
   &[data-active] {
     outline: none;
     &:nth-child(3n) {
@@ -47,12 +47,17 @@ export const EmojiButton = styled.buttonBox.attrs({
       background-color: sub-5;
     }
   }
+
+  ${system};
 `
-export const Tooltip = styled(Box)`
-  ${th('tooltips')};
-  position: absolute;
-  pointer-events: none;
-  &:empty {
-    display: none;
-  }
-`
+export const Tooltip = styled(Box)(
+  ({ theme }) => css`
+    ${theme.tooltips};
+    position: absolute;
+    pointer-events: none;
+
+    &:empty {
+      display: none;
+    }
+  `
+)

--- a/packages/EmojiPicker/tsconfig.json
+++ b/packages/EmojiPicker/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Field/index.tsx
+++ b/packages/Field/index.tsx
@@ -27,12 +27,12 @@ export type FieldProps = CreateWuiProps<'div', FieldOptions>
 export const Field = forwardRef<'div', FieldProps>(
   (
     {
+      $flexDirection,
       children,
       dataTestId,
       disabled,
       disabledIcon,
       error,
-      flexDirection,
       hint,
       info,
       label,
@@ -49,7 +49,7 @@ export const Field = forwardRef<'div', FieldProps>(
     const isToggle = children.type.displayName === 'Toggle'
     const isCheckbox = baseType === 'checkbox'
     const isCheckable = isRadio || isCheckbox || isToggle
-    const layout = flexDirection || (isCheckable ? 'row' : 'column')
+    const layout = $flexDirection || (isCheckable ? 'row' : 'column')
     const isGroup = ['FieldGroup', 'RadioGroup'].includes(baseType)
     const Container = layout === 'row' ? RowContainer : Fragment
     const variant = getVariant({ error, warning, success, info })
@@ -63,7 +63,7 @@ export const Field = forwardRef<'div', FieldProps>(
       required,
       variant,
       transparent,
-      ...(isGroup ? { flexDirection: layout } : {}),
+      ...(isGroup ? { $flexDirection: layout } : {}),
     })
 
     useLayoutEffect(() => {
@@ -80,8 +80,8 @@ export const Field = forwardRef<'div', FieldProps>(
       <S.Field
         ref={ref}
         {...rest}
+        $flexDirection={layout}
         data-testid={dataTestId}
-        flexDirection={layout}
         isCheckable={isCheckable}
         withHintText={withHintText}
       >

--- a/packages/Field/layout.ts
+++ b/packages/Field/layout.ts
@@ -1,4 +1,4 @@
-import styled from '@xstyled/styled-components'
+import styled from 'styled-components'
 
 export const RowContainer = styled.div`
   display: flex;

--- a/packages/Field/package.json
+++ b/packages/Field/package.json
@@ -38,13 +38,13 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
+    "@welcome-ui/box": "^5.0.0-alpha.0",
     "@welcome-ui/field-group": "^5.0.0-alpha.0",
     "@welcome-ui/hint": "^5.0.0-alpha.0",
     "@welcome-ui/label": "^5.0.0-alpha.0",
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Field/styles.ts
+++ b/packages/Field/styles.ts
@@ -1,8 +1,9 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { StyledLabel } from '@welcome-ui/label'
+import { Box } from '@welcome-ui/box'
 import { StyledHint } from '@welcome-ui/hint'
 import { StyledFieldGroup } from '@welcome-ui/field-group'
-import { shouldForwardProp, WuiProps } from '@welcome-ui/system'
+import { system } from '@welcome-ui/system'
 import { DefaultFieldStylesProps } from '@welcome-ui/utils'
 
 const rowStyles = css`
@@ -14,32 +15,30 @@ const columnStyles = css`
 `
 
 const checkableFieldStyles = css`
-  ${th('defaultFields.checkablelabel.default')};
+  ${({ theme }) => theme.defaultFields.checkablelabel.default};
   margin-bottom: md;
 `
 
 type StyledFieldProps = {
   isCheckable?: boolean
-  flexDirection: WuiProps['flexDirection']
   checked?: boolean
   withHintText?: boolean
 }
 
-export const Field = styled('div').withConfig({ shouldForwardProp })<StyledFieldProps>(
-  ({ checked, flexDirection, isCheckable, withHintText }) => css`
+export const Field = styled(Box)<StyledFieldProps>(
+  ({ $flexDirection, checked, isCheckable, theme, withHintText }) => css`
     ${StyledFieldGroup} {
       margin-bottom: ${isCheckable && 'xxs'};
     }
     ${StyledLabel} {
-      ${flexDirection === 'row' && rowStyles};
-      ${flexDirection === 'column' && !isCheckable && columnStyles};
+      ${$flexDirection === 'row' && rowStyles};
+      ${$flexDirection === 'column' && !isCheckable && columnStyles};
       ${isCheckable && !withHintText && checkableFieldStyles};
-      ${checked && th('defaultFields.checkablelabel.checked')}
+      ${checked && theme.defaultFields.checkablelabel.checked}
     }
     ${StyledHint} {
       ${isCheckable && withHintText && checkableFieldStyles};
     }
-    ${system};
   `
 )
 
@@ -48,12 +47,12 @@ type IconWrapperProps = {
   size?: DefaultFieldStylesProps['size']
 }
 
-export const IconWrapper = styled.div<IconWrapperProps>(
-  ({ iconPlacement, size }) => css`
+export const IconWrapper = styled(Box)<IconWrapperProps>(
+  ({ iconPlacement, size, theme }) => css`
     position: absolute;
     top: 0;
-    left: ${iconPlacement === 'left' ? th(`defaultFields.iconPlacement.${size}.left`) : 'auto'};
-    right: ${iconPlacement === 'right' ? th(`defaultFields.iconPlacement.${size}.right`) : 'auto'};
+    left: ${iconPlacement === 'left' ? theme.defaultFields.iconPlacement[size].left : 'auto'};
+    right: ${iconPlacement === 'right' ? theme.defaultFields.iconPlacement[size].right : 'auto'};
     bottom: 0;
     display: flex;
     width: 16;

--- a/packages/Field/styles.ts
+++ b/packages/Field/styles.ts
@@ -7,16 +7,16 @@ import { system } from '@welcome-ui/system'
 import { DefaultFieldStylesProps } from '@welcome-ui/utils'
 
 const rowStyles = css`
-  margin-right: sm;
+  margin-right: ${({ theme }) => theme.spaces.sm};
 `
 
 const columnStyles = css`
-  margin-bottom: sm;
+  margin-bottom: ${({ theme }) => theme.spaces.sm};
 `
 
 const checkableFieldStyles = css`
   ${({ theme }) => theme.defaultFields.checkablelabel.default};
-  margin-bottom: md;
+  margin-bottom: ${({ theme }) => theme.spaces.md};
 `
 
 type StyledFieldProps = {
@@ -55,13 +55,13 @@ export const IconWrapper = styled(Box)<IconWrapperProps>(
     right: ${iconPlacement === 'right' ? theme.defaultFields.iconPlacement[size].right : 'auto'};
     bottom: 0;
     display: flex;
-    width: 16;
+    width: 16px;
     justify-content: center;
     align-items: center;
     pointer-events: none;
-    transition: medium;
-    transition-timing-function: primary;
-    color: dark-900;
+    transition: ${theme.transitions.medium};
+    transition-timing-function: ${theme.timingFunction.primary};
+    color: ${theme.colors['dark-900']};
     ${system};
     /* for button action */
     & > button {
@@ -70,8 +70,8 @@ export const IconWrapper = styled(Box)<IconWrapperProps>(
   `
 )
 
-export const IconGroupWrapper = styled.div(
-  ({ size }: { size: DefaultFieldStylesProps['size'] }) => css`
+export const IconGroupWrapper = styled.div<{ size: DefaultFieldStylesProps['size'] }>(
+  ({ size, theme }) => css`
     position: absolute;
     padding: 0;
     top: 0;
@@ -79,10 +79,10 @@ export const IconGroupWrapper = styled.div(
     right: ${size === 'xs' ? 'sm' : 'md'};
     display: flex;
     align-items: center;
-    gap: sm;
+    gap: ${theme.spaces.sm};
 
     > * {
-      width: 16;
+      width: 16px;
     }
   `
 )

--- a/packages/Field/tsconfig.json
+++ b/packages/Field/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/FieldGroup/package.json
+++ b/packages/FieldGroup/package.json
@@ -42,7 +42,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/FieldGroup/styles.ts
+++ b/packages/FieldGroup/styles.ts
@@ -13,7 +13,7 @@ export const FieldGroup = styled.fieldset(
     ${system};
 
     & > ${StyledLabel} {
-      margin-bottom: md;
+      margin-bottom: ${theme.space.md};
     }
   `
 )

--- a/packages/FieldGroup/styles.ts
+++ b/packages/FieldGroup/styles.ts
@@ -1,17 +1,19 @@
-import styled, { system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { StyledLabel } from '@welcome-ui/label'
-import { shouldForwardProp } from '@welcome-ui/system'
+import { system } from '@welcome-ui/system'
 
-export const FieldGroup = styled('fieldset').withConfig({ shouldForwardProp })`
-  width: 100%;
-  min-width: 0;
-  min-height: 0;
-  margin: 0;
-  padding: 0;
-  ${th('defaultFields.fieldset')};
-  ${system};
+export const FieldGroup = styled.fieldset(
+  ({ theme }) => css`
+    width: 100%;
+    min-width: 0;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    ${theme.defaultFields.fieldset};
+    ${system};
 
-  & > ${StyledLabel} {
-    margin-bottom: md;
-  }
-`
+    & > ${StyledLabel} {
+      margin-bottom: md;
+    }
+  `
+)

--- a/packages/FieldGroup/tsconfig.json
+++ b/packages/FieldGroup/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/FileDrop/FilePreview.tsx
+++ b/packages/FileDrop/FilePreview.tsx
@@ -23,17 +23,17 @@ export const FilePreview: React.FC<MessageProps & WordingsType> = ({
 
   return (
     <>
-      <Icon color="dark-900" h={50} mb="lg" w={50} />
-      <Text color="dark-900" lines={1} m={0} maxWidth={600} variant="h4">
+      <Icon $color="dark-900" $h="50px" $mb="lg" $w="50px" />
+      <Text $color="dark-900" $m="0" $maxW="600px" lines={1} variant="h4">
         {name}
       </Text>
       {!isUrl && (
-        <Text color="nude-700" fontWeight="medium" lines={1} m={0} variant="sm">
+        <Text $color="nude-700" $fontWeight="medium" $m="0" lines={1} variant="sm">
           {size}
         </Text>
       )}
       {isUrl && (
-        <Button as="a" href={file} mt="md" rel="noopener" size="sm" target="_blank">
+        <Button $mt="md" as="a" href={file} rel="noopener" size="sm" target="_blank">
           <span>{previewButtonText}</span>
           <ExternalLinkIcon />
         </Button>

--- a/packages/FileDrop/Message.tsx
+++ b/packages/FileDrop/Message.tsx
@@ -18,13 +18,13 @@ export const Message: React.FC<MessageProps & WordingsType> = ({
 }) => {
   return (
     <>
-      <Text color="dark-900" m="0" variant="h4">
+      <Text $color="dark-900" $m="0" variant="h4">
         {title}
       </Text>
-      <Text color="nude-700" m="0" mt="xs" variant="sm">
+      <Text $color="nude-700" $m="0" $mt="xs" variant="sm">
         {hint}
       </Text>
-      <Button disabled={disabled} mt="lg" onClick={openFile} type="button">
+      <Button $mt="lg" disabled={disabled} onClick={openFile} type="button">
         {fileButtonText}
       </Button>
     </>

--- a/packages/FileDrop/package.json
+++ b/packages/FileDrop/package.json
@@ -38,6 +38,7 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
+    "@welcome-ui/box": "^5.0.0-alpha.0",
     "@welcome-ui/button": "^5.0.0-alpha.0",
     "@welcome-ui/button-group": "^5.0.0-alpha.0",
     "@welcome-ui/files": "^5.0.0-alpha.0",
@@ -48,7 +49,6 @@
     "react-dropzone": "14.2.3"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/FileDrop/styles.ts
+++ b/packages/FileDrop/styles.ts
@@ -1,5 +1,5 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
-import { shouldForwardProp } from '@welcome-ui/system'
+import styled, { css } from 'styled-components'
+import { Box } from '@welcome-ui/box'
 import { getVariantColor } from '@welcome-ui/utils'
 
 export interface StyledFileDropProps {
@@ -8,32 +8,31 @@ export interface StyledFileDropProps {
   isDragReject?: boolean
 }
 
-export const FileDrop = styled('div').withConfig({ shouldForwardProp })<StyledFileDropProps>(
-  ({ disabled, isDragAccept, isDragReject }) => css`
-    ${th('defaultFields.default')};
-    ${th('filedrops.default')};
-    ${isDragAccept && th('filedrops.dragAccept')};
+export const FileDrop = styled(Box)<StyledFileDropProps>(
+  ({ disabled, isDragAccept, isDragReject, theme }) => css`
+    ${theme.defaultFields.default};
+    ${theme.filedrops.default};
+    ${isDragAccept && theme.filedrops.dragAccept};
     ${isDragReject &&
     css`
       border-color: ${getVariantColor('error')};
-      ${th('filedrops.dragReject')}
+      ${theme.filedrops.dragReject}
     `};
     position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: md;
+    padding: ${theme.space.md};
     transition: medium;
-    ${system};
 
     &:focus {
-      ${th('defaultFields.focused.default')};
+      ${theme.defaultFields.focused.default};
     }
 
     ${disabled &&
     css`
-      ${th('defaultFields.disabled')};
-      ${th('filedrops.disabled')};
+      ${theme.defaultFields.disabled};
+      ${theme.filedrops.disabled};
     `};
   `
 )
@@ -53,10 +52,12 @@ export const ImagePreview = styled.img`
   object-fit: contain;
 `
 
-export const Actions = styled.div`
-  position: absolute;
-  top: ${th.space('md')};
-  right: ${th.space('md')};
-  display: flex;
-  gap: xs;
-`
+export const Actions = styled.div(
+  ({ theme }) => css`
+    position: absolute;
+    top: ${theme.space.md};
+    right: ${theme.space.md};
+    display: flex;
+    gap: ${theme.space.xs};
+  `
+)

--- a/packages/FileDrop/styles.ts
+++ b/packages/FileDrop/styles.ts
@@ -23,7 +23,7 @@ export const FileDrop = styled(Box)<StyledFileDropProps>(
     justify-content: center;
     align-items: center;
     padding: ${theme.space.md};
-    transition: medium;
+    transition: ${theme.transitions.medium};
 
     &:focus {
       ${theme.defaultFields.focused.default};

--- a/packages/FileDrop/tsconfig.json
+++ b/packages/FileDrop/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/FileUpload/Preview.tsx
+++ b/packages/FileUpload/Preview.tsx
@@ -14,7 +14,7 @@ export const Preview: React.FC<PreviewProps> = ({ file, onRemove }) => {
   const size = getFileSize(file)
 
   return (
-    <Tag data-id={name} key={name} mr="sm" mt="sm" onRemove={onRemove}>
+    <Tag $mr="sm" $mt="sm" data-id={name} key={name} onRemove={onRemove}>
       <Icon size="md" />
       {name}
       {size && <Box color="nude-600">({size})</Box>}

--- a/packages/FileUpload/package.json
+++ b/packages/FileUpload/package.json
@@ -46,7 +46,6 @@
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/FileUpload/styles.ts
+++ b/packages/FileUpload/styles.ts
@@ -1,6 +1,5 @@
-import styled from '@xstyled/styled-components'
-import { shouldForwardProp } from '@welcome-ui/system'
+import styled from 'styled-components'
 
-export const Input = styled('input').withConfig({ shouldForwardProp })`
+export const Input = styled('input')`
   display: none;
 `

--- a/packages/FileUpload/tsconfig.json
+++ b/packages/FileUpload/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Files/tsconfig.json
+++ b/packages/Files/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["index.ts", "../../types"]
 }

--- a/packages/Flex/index.tsx
+++ b/packages/Flex/index.tsx
@@ -4,19 +4,19 @@ import { CreateWuiProps, forwardRef, WuiProps } from '@welcome-ui/system'
 
 export interface FlexOptions {
   /** same as alignItems */
-  align?: WuiProps['alignItems']
+  align?: WuiProps['$alignItems']
   /** same as justifyContent */
-  justify?: WuiProps['justifyContent']
+  justify?: WuiProps['$justifyContent']
   /** same as flexWrap */
-  wrap?: WuiProps['flexWrap']
+  wrap?: WuiProps['$flexWrap']
   /** same as flexDirection */
-  direction?: WuiProps['flexDirection']
+  direction?: WuiProps['$flexDirection']
   /** same as flexBasis */
-  basis?: WuiProps['flexBasis']
+  basis?: WuiProps['$flexBasis']
   /** same as flexGrow */
-  grow?: WuiProps['flexGrow']
+  grow?: WuiProps['$flexGrow']
   /** same as flexShrink */
-  shrink?: WuiProps['flexShrink']
+  shrink?: WuiProps['$flexShrink']
 }
 
 export type FlexProps = CreateWuiProps<'div', FlexOptions>
@@ -25,15 +25,15 @@ export const Flex = forwardRef<'div', FlexProps>(
   ({ align, basis, dataTestId, direction, grow, justify, shrink, wrap, ...rest }, ref) => {
     return (
       <Box
-        alignItems={align}
+        $alignItems={align}
+        $display="flex"
+        $flexBasis={basis}
+        $flexDirection={direction}
+        $flexGrow={grow}
+        $flexShrink={shrink}
+        $flexWrap={wrap}
+        $justifyContent={justify}
         data-testid={dataTestId}
-        display="flex"
-        flexBasis={basis}
-        flexDirection={direction}
-        flexGrow={grow}
-        flexShrink={shrink}
-        flexWrap={wrap}
-        justifyContent={justify}
         ref={ref}
         {...rest}
       />

--- a/packages/Flex/package.json
+++ b/packages/Flex/package.json
@@ -42,7 +42,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Flex/tsconfig.json
+++ b/packages/Flex/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Grid/Item.tsx
+++ b/packages/Grid/Item.tsx
@@ -4,11 +4,11 @@ import { CreateWuiProps, forwardRef, WuiProps } from '@welcome-ui/system'
 
 export interface ItemOptions {
   /** same as gridArea */
-  area?: WuiProps['gridArea']
+  area?: WuiProps['$gridArea']
   /** same as gridColumn */
-  column?: WuiProps['gridColumn']
+  column?: WuiProps['$gridColumn']
   /** same as gridRow */
-  row?: WuiProps['row']
+  row?: WuiProps['$gridRow']
 }
 
 export type ItemProps = CreateWuiProps<'div', ItemOptions>
@@ -20,11 +20,11 @@ export const Item = forwardRef<'div', ItemProps>(
   ({ area, column, dataTestId, row, ...rest }, ref) => {
     return (
       <Box
+        $gridArea={area}
+        $gridColumn={column}
+        $gridRow={row}
         data-testid={dataTestId}
-        gridArea={area}
-        gridColumn={column}
         ref={ref}
-        row={row}
         {...rest}
       />
     )

--- a/packages/Grid/index.tsx
+++ b/packages/Grid/index.tsx
@@ -6,29 +6,29 @@ import { Item } from './Item'
 
 export interface GridOptions {
   /** same as gridArea */
-  area?: WuiProps['gridArea']
+  area?: WuiProps['$gridArea']
   /** same as gridAutoColumns */
-  autoColumns?: WuiProps['gridAutoColumns']
+  autoColumns?: WuiProps['$gridAutoColumns']
   /** same as gridAutoFlow */
-  autoFlow?: WuiProps['gridAutoFlow']
+  autoFlow?: WuiProps['$gridAutoFlow']
   /** same as gridAutoRows */
-  autoRows?: WuiProps['gridAutoRows']
+  autoRows?: WuiProps['$gridAutoRows']
   /** same as gridColumn */
-  column?: WuiProps['gridColumn']
+  column?: WuiProps['$gridColumn']
   /** same as columnGap */
-  columnGap?: WuiProps['columnGap']
+  columnGap?: WuiProps['$columnGap']
   /** same as gridGap */
-  gap?: WuiProps['gap']
+  gap?: WuiProps['$gap']
   /** same as gridRow */
-  row?: WuiProps['gridRow']
+  row?: WuiProps['$gridRow']
   /** same as gridRowGap */
-  rowGap?: WuiProps['rowGap']
+  rowGap?: WuiProps['$rowGap']
   /** same as gridTemplateAreas */
-  templateAreas?: WuiProps['gridTemplateAreas']
+  templateAreas?: WuiProps['$gridTemplateAreas']
   /** same as gridTemplateColumns */
-  templateColumns?: WuiProps['gridTemplateColumns']
+  templateColumns?: WuiProps['$gridTemplateColumns']
   /** same as gridTemplateRows */
-  templateRows?: WuiProps['gridTemplateRows']
+  templateRows?: WuiProps['$gridTemplateRows']
 }
 
 export type GridProps = CreateWuiProps<'div', GridOptions>
@@ -55,21 +55,21 @@ const GridComponent = forwardRef<'div', GridProps>(
   ) => {
     return (
       <Box
-        columnGap={columnGap}
+        $columnGap={columnGap}
+        $display="grid"
+        $gap={gap}
+        $gridArea={area}
+        $gridAutoColumns={autoColumns}
+        $gridAutoFlow={autoFlow}
+        $gridAutoRows={autoRows}
+        $gridColumn={column}
+        $gridRow={row}
+        $gridTemplateAreas={templateAreas}
+        $gridTemplateColumns={templateColumns}
+        $gridTemplateRows={templateRows}
+        $rowGap={rowGap}
         data-testid={dataTestId}
-        display="grid"
-        gap={gap}
-        gridArea={area}
-        gridAutoColumns={autoColumns}
-        gridAutoFlow={autoFlow}
-        gridAutoRows={autoRows}
-        gridColumn={column}
-        gridRow={row}
-        gridTemplateAreas={templateAreas}
-        gridTemplateColumns={templateColumns}
-        gridTemplateRows={templateRows}
         ref={ref}
-        rowGap={rowGap}
         {...rest}
       />
     )

--- a/packages/Grid/package.json
+++ b/packages/Grid/package.json
@@ -42,7 +42,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Grid/tsconfig.json
+++ b/packages/Grid/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Hint/package.json
+++ b/packages/Hint/package.json
@@ -42,7 +42,6 @@
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Hint/styles.ts
+++ b/packages/Hint/styles.ts
@@ -1,4 +1,5 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { Box } from '@welcome-ui/box'
 
 import { Variant } from './index'
 
@@ -9,13 +10,12 @@ export const VARIANTS: Record<Variant, string> = {
   warning: 'colors.warning-500',
 }
 
-export const Hint = styled.div<{ variant: Variant }>(
-  ({ variant }) => css`
-    ${th('hints')};
-    color: ${th(VARIANTS[variant]) || undefined};
+export const Hint = styled(Box)<{ variant: Variant }>(
+  ({ theme, variant }) => css`
+    ${theme.hints};
+    color: ${theme[VARIANTS[variant]] || undefined};
     margin-top: xs;
     display: flex;
     align-items: center;
-    ${system};
   `
 )

--- a/packages/Hint/styles.ts
+++ b/packages/Hint/styles.ts
@@ -1,21 +1,23 @@
-import styled, { css } from 'styled-components'
+import styled, { css, DefaultTheme } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 
 import { Variant } from './index'
 
-export const VARIANTS: Record<Variant, string> = {
-  error: 'colors.danger-500',
-  info: 'colors.info-500',
-  success: 'colors.success-500',
-  warning: 'colors.warning-500',
+export const VARIANTS: Record<Variant, keyof DefaultTheme['colors']> = {
+  error: 'danger-500',
+  info: 'info-500',
+  success: 'success-500',
+  warning: 'warning-500',
 }
 
-export const Hint = styled(Box)<{ variant: Variant }>(
-  ({ theme, variant }) => css`
+export const Hint = styled(Box)<{ variant: Variant }>(({ theme, variant }) => {
+  const color = VARIANTS[variant]
+
+  return css`
     ${theme.hints};
-    color: ${theme[VARIANTS[variant]] || undefined};
-    margin-top: xs;
+    color: ${theme.colors[color] || undefined};
+    margin-top: ${theme.space.xs};
     display: flex;
     align-items: center;
   `
-)
+})

--- a/packages/Hint/tsconfig.json
+++ b/packages/Hint/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Icon/package.json
+++ b/packages/Icon/package.json
@@ -41,7 +41,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Icon/styles.ts
+++ b/packages/Icon/styles.ts
@@ -1,6 +1,5 @@
-import styled, { css, system } from '@xstyled/styled-components'
-import { WuiProps } from '@welcome-ui/system'
-import { WuiTheme } from '@welcome-ui/core'
+import styled, { css, DefaultTheme } from 'styled-components'
+import { system, WuiProps } from '@welcome-ui/system'
 
 import { IconOptions } from './index'
 
@@ -24,8 +23,9 @@ type StyledIconProps = Pick<IconOptions, 'size'> &
   WuiProps &
   Partial<{ alt: string; title: string }>
 
-export const Icon = styled('svg')<StyledIconProps>(({ isFlag, size = 'md', stroked, theme }) => {
-  const formattedSize = theme.icons[size as keyof WuiTheme['icons']] || size
+export const Icon = styled.div<StyledIconProps>(({ isFlag, size = 'md', stroked, theme }) => {
+  const formattedSize = theme.icons[size as keyof DefaultTheme['icons']] || size
+
   return css`
     ${!isFlag && (stroked ? iconSvgStrokedStyles : iconSvgFilledStyles)};
     width: ${formattedSize};

--- a/packages/Icon/styles.ts
+++ b/packages/Icon/styles.ts
@@ -23,7 +23,7 @@ type StyledIconProps = Pick<IconOptions, 'size'> &
   WuiProps &
   Partial<{ alt: string; title: string }>
 
-export const Icon = styled.div<StyledIconProps>(({ isFlag, size = 'md', stroked, theme }) => {
+export const Icon = styled.svg<StyledIconProps>(({ isFlag, size = 'md', stroked, theme }) => {
   const formattedSize = theme.icons[size as keyof DefaultTheme['icons']] || size
 
   return css`

--- a/packages/Icon/tsconfig.json
+++ b/packages/Icon/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/IconFont/package.json
+++ b/packages/IconFont/package.json
@@ -40,7 +40,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/IconFont/styles.ts
+++ b/packages/IconFont/styles.ts
@@ -1,11 +1,11 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
-import { IconOptions } from '@welcome-ui/icon'
+import styled, { css, DefaultTheme } from 'styled-components'
+import { system } from '@welcome-ui/system'
 
 import unicodeMap from './unicode.json'
 
 export type StyledIconProps = {
   name: keyof typeof unicodeMap
-  size: IconOptions['size']
+  size: keyof DefaultTheme['icons']
 }
 
 function getIconContentByName(name: StyledIconProps['name']) {
@@ -18,10 +18,10 @@ function getIconContentByName(name: StyledIconProps['name']) {
 
 // stylelint-disable font-family-no-missing-generic-family-keyword
 export const Icon = styled.i<StyledIconProps>(
-  ({ name, size = 'md' }) => css`
+  ({ name, size = 'md', theme }) => css`
     display: inline-block;
     font-family: icons;
-    font-size: ${th(`icons.${size}`)};
+    font-size: ${theme.icons[size]};
     ${system};
     &::before {
       content: '${getIconContentByName(name)}';

--- a/packages/IconFont/styles.ts
+++ b/packages/IconFont/styles.ts
@@ -20,7 +20,7 @@ function getIconContentByName(name: StyledIconProps['name']) {
 export const Icon = styled.i<StyledIconProps>(
   ({ name, size = 'md', theme }) => css`
     display: inline-block;
-    font-family: icons;
+    font-family: ${theme.fonts.icons};
     font-size: ${theme.icons[size]};
     ${system};
     &::before {

--- a/packages/IconFont/tsconfig.json
+++ b/packages/IconFont/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/InputText/package.json
+++ b/packages/InputText/package.json
@@ -44,7 +44,6 @@
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/InputText/styles.ts
+++ b/packages/InputText/styles.ts
@@ -5,7 +5,7 @@ import { defaultFieldStyles } from '@welcome-ui/utils'
 import { InputTextOptions } from './index'
 
 export const InputText = styled('input')<InputTextOptions>(
-  ({ icon, iconPlacement, isClearable, size, transparent, variant }) => css`
+  ({ icon, iconPlacement, isClearable, size, theme, transparent, variant }) => css`
     ${defaultFieldStyles({ size, variant, transparent })};
     text-overflow: ellipsis;
 
@@ -14,7 +14,7 @@ export const InputText = styled('input')<InputTextOptions>(
       icon &&
       iconPlacement === 'left' &&
       css`
-        padding-left: 36;
+        padding-left: 36px;
       `
     };
 
@@ -22,7 +22,7 @@ export const InputText = styled('input')<InputTextOptions>(
       /* With clear button or right icon */
       (isClearable || (icon && iconPlacement === 'right')) &&
       css`
-        padding-right: 36;
+        padding-right: 36px;
       `
     };
 
@@ -32,7 +32,7 @@ export const InputText = styled('input')<InputTextOptions>(
       icon &&
       iconPlacement === 'right' &&
       css`
-        padding-right: 4xl;
+        padding-right: ${theme.spaces['4xl']};
       `
     };
 

--- a/packages/InputText/styles.ts
+++ b/packages/InputText/styles.ts
@@ -1,10 +1,10 @@
-import styled, { css, system } from '@xstyled/styled-components'
-import { shouldForwardProp } from '@welcome-ui/system'
+import styled, { css } from 'styled-components'
+import { system } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 
 import { InputTextOptions } from './index'
 
-export const InputText = styled('input').withConfig({ shouldForwardProp })<InputTextOptions>(
+export const InputText = styled('input')<InputTextOptions>(
   ({ icon, iconPlacement, isClearable, size, transparent, variant }) => css`
     ${defaultFieldStyles({ size, variant, transparent })};
     text-overflow: ellipsis;

--- a/packages/InputText/tsconfig.json
+++ b/packages/InputText/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Label/index.tsx
+++ b/packages/Label/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { LockIcon } from '@welcome-ui/icons'
-import { VariantIcon } from '@welcome-ui/variant-icon'
-import { Variant, wrapChildren } from '@welcome-ui/utils'
+import { Variant, VariantIcon } from '@welcome-ui/variant-icon'
+import { wrapChildren } from '@welcome-ui/utils'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 
 import * as S from './styles'

--- a/packages/Label/package.json
+++ b/packages/Label/package.json
@@ -44,7 +44,6 @@
     "@welcome-ui/variant-icon": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Label/styles.ts
+++ b/packages/Label/styles.ts
@@ -1,24 +1,24 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
-import { shouldForwardProp } from '@welcome-ui/system'
+import styled, { css } from 'styled-components'
+import { system, WuiProps } from '@welcome-ui/system'
 import { getVariantColor, Variant } from '@welcome-ui/utils'
 
-export const Label = styled('label').withConfig({ shouldForwardProp })<{
-  required: boolean
-}>(
-  ({ required }) => css`
+type LabelProps = { required: boolean } & WuiProps
+
+export const Label = styled('label')<LabelProps>(
+  ({ required, theme }) => css`
     position: relative;
     display: flex;
     flex-shrink: 0;
     max-width: 100%;
     align-items: center;
-    line-height: lg;
-    ${th('labels')};
+    line-height: ${theme.lineHeights.lg};
+    ${theme.labels};
     ${system};
     user-select: none;
 
     > * {
       &:not(:last-child) {
-        margin-right: sm;
+        margin-right: ${theme.space.sm};
       }
 
       :last-child {
@@ -31,25 +31,25 @@ export const Label = styled('label').withConfig({ shouldForwardProp })<{
 export const requiredStyles = css`
   &::after {
     content: '*';
-    margin-left: xs;
+    margin-left: ${({ theme }) => theme.space.xs};
     /* It prevents the element to shift the layout and it allows us to put it properly on top with super */
     line-height: 0;
     vertical-align: super;
-    font-size: subtitle-sm;
-    font-weight: bold;
-    color: primary-500;
+    font-size: ${({ theme }) => theme.fontSizes['subtitle-sm']};
+    font-weight: ${({ theme }) => theme.fontWeights.bold};
+    color: ${({ theme }) => theme.colors['primary-500']};
   }
 `
 
 export const Disabled = styled.div`
   display: inline-flex;
-  margin-right: xs;
+  margin-right: ${({ theme }) => theme.space.xs};
 `
 
 export const Icon = styled.div<{ variant: Variant }>(
-  ({ variant }) => css`
+  ({ theme, variant }) => css`
     display: inline-flex;
-    margin-right: xs;
+    margin-right: ${theme.space.xs};
     color: ${getVariantColor(variant)};
     fill: ${getVariantColor(variant)};
     flex-shrink: 0;

--- a/packages/Label/tsconfig.json
+++ b/packages/Label/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Link/index.tsx
+++ b/packages/Link/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-multi-comp */
 import React, { Children, cloneElement, useEffect, useRef, useState } from 'react'
-import { useTheme } from '@xstyled/styled-components'
+import { useTheme } from 'styled-components'
 import { UniversalLinkOptions } from '@welcome-ui/universal-link'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 

--- a/packages/Link/package.json
+++ b/packages/Link/package.json
@@ -42,7 +42,6 @@
     "@welcome-ui/universal-link": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Link/styles.ts
+++ b/packages/Link/styles.ts
@@ -1,11 +1,11 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { system } from '@welcome-ui/system'
 import { UniversalLink } from '@welcome-ui/universal-link'
-import { shouldForwardProp } from '@welcome-ui/system'
 
 import { Variant } from './index'
 
-export const Link = styled(UniversalLink).withConfig({ shouldForwardProp })<{ variant: Variant }>(
-  ({ variant }) => css`
+export const Link = styled(UniversalLink)<{ variant: Variant }>(
+  ({ theme, variant }) => css`
     display: inline-flex;
     flex-direction: row;
     align-items: center;
@@ -16,7 +16,7 @@ export const Link = styled(UniversalLink).withConfig({ shouldForwardProp })<{ va
 
     &:hover,
     &:focus {
-      ${th(`links.${variant || 'primary'}.hover`)};
+      ${theme.links[variant || 'primary'].hover};
       outline: none !important; /* important for firefox */
     }
 
@@ -25,8 +25,8 @@ export const Link = styled(UniversalLink).withConfig({ shouldForwardProp })<{ va
       pointer-events: none;
     }
 
-    ${th('links.default')};
-    ${th(`links.${variant || 'primary'}.default`)};
+    ${theme.links.default};
+    ${theme.links[variant || 'primary'].default};
     ${system};
 
     & > *:not(:only-child):not(:last-child) {

--- a/packages/Link/styles.ts
+++ b/packages/Link/styles.ts
@@ -30,7 +30,7 @@ export const Link = styled(UniversalLink)<{ variant: Variant }>(
     ${system};
 
     & > *:not(:only-child):not(:last-child) {
-      margin-right: xs;
+      margin-right: ${theme.spaces.xs};
     }
   `
 )

--- a/packages/Link/tsconfig.json
+++ b/packages/Link/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Loader/index.tsx
+++ b/packages/Loader/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Box } from '@welcome-ui/box'
-import { CreateWuiProps, ExtraSize, forwardRef } from '@welcome-ui/system'
+import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 
 import * as S from './styles'
 
-export type Size = 'xs' | 'sm' | 'md' | 'lg' | ExtraSize
+export type Size = 'xs' | 'sm' | 'md' | 'lg' | string | number
 
 export interface LoaderOptions {
   color?: string
@@ -16,7 +16,7 @@ export type LoaderProps = CreateWuiProps<'div', LoaderOptions>
 
 export const Loader = forwardRef<'div', LoaderProps>(
   ({ color, dataTestId, size = 'sm', ...rest }, ref) => (
-    <Box color={color} data-testid={dataTestId} display="flex" ref={ref} {...rest}>
+    <Box $color={color} $display="flex" data-testid={dataTestId} ref={ref} {...rest}>
       <S.LoadingDot shape="circle" size={size} />
       <S.LoadingDot shape="circle" size={size} />
       <S.LoadingDot shape="circle" size={size} />

--- a/packages/Loader/package.json
+++ b/packages/Loader/package.json
@@ -43,7 +43,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Loader/styles.ts
+++ b/packages/Loader/styles.ts
@@ -1,8 +1,8 @@
-import styled, { css, keyframes, system, th } from '@xstyled/styled-components'
+import styled, { css, DefaultTheme, keyframes } from 'styled-components'
 import { Shape } from '@welcome-ui/shape'
-import { shouldForwardProp } from '@welcome-ui/system'
+import { system } from '@welcome-ui/system'
 
-import { Size } from '.'
+import type { Size } from './index'
 
 const animation = keyframes`
   0%, 100% {
@@ -23,28 +23,27 @@ export interface LoadingDotOptions {
   size: Size
 }
 
-export const LoadingDot = styled(Shape).withConfig({ shouldForwardProp })<LoadingDotOptions>(
-  ({ size, theme }) => {
-    const sizeValue = th(`loaders.${size}`) || size
-    const formattedSize = typeof sizeValue === 'number' ? theme.toRem(sizeValue) : sizeValue
-    return css`
-      width: ${formattedSize};
-      height: ${formattedSize};
-      background-color: currentColor;
-      ${system}
-      ${animationRule};
-      &:not(:first-child) {
-        margin-left: calc(${formattedSize} / 2);
-      }
-      &:nth-child(1) {
-        animation-delay: 0s;
-      }
-      &:nth-child(2) {
-        animation-delay: 0.125s;
-      }
-      &:nth-child(3) {
-        animation-delay: 0.25s;
-      }
-    `
-  }
-)
+export const LoadingDot = styled(Shape)<LoadingDotOptions>(({ size, theme }) => {
+  const sizeValue = theme.loaders[size as keyof DefaultTheme['loaders']] || size
+  const formattedSize = typeof sizeValue === 'number' ? theme.toRem(sizeValue) : sizeValue
+
+  return css`
+    width: ${formattedSize};
+    height: ${formattedSize};
+    background-color: currentColor;
+    ${system}
+    ${animationRule};
+    &:not(:first-child) {
+      margin-left: calc(${formattedSize} / 2);
+    }
+    &:nth-child(1) {
+      animation-delay: 0s;
+    }
+    &:nth-child(2) {
+      animation-delay: 0.125s;
+    }
+    &:nth-child(3) {
+      animation-delay: 0.25s;
+    }
+  `
+})

--- a/packages/Loader/tsconfig.json
+++ b/packages/Loader/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/MarkdownEditor/easyMdeStyles.ts
+++ b/packages/MarkdownEditor/easyMdeStyles.ts
@@ -1,4 +1,4 @@
-import { css } from '@xstyled/styled-components'
+import { css } from 'styled-components'
 
 export const easyMdeStyles = css`
   /**

--- a/packages/MarkdownEditor/emojiMartStyles.ts
+++ b/packages/MarkdownEditor/emojiMartStyles.ts
@@ -1,4 +1,4 @@
-import { css } from '@xstyled/styled-components'
+import { css } from 'styled-components'
 
 export const emojiMartStyles = css`
   .emoji-mart,

--- a/packages/MarkdownEditor/package.json
+++ b/packages/MarkdownEditor/package.json
@@ -46,7 +46,6 @@
     "easymde": "2.18.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/MarkdownEditor/styles.ts
+++ b/packages/MarkdownEditor/styles.ts
@@ -1,5 +1,5 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
-import { shouldForwardProp } from '@welcome-ui/system'
+import styled, { css } from 'styled-components'
+import { Box } from '@welcome-ui/box'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 
 import { emojiMartStyles } from './emojiMartStyles'
@@ -11,16 +11,14 @@ interface ToolbarIconOptions {
   active?: boolean
 }
 
-export const Wrapper = styled('div').withConfig({ shouldForwardProp })<
-  { focused: boolean } & MarkdownEditorOptions
->(
-  ({ disabled, focused, size, variant }) => css`
+export const Wrapper = styled(Box)<{ focused: boolean } & MarkdownEditorOptions>(
+  ({ disabled, focused, size, theme, variant }) => css`
     ${easyMdeStyles};
     ${defaultFieldStyles({ size, variant })};
     position: relative;
     pointer-events: ${disabled && 'none'};
-    ${focused && th('defaultFields.focused.default')};
-    ${disabled && th('defaultFields.disabled')};
+    ${focused && theme.defaultFields.focused.default};
+    ${disabled && theme.defaultFields.disabled};
     height: auto;
     padding: 0;
     border-radius: sm;
@@ -39,64 +37,71 @@ export const Wrapper = styled('div').withConfig({ shouldForwardProp })<
     .cm-strong {
       font-weight: bold;
     }
-    ${system};
   `
 )
 
-export const Toolbar = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  padding: sm xs;
-  opacity: 1;
-  background-color: light-100;
-  border-bottom: ${th('borderWidths.sm')} solid ${th('colors.nude-200')};
-  position: sticky;
-  top: 0;
-  overflow: auto;
-  z-index: 1;
-`
-
-export const ToolbarIcon = styled.a.withConfig({ shouldForwardProp })<ToolbarIconOptions>(
-  ({ active }) => css`
+export const Toolbar = styled(Box)(
+  ({ theme }) => css`
     display: flex;
     align-items: center;
-    padding: 0 xs;
+    justify-content: flex-start;
+    padding: ${theme.space.sm} ${theme.space.xs};
+    opacity: 1;
+    background-color: ${theme.colors['light-100']};
+    border-bottom: ${theme.borderWidths.sm} solid ${theme.colors['nude-200']};
+    position: sticky;
+    top: 0;
+    overflow: auto;
+    z-index: 1;
+  `
+)
+
+export const ToolbarIcon = styled.a<ToolbarIconOptions>(
+  ({ active, theme }) => css`
+    display: flex;
+    align-items: center;
+    padding: 0 ${theme.space.xs};
     cursor: pointer;
-    color: ${active ? th('colors.nude-900') : th('colors.dark-900')};
-    transition: medium;
+    color: ${active ? theme.colors['nude-900'] : theme.colors['dark-900']};
+    transition: ${theme.transitions.medium};
 
     > svg {
       width: 16;
     }
 
     &:hover {
-      color: ${th('colors.dark-500')};
+      color: ${theme.colors['dark-500']};
     }
   `
 )
 
-export const Divider = styled.div`
-  display: inline-block;
-  width: 1px;
-  height: 12;
-  margin: 0 xs;
-  background-color: nude-600;
-`
+export const Divider = styled.div(
+  ({ theme }) => css`
+    display: inline-block;
+    width: 1px;
+    height: 12;
+    margin: 0 ${theme.space.xs};
+    background-color: ${theme.colors['nude-600']};
+  `
+)
 
-export const EmojiPicker = styled.div`
-  ${emojiMartStyles};
-  position: absolute;
-  z-index: 2;
-  top: ${th('space.md')};
-  right: ${th('space.md')};
-`
+export const EmojiPicker = styled.div(
+  ({ theme }) => css`
+    ${emojiMartStyles};
+    position: absolute;
+    z-index: 2;
+    top: ${theme.space.md};
+    right: ${theme.space.md};
+  `
+)
 
-export const Actions = styled.div`
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: md;
-  background-color: light-900;
-`
+export const Actions = styled.div(
+  ({ theme }) => css`
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: ${theme.space.md};
+    background-color: ${theme.colors['light-900']};
+  `
+)

--- a/packages/MarkdownEditor/tsconfig.json
+++ b/packages/MarkdownEditor/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Modal/Close.tsx
+++ b/packages/Modal/Close.tsx
@@ -1,13 +1,13 @@
-import { CloseButton, CloseButtonProps } from '@welcome-ui/close-button'
 import React from 'react'
+import { CloseButton, CloseButtonProps } from '@welcome-ui/close-button'
 
 export const Close: React.FC<CloseButtonProps> = props => {
   return (
     <CloseButton
-      position={{ xs: 'fixed', md: 'absolute' }}
-      right="sm"
-      top="sm"
-      zIndex="1"
+      $position={{ xs: 'fixed', md: 'absolute' }}
+      $right="sm"
+      $top="sm"
+      $zIndex="1"
       {...props}
     />
   )

--- a/packages/Modal/Footer.tsx
+++ b/packages/Modal/Footer.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { Box, BoxProps } from '@welcome-ui/box'
+import { BoxProps } from '@welcome-ui/box'
 import { Text } from '@welcome-ui/text'
 import { forwardRef } from '@welcome-ui/system'
-import { useTheme } from '@xstyled/styled-components'
+
+import * as S from './styles'
 
 export interface FooterOptions {
   informations?: {
@@ -17,29 +18,20 @@ export type FooterProps = FooterOptions & BoxProps
  * @name Modal.Footer
  */
 export const Footer = forwardRef<'div', FooterProps>(({ children, informations, ...rest }, ref) => {
-  const { modals } = useTheme()
-
   return (
-    <Box
-      {...modals.footer}
-      bottom="0"
-      position={{ xs: 'fixed', md: 'relative' }}
-      ref={ref}
-      w="100%"
-      {...rest}
-    >
-      {children && <Box {...modals.footer.children}>{children}</Box>}
+    <S.Footer bottom="0" position={{ xs: 'fixed', md: 'relative' }} ref={ref} w="100%" {...rest}>
+      {children && <S.FooterWrapper>{children}</S.FooterWrapper>}
       {informations && (
-        <Box {...modals.footer.informations}>
-          <Text color="dark-900" fontWeight="bold" variant="subtitle-sm">
+        <S.FooterInformations>
+          <Text $color="dark-900" $fontWeight="bold" variant="subtitle-sm">
             {informations.title}
           </Text>
-          <Text color="dark-900" mb="0" mt="md" variant="sm">
+          <Text $color="dark-900" $mb="0" $mt="md" variant="sm">
             {informations.subtitle}
           </Text>
-        </Box>
+        </S.FooterInformations>
       )}
-    </Box>
+    </S.Footer>
   )
 })
 

--- a/packages/Modal/Header.tsx
+++ b/packages/Modal/Header.tsx
@@ -1,8 +1,9 @@
 import React, { ReactElement } from 'react'
-import { Box, BoxProps } from '@welcome-ui/box'
+import { BoxProps } from '@welcome-ui/box'
 import { Text } from '@welcome-ui/text'
 import { forwardRef } from '@welcome-ui/system'
-import { useTheme } from '@xstyled/styled-components'
+
+import * as S from './styles'
 
 export interface HeaderOptions {
   title: string
@@ -16,22 +17,19 @@ export type HeaderProps = HeaderOptions & BoxProps
  * @name Modal.Header
  */
 export const Header = forwardRef<'div', HeaderProps>(({ icon, subtitle, title, ...rest }, ref) => {
-  const { modals } = useTheme()
-
   return (
-    <Box
-      {...modals.header}
-      position={{ xs: 'fixed', md: 'relative' }}
+    <S.Header
+      $position={{ xs: 'fixed', md: 'relative' }}
+      $textAlign={icon ? 'center' : null}
       ref={ref}
-      textAlign={icon ? 'center' : null}
       {...rest}
     >
       {icon}
-      <Text mb={subtitle ? 'lg' : 0} mt={icon ? 'xl' : 0} variant="h4">
+      <Text $mb={subtitle ? 'lg' : '0'} $mt={icon ? 'xl' : '0'} variant="h4">
         {title}
       </Text>
-      {subtitle && <Text {...modals.header.subtitle}>{subtitle}</Text>}
-    </Box>
+      {subtitle && <S.Subtitle>{subtitle}</S.Subtitle>}
+    </S.Header>
   )
 })
 

--- a/packages/Modal/index.tsx
+++ b/packages/Modal/index.tsx
@@ -7,10 +7,10 @@ import {
   useDialogState,
 } from 'reakit/Dialog'
 import { DisclosureActions } from 'reakit/Disclosure'
-import { Box, BoxProps } from '@welcome-ui/box'
+import { BoxProps } from '@welcome-ui/box'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
-import { useTheme } from '@xstyled/styled-components'
-import { Shape, ShapeProps } from '@welcome-ui/shape'
+import { useTheme } from 'styled-components'
+import { ShapeProps } from '@welcome-ui/shape'
 
 import * as S from './styles'
 import { Close } from './Close'
@@ -147,19 +147,15 @@ const ModalComponent = forwardRef<'div', ModalProps>(
 )
 
 const Content = forwardRef<'div', BoxProps>((props, ref) => {
-  const { modals } = useTheme()
-
-  return <Box ref={ref} {...modals.content} flex="1" overflowY={{ md: 'auto' }} {...props} />
+  return <S.Content $overflowY={{ md: 'auto' }} ref={ref} {...props} />
 })
 
 Content.displayName = 'Content'
 
 const Cover: React.FC<ShapeProps> = props => {
-  const { modals } = useTheme()
-
   return (
     <div>
-      <Shape {...modals.cover} {...props} />
+      <S.Cover {...props} />
     </div>
   )
 }

--- a/packages/Modal/package.json
+++ b/packages/Modal/package.json
@@ -49,7 +49,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Modal/styles.ts
+++ b/packages/Modal/styles.ts
@@ -1,14 +1,17 @@
-import styled, { css, th, up } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { up } from '@welcome-ui/system'
+import { Box } from '@welcome-ui/box'
+import { Text } from '@welcome-ui/text'
 import { cardStyles } from '@welcome-ui/utils'
 import { DialogBackdrop, Dialog as ReakitDialog } from 'reakit/Dialog'
 
-import { Size } from '.'
+import { Size } from './index'
 
 export const Backdrop = styled(DialogBackdrop).withConfig({
   shouldForwardProp: prop => !['hideOnClickOutside'].includes(prop),
 })<{ hideOnClickOutside: boolean }>(
-  ({ hideOnClickOutside }) => css`
-    ${th('modals.backdrop')};
+  ({ hideOnClickOutside, theme }) => css`
+    ${theme.modals.backdrop};
     display: flex;
     align-items: center;
     justify-content: center;
@@ -32,13 +35,13 @@ export const Backdrop = styled(DialogBackdrop).withConfig({
 )
 
 export const Dialog = styled(ReakitDialog)<{ size: Size }>(
-  ({ size }) => css`
+  ({ size, theme }) => css`
     ${cardStyles};
-    ${th('modals.default')};
+    ${theme.modals.default};
     position: relative;
     display: flex;
     flex-direction: column;
-    margin-top: xl;
+    margin-top: ${theme.space.xl};
     opacity: 0;
     height: 100%;
     width: 100%;
@@ -58,13 +61,53 @@ export const Dialog = styled(ReakitDialog)<{ size: Size }>(
       margin-top: 0;
     }
 
-    ${up(
-      'md',
-      css`
-        height: auto;
-        max-height: 90%;
-        ${th(`modals.sizes.${size}`)};
-      `
-    )}
+    ${up('md')} {
+      height: auto;
+      max-height: 90%;
+      ${theme.modals.sizes[size]};
+    }
+  `
+)
+
+export const Content = styled(Box)(
+  ({ theme }) => css`
+    flex: 1;
+    ${theme.modals.content}
+  `
+)
+
+export const Cover = styled(Box)(
+  ({ theme }) => css`
+    ${theme.modals.cover}
+  `
+)
+
+export const Header = styled(Box)(
+  ({ theme }) => css`
+    ${theme.modals.header}
+  `
+)
+
+export const Subtitle = styled(Text)(
+  ({ theme }) => css`
+    ${theme.modals.header.subtitle}
+  `
+)
+
+export const Footer = styled(Box)(
+  ({ theme }) => css`
+    ${theme.modals.footer}
+  `
+)
+
+export const FooterWrapper = styled(Box)(
+  ({ theme }) => css`
+    ${theme.modals.footer.children}
+  `
+)
+
+export const FooterInformations = styled(Box)(
+  ({ theme }) => css`
+    ${theme.modals.footer.informations}
   `
 )

--- a/packages/Modal/tsconfig.json
+++ b/packages/Modal/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Pagination/package.json
+++ b/packages/Pagination/package.json
@@ -44,7 +44,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Pagination/styles.ts
+++ b/packages/Pagination/styles.ts
@@ -1,4 +1,5 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { system } from '@welcome-ui/system'
 import { hideFocusRingsDataAttribute } from '@welcome-ui/utils'
 
 export const Pagination = styled.nav(system)
@@ -9,56 +10,62 @@ export const List = styled.ul`
   margin: 0;
 `
 
-export const Item = styled.li`
-  display: inline-block;
-  vertical-align: bottom;
-  padding: 0;
-  margin-right: sm;
+export const Item = styled.li(
+  ({ theme }) => css`
+    display: inline-block;
+    vertical-align: bottom;
+    padding: 0;
+    margin-right: ${theme.space.sm};
 
-  &:last-child {
-    margin-right: 0;
-  }
-`
+    &:last-child {
+      margin-right: 0;
+    }
+  `
+)
 
-export const Dots = styled.span`
-  ${th('paginations.default')};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`
+export const Dots = styled.span(
+  ({ theme }) => css`
+    ${theme.paginations.default};
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  `
+)
 
-export const AbstractLink = styled.a`
-  ${th('paginations.default')};
-  ${th('paginations.item')};
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  text-decoration: none;
+export const AbstractLink = styled.a(
+  ({ theme }) => css`
+    ${theme.paginations.default};
+    ${theme.paginations.item};
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    text-decoration: none;
 
-  &:focus {
-    outline: none !important; /* important for firefox */
-    transition: none;
-  }
+    &:focus {
+      outline: none !important; /* important for firefox */
+      transition: none;
+    }
 
-  [${hideFocusRingsDataAttribute}] &:focus {
-    box-shadow: none;
-  }
-`
+    [${hideFocusRingsDataAttribute}] &:focus {
+      box-shadow: none;
+    }
+  `
+)
 
 export const ArrowLink = styled(AbstractLink)<{ isDisabled: boolean }>(
-  ({ isDisabled }) => css`
+  ({ isDisabled, theme }) => css`
     ${isDisabled &&
     css`
-      color: nude-700;
-      background-color: nude-400;
+      color: ${theme.colors['nude-700']};
+      background-color: ${theme.colors['nude-400']};
     `}
   `
 )
 
 export const PageLink = styled(AbstractLink)(
-  props => css`
-    ${props['aria-current'] && th('paginations.active')}
+  ({ theme, ...props }) => css`
+    ${props['aria-current'] && theme.paginations.active}
   `
 )

--- a/packages/Pagination/tsconfig.json
+++ b/packages/Pagination/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/PasswordInput/package.json
+++ b/packages/PasswordInput/package.json
@@ -44,7 +44,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/PasswordInput/tsconfig.json
+++ b/packages/PasswordInput/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Picker/index.tsx
+++ b/packages/Picker/index.tsx
@@ -34,13 +34,13 @@ export const Picker = forwardRef<'fieldset', PickerProps>(
     return (
       <FieldGroup
         {...rest}
+        $mb="0"
         as={ReakitRadioGroup}
         dataTestId={dataTestId}
-        mb={0}
         ref={ref}
         required={required}
       >
-        <Box display="flex" flexWrap="wrap">
+        <Box $display="flex" $flexWrap="wrap">
           {options.map(({ element: Component, value: optValue }) => (
             <Label
               checkableField

--- a/packages/Picker/package.json
+++ b/packages/Picker/package.json
@@ -46,7 +46,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Picker/styles.ts
+++ b/packages/Picker/styles.ts
@@ -1,8 +1,8 @@
-import styled, { system } from '@xstyled/styled-components'
-import { shouldForwardProp } from '@welcome-ui/system'
+import styled from 'styled-components'
 import { Radio as ReakitRadio } from 'reakit/Radio'
+import { system } from '@welcome-ui/system'
 
-export const Radio = styled(ReakitRadio).withConfig({ shouldForwardProp })`
+export const Radio = styled(ReakitRadio)`
   display: none;
   ${system};
 `

--- a/packages/Picker/tsconfig.json
+++ b/packages/Picker/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Popover/index.tsx
+++ b/packages/Popover/index.tsx
@@ -53,23 +53,28 @@ export const PopoverComponent = forwardRef<'div', PopoverProps>(
 
     return (
       <S.Popover {...rest} $withCloseButton={withCloseButton} ref={ref}>
-        <Box position="relative">
+        <Box $position="relative">
           <S.Arrow {...rest}>
-            <S.ArrowItem $transform={transform} h={30} w={30} xmlns="http://www.w3.org/2000/svg">
+            <S.ArrowItem
+              $h="30px"
+              $transform={transform}
+              $w="30px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
               <path d="M6 30l9-10 9 10z" fill="currentColor" fillRule="nonzero" />
             </S.ArrowItem>
           </S.Arrow>
           {children}
           {withCloseButton && (
             <Button
-              flex="0 0 auto"
-              ml="md"
+              $flex="0 0 auto"
+              $ml="md"
+              $position="absolute"
+              $right="1px"
+              $top="1px"
               onClick={closePopover}
-              position="absolute"
-              right={1}
               shape="square"
               size="sm"
-              top={1}
               variant="secondary"
             >
               <CrossIcon />

--- a/packages/Popover/package.json
+++ b/packages/Popover/package.json
@@ -45,7 +45,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Popover/styles.ts
+++ b/packages/Popover/styles.ts
@@ -40,7 +40,7 @@ export const Popover = styled(BasePopover)<{ $withCloseButton: boolean }>(
     ${$withCloseButton &&
     css`
       ${Title} {
-        padding-right: 50;
+        padding-right: 50px;
       }
     `}
   `

--- a/packages/Popover/styles.ts
+++ b/packages/Popover/styles.ts
@@ -1,28 +1,32 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Popover as BasePopover, PopoverArrow, PopoverDisclosure } from 'reakit/Popover'
+import { system, WuiProps } from '@welcome-ui/system'
 
-export const Arrow = styled(PopoverArrow)`
-  color: ${th('popovers.default.backgroundColor')};
-`
+export const Arrow = styled(PopoverArrow)(
+  ({ theme }) => css`
+    color: ${theme.popovers.default.backgroundColor};
+  `
+)
 
-export const ArrowItem = styled.svgBox<{ $transform: string }>(
+export const ArrowItem = styled.svg<WuiProps>(
   ({ $transform }) => css`
     transform: ${$transform};
+    ${system}
   `
 )
 
 export const Content = styled.div`
-  ${th('popovers.content')};
+  ${({ theme }) => theme.popovers.content};
 `
 
 export const Title = styled.h6`
   margin: 0;
-  ${th('popovers.title')};
+  ${({ theme }) => theme.popovers.title};
 `
 
 export const Popover = styled(BasePopover)<{ $withCloseButton: boolean }>(
-  ({ $withCloseButton }) => css`
-    ${th('popovers.default')};
+  ({ $withCloseButton, theme }) => css`
+    ${theme.popovers.default};
     outline: none;
     opacity: 0;
     transition: opacity 150ms ease-in-out;

--- a/packages/Popover/tsconfig.json
+++ b/packages/Popover/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Radio/index.tsx
+++ b/packages/Radio/index.tsx
@@ -18,13 +18,13 @@ export type RadioProps = CreateWuiProps<'input', RadioOptions & LabelOptions>
 export const Radio = forwardRef<'input', RadioProps>(
   (
     {
+      $flexDirection,
+      $maxW,
       dataTestId,
       disabled,
       disabledIcon,
-      flexDirection,
       hint,
       label,
-      maxWidth,
       onChange,
       onClick,
       variant,
@@ -41,17 +41,17 @@ export const Radio = forwardRef<'input', RadioProps>(
 
     return (
       <S.Label
+        $flexDirection="column"
+        $maxW={$maxW}
         checkableField
         disabled={disabled}
         disabledIcon={disabledIcon}
-        flexDirection="column"
-        maxWidth={maxWidth}
         onClick={handleClick}
         variant={variant}
         withDisabledIcon={false}
         withHint={withHint || !!hint}
       >
-        <S.Wrapper flexDirection={flexDirection}>
+        <S.Wrapper $flexDirection={$flexDirection}>
           <S.Input>
             <S.Radio
               data-testid={dataTestId}

--- a/packages/Radio/package.json
+++ b/packages/Radio/package.json
@@ -46,7 +46,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Radio/styles.ts
+++ b/packages/Radio/styles.ts
@@ -1,22 +1,22 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
-import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles } from '@welcome-ui/utils'
 import { Hint as HintWUI } from '@welcome-ui/hint'
 import { Label as WUILabel } from '@welcome-ui/label'
+import { system } from '@welcome-ui/system'
 import { Radio as ReakitRadio } from 'reakit/Radio'
 
 import { RadioProps } from './index'
 
 /* /!\ WARNING /!\ Don't add style after pseudo selector, it won't apply because of the dynamic color injected in the fill of the content */
 
-export const Radio = styled(ReakitRadio).withConfig({ shouldForwardProp })<RadioProps>(
-  ({ order = '-1', size, variant }) => css`
+export const Radio = styled(ReakitRadio)<RadioProps>(
+  ({ $order = '-1', size, theme, variant }) => css`
     ${defaultFieldStyles({ size, variant })};
-    ${th('radios.default')}
+    ${theme.radios.default}
     position: relative;
     padding: 0;
-    order: ${order};
+    order: ${$order};
     cursor: pointer;
     border-radius: 50%;
     transition: medium;
@@ -36,17 +36,17 @@ export const Radio = styled(ReakitRadio).withConfig({ shouldForwardProp })<Radio
 
     &[aria-checked='true'] {
       &:not([disabled]) {
-        ${th('radios.checked')};
+        ${theme.radios.checked};
       }
 
       &[disabled] {
         &::after {
-          background-color: ${th('radios.checkedCenteredColor.disabled')};
+          background-color: ${theme.radios.checkedCenteredColor.disabled};
         }
       }
 
       &::after {
-        background-color: ${th('radios.checkedCenteredColor.default')};
+        background-color: ${theme.radios.checkedCenteredColor.default};
       }
     }
   `
@@ -56,8 +56,8 @@ export const Radio = styled(ReakitRadio).withConfig({ shouldForwardProp })<Radio
 export const Label = styled(WUILabel)<{
   withHint?: boolean
 }>(
-  ({ withHint }) => css`
-    ${withHint && th('radios.withHint.default')};
+  ({ theme, withHint }) => css`
+    ${withHint && theme.radios.withHint.default};
     max-width: 100%;
     align-items: flex-start;
     ${system}
@@ -65,7 +65,7 @@ export const Label = styled(WUILabel)<{
 )
 
 export const Hint = styled(HintWUI)`
-  ${th('radios.withHint.hint')};
+  ${({ theme }) => theme.radios.withHint.hint};
 `
 
 export const Input = styled.div`

--- a/packages/Radio/styles.ts
+++ b/packages/Radio/styles.ts
@@ -19,17 +19,17 @@ export const Radio = styled(ReakitRadio)<RadioProps>(
     order: ${$order};
     cursor: pointer;
     border-radius: 50%;
-    transition: medium;
+    transition: ${theme.transitions.medium};
     ${system};
 
     &::after {
       content: '';
       position: absolute;
-      width: 8;
-      height: 8;
-      border-radius: 8;
-      top: 3;
-      left: 3;
+      width: 8px;
+      height: 8px;
+      border-radius: 8px;
+      top: 3px;
+      left: 3px;
       background-color: transparent;
       transition: medium;
     }

--- a/packages/Radio/tsconfig.json
+++ b/packages/Radio/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/RadioGroup/index.tsx
+++ b/packages/RadioGroup/index.tsx
@@ -29,8 +29,8 @@ export type RadioGroupProps = CreateWuiProps<
 export const RadioGroup = forwardRef<'fieldset', RadioGroupProps>(
   (
     {
-      flexDirection,
-      maxWidth,
+      $flexDirection,
+      $maxW,
       label,
       name,
       options = [],
@@ -45,8 +45,8 @@ export const RadioGroup = forwardRef<'fieldset', RadioGroupProps>(
     const withHint = options.findIndex(obj => Object.keys(obj).includes('hint')) !== -1
 
     return (
-      <FieldGroup as={ReakitRadioGroup} label={label} mb={0} ref={ref} required={required}>
-        <S.Radios flexDirection={flexDirection}>
+      <FieldGroup $mb="0" as={ReakitRadioGroup} label={label} ref={ref} required={required}>
+        <S.Radios $flexDirection={$flexDirection}>
           {options.map(option => (
             <Component
               {...rest}
@@ -55,7 +55,7 @@ export const RadioGroup = forwardRef<'fieldset', RadioGroupProps>(
               id={`${name}.${option.value}`}
               key={option.value}
               label={option.label}
-              maxWidth={maxWidth}
+              maxWidth={$maxW}
               name={name}
               type="radio"
               value={option.value}

--- a/packages/RadioGroup/package.json
+++ b/packages/RadioGroup/package.json
@@ -44,7 +44,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/RadioGroup/styles.ts
+++ b/packages/RadioGroup/styles.ts
@@ -1,14 +1,12 @@
-import styled, { css, system } from '@xstyled/styled-components'
-import { WuiProps } from '@welcome-ui/system'
+import styled, { css } from 'styled-components'
+import { system, WuiProps } from '@welcome-ui/system'
 
-export const Radios = styled.div<{
-  flexDirection?: WuiProps['flexDirection']
-}>(
-  ({ flexDirection }) => css`
+export const Radios = styled.div<WuiProps>(
+  ({ $flexDirection, theme }) => css`
     display: flex;
-    flex-direction: ${flexDirection};
+    flex-direction: ${$flexDirection};
     flex-wrap: wrap;
-    margin-bottom: -md;
+    margin-bottom: -${theme.space.md};
     ${system};
 
     > *:not(:last-child) {

--- a/packages/RadioGroup/styles.ts
+++ b/packages/RadioGroup/styles.ts
@@ -6,11 +6,11 @@ export const Radios = styled.div<WuiProps>(
     display: flex;
     flex-direction: ${$flexDirection};
     flex-wrap: wrap;
-    margin-bottom: -${theme.space.md};
+    margin-bottom: -${theme.spaces.md};
     ${system};
 
     > *:not(:last-child) {
-      margin-bottom: md;
+      margin-bottom: ${theme.spaces.md};
     }
   `
 )

--- a/packages/RadioGroup/tsconfig.json
+++ b/packages/RadioGroup/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/RadioTab/index.tsx
+++ b/packages/RadioTab/index.tsx
@@ -21,11 +21,11 @@ export type RadioTabsProps = CreateWuiProps<
 
 export const RadioTab = forwardRef<'input', RadioTabsProps>((props, ref) => {
   const {
+    $flexDirection,
     checked,
     dataTestId,
     disabled,
     disabledIcon,
-    flexDirection,
     label,
     onChange,
     onClick,
@@ -42,10 +42,10 @@ export const RadioTab = forwardRef<'input', RadioTabsProps>((props, ref) => {
 
   return (
     <S.Label
+      $flexDirection={$flexDirection}
       checked={checked}
       disabled={disabled}
       disabledIcon={disabledIcon}
-      flexDirection={flexDirection}
       onClick={handleClick}
       size={size}
       variant={variant}

--- a/packages/RadioTab/package.json
+++ b/packages/RadioTab/package.json
@@ -43,7 +43,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/RadioTab/styles.ts
+++ b/packages/RadioTab/styles.ts
@@ -1,10 +1,9 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Radio as ReakitRadio } from 'reakit/Radio'
-import { shouldForwardProp } from '@welcome-ui/system'
 import { defaultFieldStyles, DefaultFieldStylesProps, overflowEllipsis } from '@welcome-ui/utils'
-import { WuiProps } from '@welcome-ui/system'
+import { system, WuiProps } from '@welcome-ui/system'
 
-export const Radio = styled(ReakitRadio).withConfig({ shouldForwardProp })`
+export const Radio = styled(ReakitRadio)`
   position: absolute;
   top: 0;
   left: 0;
@@ -13,7 +12,7 @@ export const Radio = styled(ReakitRadio).withConfig({ shouldForwardProp })`
 `
 
 const columnStyles = css`
-  margin-top: -${th.borderWidth('sm')};
+  margin-top: -${({ theme }) => theme.borderWidths.sm};
   border-radius: 0;
 
   &:first-of-type {
@@ -30,17 +29,17 @@ const columnStyles = css`
 `
 
 const rowStyles = css`
-  margin-left: -${th.borderWidth('sm')};
+  margin-left: -${({ theme }) => theme.borderWidths.sm};
   border-radius: 0;
 
   &:first-of-type {
-    border-radius: md;
+    border-radius: ${({ theme }) => theme.space.md};
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
 
   &:last-of-type {
-    border-radius: md;
+    border-radius: ${({ theme }) => theme.space.md};
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
@@ -49,34 +48,34 @@ const rowStyles = css`
 export const Label = styled.label<
   {
     checked?: boolean
-    flexDirection?: WuiProps['flexDirection']
     disabled?: boolean
     disabledIcon?: React.ReactElement
-  } & DefaultFieldStylesProps
+  } & DefaultFieldStylesProps &
+    WuiProps
 >(
-  ({ checked, flexDirection, size, variant }) => css`
-    ${th('radioTabs.default')};
+  ({ $flexDirection, checked, size, theme, variant }) => css`
+    ${theme.radioTabs.default};
     flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
     min-width: 0;
-    min-height: ${th(`defaultFields.sizes.${size}.height`)};
+    min-height: ${theme.defaultFields.sizes[size].height};
     max-width: 100%;
     margin: 0;
     text-align: center;
     position: relative;
     cursor: pointer;
-    transition: medium;
+    transition: ${theme.transitions.medium};
 
     ${defaultFieldStyles({ size, variant })};
     ${checked &&
     css`
-      ${th('radioTabs.checked')};
+      ${theme.radioTabs.checked};
       z-index: 2;
     `};
-    ${flexDirection === 'column' && columnStyles};
-    ${flexDirection === 'row' && rowStyles};
+    ${$flexDirection === 'column' && columnStyles};
+    ${$flexDirection === 'row' && rowStyles};
     ${system};
     padding-top: 0;
     padding-bottom: 0;

--- a/packages/RadioTab/styles.ts
+++ b/packages/RadioTab/styles.ts
@@ -16,13 +16,13 @@ const columnStyles = css`
   border-radius: 0;
 
   &:first-of-type {
-    border-radius: md;
+    border-radius: ${({ theme }) => theme.spaces.md};
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
 
   &:last-of-type {
-    border-radius: md;
+    border-radius: ${({ theme }) => theme.spaces.md};
     border-top-right-radius: 0;
     border-top-left-radius: 0;
   }

--- a/packages/RadioTab/tsconfig.json
+++ b/packages/RadioTab/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Search/package.json
+++ b/packages/Search/package.json
@@ -46,7 +46,6 @@
     "downshift": "^7.0.1"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Search/styles.ts
+++ b/packages/Search/styles.ts
@@ -1,11 +1,11 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { StyledIcon } from '@welcome-ui/icon'
-import { shouldForwardProp } from '@welcome-ui/system'
+import { system } from '@welcome-ui/system'
 import { cardStyles, centerContent, defaultFieldStyles, overflowEllipsis } from '@welcome-ui/utils'
 
 import { SearchOptions } from './index'
 
-export const Wrapper = styled('div').withConfig({ shouldForwardProp })`
+export const Wrapper = styled('div')`
   position: relative;
   ${system};
 `
@@ -14,16 +14,14 @@ export const InputWrapper = styled.div`
   position: relative;
 `
 
-export const Input = styled('input').withConfig({ shouldForwardProp })<
-  { hasIcon?: boolean } & SearchOptions
->(
-  ({ hasIcon, size, transparent, variant }) => css`
+export const Input = styled('input')<{ hasIcon?: boolean } & SearchOptions>(
+  ({ hasIcon, size, theme, transparent, variant }) => css`
     position: relative;
     ${defaultFieldStyles({ size, variant, transparent })};
     ${overflowEllipsis};
     ${hasIcon &&
     css`
-      padding-left: ${th(`defaultFields.sizes.${size}.height`)};
+      padding-left: ${theme.defaultFields.sizes[size as SearchOptions['size']].height};
     `};
     ${system};
 
@@ -33,45 +31,47 @@ export const Input = styled('input').withConfig({ shouldForwardProp })<
   `
 )
 
-export const Menu = styled.ul`
-  ${th('defaultFields.select.default')};
-  ${cardStyles}
-  position: absolute;
-  z-index: 2;
-  right: 0;
-  left: 0;
-  margin: 0;
-  margin-top: md;
-  padding: 0;
-  transition: medium;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
-`
+export const Menu = styled.ul(
+  ({ theme }) => css`
+    ${theme.defaultFields.select.default};
+    ${cardStyles}
+    position: absolute;
+    z-index: 2;
+    right: 0;
+    left: 0;
+    margin: 0;
+    margin-top: ${theme.space.md};
+    padding: 0;
+    transition: ${theme.transitions.medium};
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  `
+)
 
 export const Item = styled.li<{
   isExisting?: boolean
   isHighlighted?: boolean
   isSelected?: boolean
 }>(
-  ({ isExisting, isHighlighted, isSelected }) => css`
-    color: nude-700;
-    ${isHighlighted && th('defaultFields.select.highlighted')};
-    ${isSelected && th('defaultFields.select.selected')};
-    ${isExisting && th('defaultFields.select.existing')};
-    ${isSelected && isHighlighted && th('defaultFields.select.selectedAndHighlighted')};
+  ({ isExisting, isHighlighted, isSelected, theme }) => css`
+    color: ${theme.colors['nude-700']};
+    ${isHighlighted && theme.defaultFields.select.highlighted};
+    ${isSelected && theme.defaultFields.select.selected};
+    ${isExisting && theme.defaultFields.select.existing};
+    ${isSelected && isHighlighted && theme.defaultFields.select.selectedAndHighlighted};
     ${overflowEllipsis};
-    padding: sm;
+    padding: ${theme.space.md};
     list-style: none;
     text-decoration: none;
-    font-size: sm;
-    transition: background ${th.transition('medium')};
+    font-size: ${theme.space.md};
+    transition: background ${theme.transitions.medium};
   `
 )
 
 export const Icon = styled.div<{ size: SearchOptions['size'] }>(
-  ({ size }) => css`
+  ({ size, theme }) => css`
     position: absolute;
-    width: ${th(`defaultFields.sizes.${size}.height`)};
+    width: ${theme.defaultFields.sizes[size].height};
     padding: 0;
     top: 0;
     bottom: 0;
@@ -90,10 +90,10 @@ export const Indicators = styled.div`
 `
 
 export const DropDownIndicator = styled.button<{ size: SearchOptions['size']; isOpen?: boolean }>(
-  ({ isOpen, size }) => css`
+  ({ isOpen, size, theme }) => css`
     position: relative;
     height: 100%;
-    width: ${th(`defaultFields.sizes.${size}.height`)};
+    width: ${theme.defaultFields.sizes[size].height};
     padding: 0;
     outline: none !important; /* important for firefox */
     appearance: none;
@@ -104,7 +104,7 @@ export const DropDownIndicator = styled.button<{ size: SearchOptions['size']; is
 
     ${StyledIcon} {
       transform: ${isOpen ? 'rotate3d(0, 0, 1, 180deg)' : 'rotate3d(0)'};
-      transition: medium;
+      transition: ${theme.transitions.medium};
     }
 
     &:not(:last-child) {

--- a/packages/Search/tsconfig.json
+++ b/packages/Search/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Select/index.test.tsx
+++ b/packages/Select/index.test.tsx
@@ -266,7 +266,9 @@ test('<Select isMultiple> can remove multiple items', () => {
   expect(tags.length).toBe(2)
 
   const removeButton = tags[1].querySelector('[title=Remove]')
-  fireEvent.click(removeButton)
+  if (removeButton) {
+    fireEvent.click(removeButton)
+  }
   tags = getAllByRole('listitem')
   expect(tags.length).toBe(1)
 
@@ -309,7 +311,7 @@ test('<Select renderItem> formats items', () => {
   const select = getByTestId('select')
   const icon = select.querySelector('svg')
   expect(select).toHaveTextContent('February')
-  expect(icon.getAttribute('title')).toBe('Calendar')
+  expect(icon?.getAttribute('title')).toBe('Calendar')
 })
 
 test('<Select icon> shows icon', () => {
@@ -380,7 +382,9 @@ test('<Select isCreatable> can create new items', async () => {
   expect(option).toHaveTextContent(`Create "${firstItem.label}"`)
 
   // Click on 'Create' item
-  fireEvent.click(option)
+  if (option) {
+    fireEvent.click(option)
+  }
 
   // Expect `onCreate` callback to be called
   expect(handleCreate).toHaveBeenCalledTimes(1)
@@ -402,7 +406,9 @@ test('<Select isCreatable> can create new items', async () => {
   expect(option).toHaveTextContent(`Create "${secondItem.label}"`)
 
   // Click on 'Create' item
-  fireEvent.click(option)
+  if (option) {
+    fireEvent.click(option)
+  }
 
   // Expect `onCreate` callback to be called
   expect(handleCreate).toHaveBeenCalledTimes(2)
@@ -437,7 +443,9 @@ test('<Select isCreatable isMultiple> can create new items', async () => {
 
   // Click on 'Create' item
   const option = getByRole('listbox').querySelector('li')
-  fireEvent.click(option)
+  if (option) {
+    fireEvent.click(option)
+  }
 
   // Expect `onCreate` callback to be called
   expect(handleCreate).toHaveBeenCalledTimes(1)
@@ -481,7 +489,9 @@ test("<Select isCreatable> can't create an existing item", async () => {
   expect(option).toHaveTextContent('October')
 
   // Click on 'Create' item
-  fireEvent.click(option)
+  if (option) {
+    fireEvent.click(option)
+  }
 
   // Expect `onCreate` callback not to be called
   expect(handleCreate).toHaveBeenCalledTimes(0)

--- a/packages/Select/package.json
+++ b/packages/Select/package.json
@@ -47,7 +47,6 @@
     "match-sorter": "^6.3.1"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Select/styles.ts
+++ b/packages/Select/styles.ts
@@ -1,7 +1,7 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { StyledIcon } from '@welcome-ui/icon'
 import { StyledTag } from '@welcome-ui/tag'
-import { shouldForwardProp } from '@welcome-ui/system'
+import { system } from '@welcome-ui/system'
 import {
   cardStyles,
   centerContent,
@@ -12,7 +12,7 @@ import {
 
 import { SelectOptions } from './index'
 
-export const Wrapper = styled('div').withConfig({ shouldForwardProp })`
+export const Wrapper = styled('div')`
   position: relative;
   ${system}
 `
@@ -21,7 +21,7 @@ export const InputWrapper = styled.div`
   position: relative;
 `
 
-export const Input = styled('div').withConfig({ shouldForwardProp })(
+export const Input = styled('div')(
   ({
     hasIcon,
     isClearable,
@@ -71,46 +71,42 @@ export const Input = styled('div').withConfig({ shouldForwardProp })(
   `
 )
 
-export const Menu = styled.ul`
-  ${th('defaultFields.select.default')};
-  ${cardStyles};
-  position: absolute;
-  z-index: 2;
-  right: 0;
-  left: 0;
-  margin: 0;
-  margin-top: md;
-  padding: 0;
-  transition: medium;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
-`
+export const Menu = styled.ul(
+  ({ theme }) => css`
+    ${theme.defaultFields.select.default};
+    ${cardStyles};
+    position: absolute;
+    z-index: 2;
+    right: 0;
+    left: 0;
+    margin: 0;
+    margin-top: ${theme.space.md};
+    padding: 0;
+    transition: ${theme.transitions.medium};
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  `
+)
 
-export const Item = styled.li(
-  ({
-    allowUnselectFromList,
-    isDisabled,
-    isHighlighted,
-    isMultiple,
-    isSelected,
-  }: {
-    allowUnselectFromList: boolean
-    isHighlighted: boolean
-    isMultiple: boolean
-    isSelected: boolean
-    isDisabled?: boolean
-  }) => css`
+export const Item = styled.li<{
+  allowUnselectFromList: boolean
+  isHighlighted: boolean
+  isMultiple: boolean
+  isSelected: boolean
+  isDisabled?: boolean
+}>(
+  ({ allowUnselectFromList, isDisabled, isHighlighted, isMultiple, isSelected, theme }) => css`
     color: nude-700;
-    ${isHighlighted && th('defaultFields.select.highlighted')};
-    ${isSelected && !isMultiple && th('defaultFields.select.selected')};
-    ${isSelected && isMultiple && !allowUnselectFromList && th('defaultFields.select.existing')};
-    ${isDisabled && th('defaultFields.select.disabled')};
+    ${isHighlighted && theme.defaultFields.select.highlighted};
+    ${isSelected && !isMultiple && theme.defaultFields.select.selected};
+    ${isSelected && isMultiple && !allowUnselectFromList && theme.defaultFields.select.existing};
+    ${isDisabled && theme.defaultFields.select.disabled};
     ${overflowEllipsis};
     padding: sm;
     list-style: none;
     text-decoration: none;
     font-size: sm;
-    transition: background ${th.transition('medium')};
+    transition: background ${theme.transitions.medium};
   `
 )
 
@@ -130,8 +126,8 @@ export const Indicators = styled.div(
   `
 )
 
-export const DropDownIndicator = styled.button.withConfig({ shouldForwardProp })(
-  ({ isOpen }: { isOpen?: boolean }) => css`
+export const DropDownIndicator = styled.button<{ isOpen?: boolean }>(
+  ({ isOpen, theme }) => css`
     position: relative;
     height: 100%;
     padding: 0;
@@ -144,7 +140,7 @@ export const DropDownIndicator = styled.button.withConfig({ shouldForwardProp })
 
     ${StyledIcon} {
       transform: ${isOpen ? 'rotate3d(0, 0, 1, 180deg)' : 'rotate3d(0)'};
-      transition: medium;
+      transition: ${theme.transitions.medium};
     }
 
     &:not(:last-child) {
@@ -153,15 +149,17 @@ export const DropDownIndicator = styled.button.withConfig({ shouldForwardProp })
   `
 )
 
-export const Tags = styled.div`
-  margin-top: lg;
+export const Tags = styled.div(
+  ({ theme }) => css`
+    margin-top: ${theme.space.lg};
 
-  ${/* sc-selector */ StyledTag}:not(:last-child) {
-    margin-right: sm;
-    margin-bottom: sm;
-  }
+    ${/* sc-selector */ StyledTag}:not(:last-child) {
+      margin-right: ${theme.space.sm};
+      margin-bottom: ${theme.space.sm};
+    }
 
-  &:empty {
-    display: none;
-  }
-`
+    &:empty {
+      display: none;
+    }
+  `
+)

--- a/packages/Select/styles.ts
+++ b/packages/Select/styles.ts
@@ -21,21 +21,15 @@ export const InputWrapper = styled.div`
   position: relative;
 `
 
-export const Input = styled('div')(
-  ({
-    hasIcon,
-    isClearable,
-    size,
-    transparent,
-    variant,
-  }: { hasIcon: boolean } & SelectOptions) => css`
+export const Input = styled('div')<{ hasIcon: boolean } & SelectOptions>(
+  ({ hasIcon, isClearable, size, theme, transparent, variant }) => css`
     position: relative;
     ${defaultFieldStyles({ size, variant, transparent })};
     ${overflowEllipsis};
-    padding-right: ${isClearable ? '4xl' : '36'};
+    padding-right: ${isClearable ? theme.spaces['4xl'] : '36px'};
     ${hasIcon &&
     css`
-      padding-left: 36;
+      padding-left: 36px;
     `};
     cursor: default;
     ${system}
@@ -96,32 +90,32 @@ export const Item = styled.li<{
   isDisabled?: boolean
 }>(
   ({ allowUnselectFromList, isDisabled, isHighlighted, isMultiple, isSelected, theme }) => css`
-    color: nude-700;
+    color: ${theme.colors['nude-700']};
     ${isHighlighted && theme.defaultFields.select.highlighted};
     ${isSelected && !isMultiple && theme.defaultFields.select.selected};
     ${isSelected && isMultiple && !allowUnselectFromList && theme.defaultFields.select.existing};
     ${isDisabled && theme.defaultFields.select.disabled};
     ${overflowEllipsis};
-    padding: sm;
+    padding: ${theme.spaces.sm};
     list-style: none;
     text-decoration: none;
-    font-size: sm;
+    font-size: ${theme.fontSizes.sm};
     transition: background ${theme.transitions.medium};
   `
 )
 
-export const Indicators = styled.div(
-  ({ size }: { size: Size }) => css`
+export const Indicators = styled.div<{ size: Size }>(
+  ({ size, theme }) => css`
     position: absolute;
     padding: 0;
     top: 0;
     bottom: 0;
-    right: ${size === 'xs' ? 'sm' : 'md'};
+    right: ${size === 'xs' ? theme.spaces.sm : theme.spaces.md};
     display: flex;
-    gap: sm;
+    gap: ${theme.spaces.sm};
 
     > * {
-      width: 16;
+      width: 16px;
     }
   `
 )

--- a/packages/Select/tsconfig.json
+++ b/packages/Select/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Shape/index.test.tsx
+++ b/packages/Shape/index.test.tsx
@@ -9,7 +9,7 @@ const content = 'Jungle'
 describe('<Shape>', () => {
   it('should render correctly', () => {
     const { container } = render(
-      <Shape h="100px" w="100px">
+      <Shape $h="100px" $w="100px">
         {content}
       </Shape>
     )
@@ -19,7 +19,7 @@ describe('<Shape>', () => {
 
   it('should render correctly with borderRadius', () => {
     const { getByTestId } = render(
-      <Shape borderRadius="lg" dataTestId="shape" h="100px" w="100px">
+      <Shape $borderRadius="lg" $h="100px" $w="100px" dataTestId="shape">
         {content}
       </Shape>
     )
@@ -30,7 +30,7 @@ describe('<Shape>', () => {
 
   it('using shape with unequal width / height props should use biggest value', () => {
     const { getByTestId } = render(
-      <Shape dataTestId="shape" h="1px" shape="circle" w="100px">
+      <Shape $h="1px" $w="100px" dataTestId="shape" shape="circle">
         {content}
       </Shape>
     )
@@ -43,7 +43,7 @@ describe('<Shape>', () => {
 
   it('should render a circle shape', () => {
     const { getByTestId } = render(
-      <Shape borderRadius="lg" dataTestId="shape" h="100px" shape="circle" w="100px">
+      <Shape $borderRadius="lg" $h="100px" $w="100px" dataTestId="shape" shape="circle">
         {content}
       </Shape>
     )

--- a/packages/Shape/package.json
+++ b/packages/Shape/package.json
@@ -38,11 +38,10 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "@welcome-ui/system": "^5.0.0-alpha.0",
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Shape/package.json
+++ b/packages/Shape/package.json
@@ -38,10 +38,10 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
+    "@welcome-ui/system": "^5.0.0-alpha.0",
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Shape/styles.ts
+++ b/packages/Shape/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { getMax } from '@welcome-ui/utils'
 import { Box } from '@welcome-ui/box'
 
@@ -11,13 +11,13 @@ const shapeStyles = (w: string, h: string, shape: ShapeOptions['shape']) => css`
 `
 
 export const Shape = styled(Box)<ShapeOptions>(
-  ({ h, shape, w }) => css`
+  ({ $h, $w, shape }) => css`
     position: relative;
     overflow: hidden;
     display: flex;
     align-items: center;
     justify-content: center;
-    ${shape && shapeStyles(w as string, h as string, shape)}
+    ${shape && shapeStyles($w as string, $h as string, shape)}
 
     img {
       object-fit: cover;

--- a/packages/Shape/tsconfig.json
+++ b/packages/Shape/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Slider/Range.tsx
+++ b/packages/Slider/Range.tsx
@@ -183,17 +183,18 @@ export const Range = forwardRef<'div', RangeProps>(
     }, [value])
 
     return (
-      <Box position="relative" w="100%">
+      <Box $position="relative" $w="100%">
         {label && (
           <Text as="label" variant="sm">
             {label}
           </Text>
         )}
 
-        <Box alignItems="center" display="flex" gap="sm">
+        <Box $alignItems="center" $display="flex" $gap="sm">
           {(type === 'inline' || type === 'fields') &&
             (type === 'fields' ? (
               <InputText
+                $w="72px"
                 max={maxValue}
                 min={min}
                 onChange={e => {
@@ -214,13 +215,12 @@ export const Range = forwardRef<'div', RangeProps>(
                 size="sm"
                 type="number"
                 value={inputMinValue.toString()}
-                w={72}
               />
             ) : (
               <Box>{min}</Box>
             ))}
 
-          <Box position="relative" w="100%">
+          <Box $position="relative" $w="100%">
             {tooltip && (
               <>
                 <S.Output isVisible={tooltipMinVisible} ref={tooltipMinRef}>
@@ -232,7 +232,7 @@ export const Range = forwardRef<'div', RangeProps>(
                 </S.Output>
               </>
             )}
-            <Box h={20} pb="sm" position="relative" pt="sm" w="100%">
+            <Box $h="20px" $pb="sm" $position="relative" $pt="sm" $w="100%">
               <S.RangeInput
                 {...restProps}
                 borderSelectorColor={borderSelectorColor}
@@ -280,13 +280,13 @@ export const Range = forwardRef<'div', RangeProps>(
             </Box>
 
             {values && (
-              <Box h={24} ml={10} mr={10} position="relative">
+              <Box $h="24px" $ml="10px" $mr="10px" $position="relative">
                 {values
                   .reduce((prev, acc) => (prev.includes(acc) ? prev : [...prev, acc]), [])
                   .filter(v => v >= min && v <= max)
                   .map((el, index) => (
                     // eslint-disable-next-line react/no-array-index-key
-                    <S.Thick key={`${el}-${index}`} left={`${getPercent(el)}%`}>
+                    <S.Thick $left={`${getPercent(el)}%`} key={`${el}-${index}`}>
                       <S.ThickLabel>{el}</S.ThickLabel>
                     </S.Thick>
                   ))}
@@ -297,6 +297,7 @@ export const Range = forwardRef<'div', RangeProps>(
           {(type === 'inline' || type === 'fields') &&
             (type === 'fields' ? (
               <InputText
+                $w="72px"
                 max={max}
                 min={minValue + 1}
                 onChange={e => {
@@ -317,7 +318,6 @@ export const Range = forwardRef<'div', RangeProps>(
                 size="sm"
                 type="number"
                 value={inputMaxValue.toString()}
-                w={72}
               />
             ) : (
               <Box>{max}</Box>
@@ -325,7 +325,7 @@ export const Range = forwardRef<'div', RangeProps>(
         </Box>
 
         {hint && (
-          <Hint color="dark.400" mt={0}>
+          <Hint $color="dark.400" $mt="0">
             {hint}
           </Hint>
         )}

--- a/packages/Slider/index.tsx
+++ b/packages/Slider/index.tsx
@@ -127,16 +127,17 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
     }, [value])
 
     return (
-      <Box display="flex" flexDirection="column" position="relative">
+      <Box $display="flex" $flexDirection="column" $position="relative">
         {label && (
           <Text as="label" variant="sm">
             {label}
           </Text>
         )}
-        <Box alignItems="center" display="flex" gap="sm">
+        <Box $alignItems="center" $display="flex" $gap="sm">
           {(type === 'inline' || type === 'left-field') &&
             (type === 'left-field' ? (
               <InputText
+                $w="72px"
                 max={max}
                 min={min}
                 onChange={handleInputChange}
@@ -144,13 +145,12 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
                 size="sm"
                 type="number"
                 value={inputValue.toString()}
-                w={72}
               />
             ) : (
               <Box>{min}</Box>
             ))}
 
-          <Box display="flex" h={20} position="relative" w="100%">
+          <Box $display="flex" $h="20px" $position="relative" $w="100%">
             <S.Slider
               borderSelectorColor={borderSelectorColor}
               disabled={disabled}
@@ -166,7 +166,7 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
                   setInputValue(value)
                 }
                 // eslint-disable-next-line prettier/prettier
-                }      
+              }
               onKeyDown={handleKeyDown}
               onMouseDown={() => {
                 tooltip && tooltipVisible === false && setTooltipVisible(true)
@@ -187,13 +187,13 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
               </S.Output>
             )}
             {values && (
-              <Box h={24} ml={10} mr={10} position="relative">
+              <Box $h="24px" $ml="10px" $mr="10px" $position="relative">
                 {values
                   .reduce((prev, acc) => (prev.includes(acc) ? prev : [...prev, acc]), [])
                   .filter(v => v >= min && v <= max)
                   .map((el, index) => (
                     // eslint-disable-next-line react/no-array-index-key
-                    <S.Thick key={`${el}-${index}`} left={`${getPercent(el)}%`}>
+                    <S.Thick $left={`${getPercent(el)}%`} key={`${el}-${index}`}>
                       <S.ThickLabel>{el}</S.ThickLabel>
                     </S.Thick>
                   ))}
@@ -204,6 +204,7 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
           {(type === 'inline' || type === 'right-field') &&
             (type === 'right-field' ? (
               <InputText
+                $w="72px"
                 max={max}
                 min={min}
                 onChange={handleInputChange}
@@ -211,7 +212,6 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
                 size="sm"
                 type="number"
                 value={inputValue.toString()}
-                w={72}
               />
             ) : (
               <Box>{max}</Box>
@@ -219,7 +219,7 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
         </Box>
 
         {hint && (
-          <Hint color="dark.400" mt={0}>
+          <Hint $color="dark-400" $mt="0px">
             {hint}
           </Hint>
         )}

--- a/packages/Slider/package.json
+++ b/packages/Slider/package.json
@@ -42,7 +42,6 @@
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.6.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.3"
   },

--- a/packages/Slider/package.json
+++ b/packages/Slider/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@welcome-ui/system": "^5.0.0-alpha.0",
+    "@welcome-ui/text": "^5.0.0-alpha.0",
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {

--- a/packages/Slider/styles.ts
+++ b/packages/Slider/styles.ts
@@ -9,8 +9,8 @@ type BorderProps = {
 const sliderSelector = css`
   appearance: none;
   cursor: pointer;
-  height: 20;
-  width: 20;
+  height: 20px;
+  width: 20px;
   transform: scale(1);
   transition: background-color ${({ theme }) => theme.transitions.medium},
     border-color ${({ theme }) => theme.transitions.medium}, transform 100ms ease-in-out;

--- a/packages/Slider/styles.ts
+++ b/packages/Slider/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 import { Hint } from '@welcome-ui/hint'
 
@@ -12,40 +12,40 @@ const sliderSelector = css`
   height: 20;
   width: 20;
   transform: scale(1);
-  transition: background-color ${th.transition('medium')}, border-color ${th.transition('medium')},
-    transform 100ms ease-in-out;
+  transition: background-color ${({ theme }) => theme.transitions.medium},
+    border-color ${({ theme }) => theme.transitions.medium}, transform 100ms ease-in-out;
 `
 
 const sliderFocused = css`
-  ${th('sliders.focused')};
+  ${({ theme }) => theme.sliders.focused};
   transform: scale(1.2);
 `
 
 const rangeTrack = css`
   position: absolute;
   width: 100%;
-  height: ${th('space.xs')};
+  height: ${({ theme }) => theme.space.xs};
 `
 
 export const Slider = styled.input<BorderProps>(
-  ({ borderSelectorColor, disabled }) => css`
-    ${th('sliders.default')};
+  ({ borderSelectorColor, disabled, theme }) => css`
+    ${theme.sliders.default};
     appearance: none;
     cursor: pointer;
     background-repeat: no-repeat;
     border-radius: 0;
     margin: auto 0;
     width: 100%;
-    height: ${th('space.xs')};
+    height: ${theme.space.xs};
 
     &::-webkit-slider-thumb {
-      ${th('sliders.selector')};
+      ${theme.sliders.selector};
       ${sliderSelector};
       border-color: ${borderSelectorColor ? borderSelectorColor : 'transparent'};
     }
 
     &::-moz-range-thumb {
-      ${th('sliders.selector')};
+      ${theme.sliders.selector};
       ${sliderSelector};
       border-color: ${borderSelectorColor ? borderSelectorColor : 'transparent'};
     }
@@ -65,26 +65,26 @@ export const Slider = styled.input<BorderProps>(
 
     ${disabled &&
     css`
-      ${th('sliders.disabled')}
+      ${theme.sliders.disabled}
       cursor: not-allowed;
 
       &::-webkit-slider-thumb {
-        ${th('sliders.selector.disabled')};
+        ${theme.sliders.selector.disabled};
         cursor: not-allowed;
       }
 
       &::-moz-range-thumb {
-        ${th('sliders.selector.disabled')};
+        ${theme.sliders.selector.disabled};
         cursor: not-allowed;
       }
 
       &:active {
         &::-webkit-slider-thumb {
-          ${th('sliders.focused.disabled')};
+          ${theme.sliders.focused.disabled};
         }
 
         &::-moz-range-thumb {
-          ${th('sliders.focused.disabled')};
+          ${theme.sliders.focused.disabled};
         }
       }
     `};
@@ -92,8 +92,8 @@ export const Slider = styled.input<BorderProps>(
 )
 
 export const RangeInput = styled.input<BorderProps>(
-  ({ borderSelectorColor, disabled }) => css`
-    ${th('sliders.rangeInput')}
+  ({ borderSelectorColor, disabled, theme }) => css`
+    ${theme.sliders.rangeInput}
     appearance: none;
     pointer-events: none;
     position: absolute;
@@ -101,24 +101,24 @@ export const RangeInput = styled.input<BorderProps>(
     width: 100%;
     outline: none;
     z-index: 1;
-    top: ${th('space.xxs')};
+    top: ${theme.space.xxs};
 
     &::-webkit-slider-thumb {
-      ${th('sliders.selector')};
+      ${theme.sliders.selector};
       ${sliderSelector};
 
       border-color: ${borderSelectorColor ? borderSelectorColor : 'transparent'};
-      top: ${th('space.sm')};
+      top: ${theme.space.sm};
       pointer-events: all;
       position: relative;
     }
 
     &::-moz-range-thumb {
-      ${th('sliders.selector')};
+      ${theme.sliders.selector};
       ${sliderSelector};
 
       border-color: ${borderSelectorColor ? borderSelectorColor : 'transparent'};
-      top: ${th('space.sm')};
+      top: ${theme.space.sm};
       pointer-events: all;
       position: relative;
     }
@@ -137,22 +137,22 @@ export const RangeInput = styled.input<BorderProps>(
     ${disabled &&
     css`
       &::-webkit-slider-thumb {
-        ${th('sliders.selector.disabled')};
+        ${theme.sliders.selector.disabled};
         cursor: not-allowed;
       }
 
       &::-moz-range-thumb {
-        ${th('sliders.selector.disabled')};
+        ${theme.sliders.selector.disabled};
         cursor: not-allowed;
       }
 
       &:active {
         &::-webkit-slider-thumb {
-          ${th('sliders.focused.disabled')};
+          ${theme.sliders.focused.disabled};
         }
 
         &::-moz-range-thumb {
-          ${th('sliders.focused.disabled')};
+          ${theme.sliders.focused.disabled};
         }
       }
     `};
@@ -160,9 +160,9 @@ export const RangeInput = styled.input<BorderProps>(
 )
 
 export const Track = styled(Box)(
-  () => css`
+  ({ theme }) => css`
     ${rangeTrack};
-    background-color: nude-400;
+    background-color: ${theme.colors['nude-400']};
   `
 )
 
@@ -171,26 +171,26 @@ type RangeProps = {
 }
 
 export const Range = styled(Box)<RangeProps>(
-  ({ disabled }) => css`
+  ({ disabled, theme }) => css`
     ${rangeTrack};
-    background-color: primary-500;
+    background-color: ${theme.colors['primary-500']};
 
     ${disabled &&
     css`
-      ${th('sliders.disabled')}
+      ${theme.sliders.disabled}
       cursor: not-allowed;
     `};
   `
 )
 
 export const Thick = styled(Box)(
-  () => css`
+  ({ theme }) => css`
     position: absolute;
 
     :before {
       content: '';
       position: absolute;
-      background-color: dark-200;
+      background-color: ${theme.colors['dark-200']};
       height: 6;
       width: 1;
       transform: translate(-50%);
@@ -199,9 +199,9 @@ export const Thick = styled(Box)(
 )
 
 export const ThickLabel = styled(Hint)(
-  () => css`
+  ({ theme }) => css`
     position: absolute;
-    color: dark-400;
+    color: ${theme.colors['dark-400']};
     top: 0;
     transform: translate(-50%);
     white-space: nowrap;
@@ -213,29 +213,29 @@ type OutputProps = {
 }
 
 export const Output = styled.output<OutputProps>(
-  ({ isVisible }) => css`
+  ({ isVisible, theme }) => css`
     opacity: 0;
     visibility: hidden;
     transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out, transform 150ms ease-in-out;
     position: absolute;
     text-align: center;
-    transform: translate(-50%, calc(-100% + -${th('space.xs')}));
+    transform: translate(-50%, calc(-100% + -${theme.space.xs}));
 
     ${isVisible &&
     css`
       opacity: 100;
       visibility: visible;
-      transform: translate(-50%, calc(-100% + -${th('space.sm')}));
+      transform: translate(-50%, calc(-100% + -${theme.space.sm}));
     `}
   `
 )
 
 export const Tooltip = styled(Box)(
-  () => css`
-    ${th('sliders.output.tooltip')};
+  ({ theme }) => css`
+    ${theme.sliders.output.tooltip};
     flex: 1 1 auto;
     margin: auto;
-    min-width: ${th('space.xxs')};
-    padding: ${th('space.xs')} ${th('space.sm')};
+    min-width: ${theme.space.xxs};
+    padding: ${theme.space.xs} ${theme.space.sm};
   `
 )

--- a/packages/Slider/tsconfig.json
+++ b/packages/Slider/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Stack/index.tsx
+++ b/packages/Stack/index.tsx
@@ -13,14 +13,14 @@ export const Stack = forwardRef<'div', StackProps>(
   ({ as = 'div', children, dataTestId, direction = 'column', spacing = 'md', ...rest }, ref) => {
     const validChildrenArray = Children.toArray(children).filter(isValidElement)
 
-    const marginType = direction === 'column' ? 'mb' : 'mr'
+    const marginType = direction === 'column' ? '$mb' : '$mr'
 
     return (
       <Box
+        $display="flex"
+        $flexDirection={direction}
         as={as}
         data-testid={dataTestId}
-        display="flex"
-        flexDirection={direction}
         ref={ref}
         {...rest}
       >

--- a/packages/Stack/package.json
+++ b/packages/Stack/package.json
@@ -38,10 +38,10 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "@welcome-ui/box": "^5.0.0-alpha.0"
+    "@welcome-ui/box": "^5.0.0-alpha.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Stack/package.json
+++ b/packages/Stack/package.json
@@ -38,11 +38,10 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "@welcome-ui/box": "^5.0.0-alpha.0",
-    "@welcome-ui/system": "^5.0.0-alpha.0"
+    "@welcome-ui/box": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Stack/tsconfig.json
+++ b/packages/Stack/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Swiper/index.tsx
+++ b/packages/Swiper/index.tsx
@@ -1,5 +1,5 @@
 import React, { cloneElement, useEffect, useMemo, useState } from 'react'
-import { useTheme } from '@xstyled/styled-components'
+import { useTheme } from 'styled-components'
 import { useViewportSize } from '@welcome-ui/utils'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 

--- a/packages/Swiper/package.json
+++ b/packages/Swiper/package.json
@@ -41,7 +41,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Swiper/styles.ts
+++ b/packages/Swiper/styles.ts
@@ -41,8 +41,8 @@ export const Pagination = styled.div`
 
 export const Bullet = styled.div<{ active: boolean }>(
   ({ active, theme }) => css`
-    height: 10;
-    width: 10;
+    height: 10px;
+    width: 10px;
     border-radius: 50%;
     cursor: pointer;
     margin: 0 ${theme.space.xxs};

--- a/packages/Swiper/styles.ts
+++ b/packages/Swiper/styles.ts
@@ -1,4 +1,5 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { system } from '@welcome-ui/system'
 
 import { UseSwiperState } from '.'
 
@@ -35,17 +36,17 @@ export const Pagination = styled.div`
   z-index: 10;
   bottom: 0;
   width: 100%;
-  padding: sm;
+  padding: ${({ theme }) => theme.space.sm};
 `
 
 export const Bullet = styled.div<{ active: boolean }>(
-  ({ active }) => css`
+  ({ active, theme }) => css`
     height: 10;
     width: 10;
     border-radius: 50%;
     cursor: pointer;
-    margin: 0 xxs;
-    ${active ? th('swipers.navigation.bullet.active') : th('swipers.navigation.bullet.default')}
+    margin: 0 ${theme.space.xxs};
+    ${active ? theme.swipers.navigation.bullet.active : theme.swipers.navigation.bullet.default}
     ${system}
   `
 )
@@ -67,17 +68,17 @@ const getNavigationStyles = ({ disabled }: NavigationStylesProps) => css`
 `
 
 export const Next = styled.div<NavigationStylesProps>(
-  props => css`
+  ({ theme, ...props }) => css`
     ${getNavigationStyles(props)}
-    margin-right: sm;
+    margin-right: ${theme.space.sm};
     right: 0;
   `
 )
 
 export const Prev = styled.div<NavigationStylesProps>(
-  props => css`
+  ({ theme, ...props }) => css`
     ${getNavigationStyles(props)}
-    margin-left: sm;
+    margin-left: ${theme.space.sm};
     left: 0;
   `
 )

--- a/packages/Swiper/tsconfig.json
+++ b/packages/Swiper/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/System/index.test.tsx
+++ b/packages/System/index.test.tsx
@@ -8,7 +8,7 @@ const content = 'test'
 describe('<Box>', () => {
   it('should render correctly with the fontStyle style prop', () => {
     const { container, getByTestId } = render(
-      <Box data-testid="box" fontStyle="italic" fontWeight="bold">
+      <Box $fontStyle="italic" $fontWeight="bold" data-testid="box">
         {content}
       </Box>
     )

--- a/packages/System/index.ts
+++ b/packages/System/index.ts
@@ -1,7 +1,22 @@
 import React from 'react'
 import type { SystemProps } from 'jsx-to-styled'
+import type { DefaultTheme } from 'styled-components'
 
 export { default as system } from 'jsx-to-styled'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Props = any & { theme: DefaultTheme }
+type Breakpoint = keyof DefaultTheme['screens']
+
+export const down = (breakpoint: Breakpoint) => (props: Props) => {
+  const value = props.theme.screens?.[breakpoint] || breakpoint
+  return `@media (max-width: ${value})`
+}
+
+export const up = (breakpoint: Breakpoint) => (props: Props) => {
+  const value = props.theme.screens?.[breakpoint] || breakpoint
+  return `@media (min-width: ${value})`
+}
 
 export type WuiProps = SystemProps
 

--- a/packages/System/index.tsx
+++ b/packages/System/index.tsx
@@ -1,128 +1,13 @@
 import React from 'react'
-import {
-  compose,
-  getPx,
-  getTransition,
-  getZIndex,
-  Props,
-  style,
-  SystemProps,
-} from '@xstyled/styled-components'
-import * as S from '@xstyled/styled-components'
-import { StyledConfig } from 'styled-components'
+import { SystemProps } from 'jsx-to-styled'
 
-// Those are styles that were in v1 but not in v2
-const oldProps = compose(
-  style({ prop: 'opacity' }),
-  style({ prop: 'overflow' }),
-  style({ prop: 'transition', themeGet: getTransition }),
-  style({ prop: 'position' }),
-  style({ prop: 'zIndex', themeGet: getZIndex }),
-  style({ prop: 'top', themeGet: getPx }),
-  style({ prop: 'right', themeGet: getPx }),
-  style({ prop: 'bottom', themeGet: getPx }),
-  style({ prop: 'left', themeGet: getPx })
-)
+export { default as system } from 'jsx-to-styled'
 
-const SYSTEM_PROPS = Object.freeze([
-  S.backgrounds,
-  S.borders,
-  S.boxShadow,
-  S.color,
-  S.display,
-  S.flexboxes,
-  S.grids,
-  S.height,
-  S.maxHeight,
-  S.maxWidth,
-  S.minHeight,
-  S.minWidth,
-  S.space,
-  S.typography,
-  S.verticalAlign,
-  S.width,
-  oldProps,
-])
-
-const WRAPPER_PROPS = Object.freeze([
-  S.margin,
-  S.marginBottom,
-  S.marginLeft,
-  S.marginRight,
-  S.marginTop,
-  S.mx,
-  S.my,
-  S.width,
-  oldProps,
-])
-
-/**
- * @deprecated use system from @xstyled/syled-components instead
- */
-export const system = compose<WuiSystemProps>(...SYSTEM_PROPS)
-/**
- * @deprecated use system from @xstyled/syled-components instead
- */
-export const wrapperSystem = compose<WuiWrapperSystemProps>(...WRAPPER_PROPS)
-const componentProps = system.meta.props
-  .filter(prop => !wrapperSystem.meta.props.includes(prop))
-  .map(prop => {
-    if (prop === 'w') return S['width']
-    if (prop === 'h') return S['height']
-    return (S as Props)[prop]
-  })
-  .filter(Boolean)
-/**
- * @deprecated use system from @xstyled/syled-components instead
- */
-export const componentSystem = compose(...componentProps)
-
-export const filterSystemProps = (prop: string): boolean => !system.meta.props.includes(prop)
-export const shouldForwardProp: StyledConfig['shouldForwardProp'] = (prop, defaultValidatorFn) =>
-  defaultValidatorFn(prop)
-
-export type WuiOldProps = S.OpacityProps &
-  S.OverflowProps &
-  S.TransitionProps &
-  S.ZIndexProps &
-  S.TopProps &
-  S.RightProps &
-  S.BottomProps &
-  S.LeftProps
-
-export type WuiSystemProps = S.BackgroundsProps &
-  S.BorderProps &
-  S.BoxShadowProps &
-  S.ColorProps &
-  S.DisplayProps &
-  S.FlexboxesProps &
-  S.GridsProps &
-  S.HeightProps &
-  S.MaxHeightProps &
-  S.MaxWidthProps &
-  S.MinHeightProps &
-  S.MinWidthProps &
-  S.SpaceProps &
-  S.TypographyProps &
-  S.VerticalAlignProps &
-  S.WidthProps &
-  WuiOldProps
-
-export type WuiWrapperSystemProps = S.MarginProps &
-  S.MarginBottomProps &
-  S.MarginLeftProps &
-  S.MarginRightProps &
-  S.MarginTopProps &
-  S.MarginXProps &
-  S.MarginYProps &
-  S.WidthProps &
-  WuiOldProps
+export type WuiProps = SystemProps
 
 export interface WuiTestProps {
   dataTestId?: string
 }
-
-export type WuiProps = SystemProps
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type As<Props = any> = React.ElementType<Props>
@@ -156,5 +41,3 @@ export const forwardRef = <Component extends As, Props = {}>(
 ): CreateWuiComponent<Component, Props> => {
   return React.forwardRef(component) as unknown as CreateWuiComponent<Component, Props>
 }
-
-export type ExtraSize = number | string

--- a/packages/System/index.tsx
+++ b/packages/System/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { SystemProps } from 'jsx-to-styled'
+import type { SystemProps } from 'jsx-to-styled'
 
 export { default as system } from 'jsx-to-styled'
 

--- a/packages/System/package.json
+++ b/packages/System/package.json
@@ -36,8 +36,10 @@
   "bugs": {
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
+  "dependencies": {
+    "jsx-to-styled": "^1.5.2"
+  },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/System/package.json
+++ b/packages/System/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "jsx-to-styled": "^1.5.2"
+    "jsx-to-styled": "^1.5.3"
   },
   "peerDependencies": {
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",

--- a/packages/System/rollup.config.js
+++ b/packages/System/rollup.config.js
@@ -1,3 +1,3 @@
 import { getRollupConfig } from '../../rollup.config.js'
 
-export default getRollupConfig({ pwd: __dirname, ts: true })
+export default getRollupConfig({ pwd: __dirname, ts: true, inputFile: 'index.ts' })

--- a/packages/System/tsconfig.json
+++ b/packages/System/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.ts", "../../types"]
 }

--- a/packages/Table/package.json
+++ b/packages/Table/package.json
@@ -43,7 +43,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Table/styles.ts
+++ b/packages/Table/styles.ts
@@ -1,5 +1,6 @@
-import styled, { css, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
+import { system } from '@welcome-ui/system'
 
 import { TableOptions } from './index'
 
@@ -28,23 +29,29 @@ export const Content = styled.div`
   overflow-x: auto;
 `
 
-export const Table = styled.tableBox`
+export const Table = styled.table`
   border: 0;
   width: 100%;
   border-collapse: collapse;
+  ${system}
 `
 
-export const Thead = styled.theadBox``
+export const Thead = styled.thead`
+  ${system}
+`
 
-export const Tbody = styled.tbodyBox``
+export const Tbody = styled.tbody`
+  ${system}
+`
 
 type Variant = 'default' | 'error' | 'warning' | 'info' | 'success' | 'clickable'
 
-export const Tr = styled.trBox<{ variant?: Variant }>(
-  ({ onClick, variant }) => css`
-    ${th('tables.tr.default')};
-    ${variant && th(`tables.tr.${variant}`)};
-    ${onClick && th('tables.tr.clickable')};
+export const Tr = styled.tr<{ variant?: Variant }>(
+  ({ onClick, theme, variant }) => css`
+    ${theme.tables.tr.default};
+    ${variant && theme.tables.tr[variant]};
+    ${onClick && theme.tables.tr.clickable};
+    ${system}
 
     &:last-child {
       border: 0;
@@ -52,24 +59,28 @@ export const Tr = styled.trBox<{ variant?: Variant }>(
   `
 )
 
-export const Th = styled.thBox`
-  ${th('tables.th')};
-  padding: xl;
-  vertical-align: middle;
+export const Th = styled.th(
+  ({ theme }) => css`
+    ${theme.tables.th};
+    padding: ${theme.space.xl};
+    vertical-align: middle;
+    ${system}
 
-  &:first-child {
-    padding-left: 0;
-  }
+    &:first-child {
+      padding-left: 0;
+    }
 
-  &:last-child {
-    padding-right: 0;
-  }
-`
+    &:last-child {
+      padding-right: 0;
+    }
+  `
+)
 
-export const Td = styled.tdBox`
-  ${th('tables.td')};
+export const Td = styled.td`
+  ${({ theme }) => theme.tables.td};
   position: relative;
   vertical-align: middle;
+  ${system}
 
   &:first-child {
     padding-left: 0;

--- a/packages/Table/styles.ts
+++ b/packages/Table/styles.ts
@@ -5,7 +5,7 @@ import { system } from '@welcome-ui/system'
 import { TableOptions } from './index'
 
 export const Wrapper = styled(Box)<TableOptions>(
-  ({ indent }) => css`
+  ({ indent, theme }) => css`
     overflow: hidden;
     width: 100%;
 
@@ -13,11 +13,11 @@ export const Wrapper = styled(Box)<TableOptions>(
     css`
       ${Td}, ${Th} {
         &:first-child {
-          padding-left: xl;
+          padding-left: ${theme.spaces.xl};
         }
 
         &:last-child {
-          padding-right: xl;
+          padding-right: ${theme.spaces.xl};
         }
       }
     `}

--- a/packages/Table/tsconfig.json
+++ b/packages/Table/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Tabs/package.json
+++ b/packages/Tabs/package.json
@@ -44,7 +44,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Tabs/styles.ts
+++ b/packages/Tabs/styles.ts
@@ -1,11 +1,11 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css, DefaultTheme } from 'styled-components'
 import { TabStateReturn } from 'reakit/Tab'
+import { system } from '@welcome-ui/system'
 
 import { ActiveBarStateReturn } from './ActiveBar'
-import { SizeOptions } from './TabList'
 
-export const TabList = styled.div<{ size: SizeOptions }>(
-  ({ size }) => css`
+export const TabList = styled.div<{ size: keyof DefaultTheme['tabs']['size'] }>(
+  ({ size, theme }) => css`
     position: relative;
     width: 100%;
     overflow-x: auto;
@@ -14,69 +14,71 @@ export const TabList = styled.div<{ size: SizeOptions }>(
 
     &[aria-orientation='vertical'] {
       flex-direction: column;
-      ${th('tabs.tabsBorder.vertical')};
+      ${theme.tabs.tabsBorder.vertical};
     }
 
-    ${th('tabs.tabsBorder.horizontal')};
+    ${theme.tabs.tabsBorder.horizontal};
 
     & > :not(:last-child) {
-      ${th(`tabs.size.${size}`)}
+      ${theme.tabs.size[size]}
     }
     ${system};
   `
 )
 
-export const Tab = styled.button`
-  border: 0;
-  background: none;
-  ${th('tabs.item.default')};
-  display: flex;
-  align-items: center;
-  flex: none;
-  padding: md 0;
-  transition: medium;
-  text-transform: none;
-  cursor: pointer;
-  gap: sm;
+export const Tab = styled.button(
+  ({ theme }) => css`
+    border: 0;
+    background: none;
+    ${theme.tabs.item.default};
+    display: flex;
+    align-items: center;
+    flex: none;
+    padding: ${theme.space.md} 0;
+    transition: ${theme.transitions.medium};
+    text-transform: none;
+    cursor: pointer;
+    gap: ${theme.space.sm};
 
-  &:focus {
-    outline: none !important; /* important for firefox */
-    &:not([aria-selected='true']) {
-      ${th('tabs.item.focus')};
+    &:focus {
+      outline: none !important; /* important for firefox */
+      &:not([aria-selected='true']) {
+        ${theme.tabs.item.focus};
+      }
     }
-  }
 
-  &[aria-selected='true'] {
-    ${th('tabs.item.active')};
-  }
+    &[aria-selected='true'] {
+      ${theme.tabs.item.active};
+    }
 
-  &[aria-disabled='true'] {
-    ${th('tabs.item.disabled')};
-    cursor: auto;
-  }
+    &[aria-disabled='true'] {
+      ${theme.tabs.item.disabled};
+      cursor: auto;
+    }
 
-  &:hover:not([aria-selected='true']):not([aria-disabled='true']) {
-    ${th('tabs.item.focus')};
-  }
+    &:hover:not([aria-selected='true']):not([aria-disabled='true']) {
+      ${theme.tabs.item.focus};
+    }
 
-  & > svg,
-  img {
-    ${th('tabs.icon')};
-  }
+    & > svg,
+    img {
+      ${theme.tabs.icon};
+    }
 
-  & > span {
-    ${th('tabs.badge')};
-  }
-`
+    & > span {
+      ${theme.tabs.badge};
+    }
+  `
+)
 
 export const TabPanel = styled.div<Pick<TabStateReturn, 'orientation'>>(
-  ({ orientation }) => css`
-    ${orientation === 'vertical' ? th('tabs.panel.vertical') : th('tabs.panel.horizontal')};
+  ({ orientation, theme }) => css`
+    ${orientation === 'vertical' ? theme.tabs.panel.vertical : theme.tabs.panel.horizontal};
   `
 )
 
 const activeBarHorizontalStyles = ({ offset = 0, size = 0 }) => css`
-  ${th('tabs.activeBar.horizontal')};
+  ${({ theme }) => theme.tabs.activeBar.horizontal};
   left: 0;
   bottom: 0;
   width: ${size}px;
@@ -84,7 +86,7 @@ const activeBarHorizontalStyles = ({ offset = 0, size = 0 }) => css`
 `
 
 const activeBarVerticalStyles = ({ offset = 0, size = 0 }) => css`
-  ${th('tabs.activeBar.vertical')};
+  ${({ theme }) => theme.tabs.activeBar.vertical};
   right: 0;
   top: 0;
   height: ${size}px;
@@ -92,11 +94,11 @@ const activeBarVerticalStyles = ({ offset = 0, size = 0 }) => css`
 `
 
 export const ActiveBar = styled.span<ActiveBarStateReturn>(
-  ({ orientation, ...rest }) => css`
+  ({ orientation, theme, ...rest }) => css`
     position: absolute;
     ${orientation === 'vertical' ? activeBarVerticalStyles(rest) : activeBarHorizontalStyles(rest)}
     will-change: width, transform;
-    transition: medium;
+    transition: ${theme.transitions.medium};
     transition-property: transform, width;
   `
 )

--- a/packages/Tabs/tsconfig.json
+++ b/packages/Tabs/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Tag/package.json
+++ b/packages/Tag/package.json
@@ -43,7 +43,6 @@
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Tag/styles.ts
+++ b/packages/Tag/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { StyledIcon } from '@welcome-ui/icon'
 import { centerContent, getMax, overflowEllipsis } from '@welcome-ui/utils'
 import { system, WuiProps } from '@welcome-ui/system'
@@ -36,7 +36,7 @@ export const Tag = styled.div<StyledTagProps & WuiProps>(
     justify-content: center;
     border-radius: ${theme.space.md};
     line-height: initial; /* avoid cropped font */
-    transition: medium;
+    transition: ${theme.transitions.medium};
     ${overflowEllipsis}
     ${system}
     ${length !== 1 &&

--- a/packages/Tag/styles.ts
+++ b/packages/Tag/styles.ts
@@ -1,12 +1,13 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from '@xstyled/styled-components'
 import { StyledIcon } from '@welcome-ui/icon'
 import { centerContent, getMax, overflowEllipsis } from '@welcome-ui/utils'
-import { WuiProps } from '@welcome-ui/system'
+import { system, WuiProps } from '@welcome-ui/system'
+import { DefaultTheme } from 'styled-components'
 
-import { Size, Variant } from './index'
+import { Size } from './index'
 
 const shapeStyles = (size: Size, w: string, h: string) => css`
-  ${th(`tags.shape.${size}`)}
+  ${({ theme }) => theme.tags.shape[size]}
   padding: 0;
   ${(w || h) &&
   css`
@@ -21,19 +22,19 @@ export interface StyledTagProps {
   hasRemoveAction: boolean
   length: number
   size: Size
-  variant: Variant
+  variant: keyof DefaultTheme['tags']['variants']
 }
 
 export const Tag = styled.div<StyledTagProps & WuiProps>(
-  ({ h, hasClickAction, hasLink, hasRemoveAction, length, size, variant, w }) => css`
-    ${th('tags.default')};
-    ${th(`tags.variants.${variant}`)};
-    ${th(`tags.sizes.${size}`)}
+  ({ $h, $w, hasClickAction, hasLink, hasRemoveAction, length, size, theme, variant }) => css`
+    ${theme.tags.default};
+    ${theme.tags.variants[variant]};
+    ${theme.tags.sizes[size]}
     position: relative;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: md;
+    border-radius: ${theme.space.md};
     line-height: initial; /* avoid cropped font */
     transition: medium;
     ${overflowEllipsis}
@@ -48,7 +49,7 @@ export const Tag = styled.div<StyledTagProps & WuiProps>(
     ${length === 1 &&
     css`
       justify-content: center;
-      ${shapeStyles(size, w as string, h as string)};
+      ${shapeStyles(size, $w as string, $h as string)};
     `};
 
     ${(hasLink || hasClickAction) &&
@@ -57,29 +58,29 @@ export const Tag = styled.div<StyledTagProps & WuiProps>(
       text-decoration: none;
 
       &:hover {
-        ${th(`tags.hover.${variant}`)};
+        ${theme.tags.hover[variant]};
       }
     `};
 
     ${hasRemoveAction &&
     css`
-      padding-right: xxl;
+      padding-right: ${theme.space.xxl};
     `}
     max-width: 100%;
 
     > *:not(:last-child) {
-      margin-right: xxs;
+      margin-right: ${theme.space.xxs};
     }
 
     & > svg {
-      width: ${th(`tags.icon.${size}`)};
-      height: ${th(`tags.icon.${size}`)};
+      width: ${theme.tags.icon[size]};
+      height: ${theme.tags.icon[size]};
     }
 
     > *:not(:only-child) {
       ${/* sc-selector */ StyledIcon}:last-child {
         opacity: 0.7;
-        transition: opacity ${th.transition('medium')};
+        transition: opacity ${theme.transitions.medium};
         cursor: pointer;
 
         &:hover {
@@ -91,9 +92,9 @@ export const Tag = styled.div<StyledTagProps & WuiProps>(
 )
 
 export const ActionIcon = styled.div<{ size: Size }>(
-  ({ size }) => css`
+  ({ size, theme }) => css`
     position: absolute;
-    ${th(`tags.sizes.${size}`)};
+    ${theme.tags.sizes[size]};
     top: 0;
     bottom: 0;
     right: 0;

--- a/packages/Tag/tsconfig.json
+++ b/packages/Tag/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Text/package.json
+++ b/packages/Text/package.json
@@ -37,11 +37,8 @@
   "bugs": {
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
-  "dependencies": {
-    "@welcome-ui/system": "^5.0.0-alpha.0"
-  },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
+    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Text/package.json
+++ b/packages/Text/package.json
@@ -37,8 +37,10 @@
   "bugs": {
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
+  "dependencies": {
+    "@welcome-ui/system": "^5.0.0-alpha.0"
+  },
   "peerDependencies": {
-    "@welcome-ui/system": "^5.0.0-alpha.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Text/styles.ts
+++ b/packages/Text/styles.ts
@@ -35,7 +35,7 @@ export const Text = styled.p<TextOptions>(({ lines, theme, variant }) => {
     ${lines && lines !== Infinity && getBlockHeight(lines)};
     /* End fallback for non-webkit */
 
-    @media (min-width: lg) {
+    @media (min-width: ${theme.breakpoints.lg}px) {
       ${theme.texts[variant]};
     }
 

--- a/packages/Text/styles.ts
+++ b/packages/Text/styles.ts
@@ -1,4 +1,5 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
+import { system } from '@welcome-ui/system'
 
 import { TextOptions } from './index'
 
@@ -23,11 +24,11 @@ const getBlockHeight = (lines: number) => css`
   word-break: ${lines === 1 ? 'break-all' : null};
 `
 
-export const Text = styled.p<TextOptions>(({ lines, variant }) => {
+export const Text = styled.p<TextOptions>(({ lines, theme, variant }) => {
   const mobileVariant = MOBILE_VARIANTS[variant as keyof typeof MOBILE_VARIANTS]
 
   return css`
-    ${th(`texts.${mobileVariant || variant}`)};
+    ${theme.texts[mobileVariant || variant]};
 
     /* Start fallback for non-webkit */
     display: block;
@@ -35,8 +36,7 @@ export const Text = styled.p<TextOptions>(({ lines, variant }) => {
     /* End fallback for non-webkit */
 
     @media (min-width: lg) {
-      ${th(`texts.${variant}`)};
-      ${system};
+      ${theme.texts[variant]};
     }
 
     ${system};

--- a/packages/Text/tsconfig.json
+++ b/packages/Text/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Textarea/package.json
+++ b/packages/Textarea/package.json
@@ -42,7 +42,6 @@
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Textarea/styles.ts
+++ b/packages/Textarea/styles.ts
@@ -1,14 +1,14 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
-import { shouldForwardProp } from '@welcome-ui/system'
+import styled, { css } from 'styled-components'
 import { defaultFieldStyles } from '@welcome-ui/utils'
+import { system } from '@welcome-ui/system'
 
 import { TextareaOptions } from './index'
 
-export const Textarea = styled('textarea').withConfig({ shouldForwardProp })<TextareaOptions>(
-  ({ size, variant }) => css`
+export const Textarea = styled('textarea')<TextareaOptions>(
+  ({ size, theme, variant }) => css`
     ${defaultFieldStyles({ size, variant })};
-    ${th('textareas')};
-    line-height: lg;
+    ${theme.textareas};
+    line-height: ${theme.lineHeights.lg};
     ${system};
   `
 )

--- a/packages/Textarea/tsconfig.json
+++ b/packages/Textarea/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Themes/Dark/tsconfig.json
+++ b/packages/Themes/Dark/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["index.ts", "../../../types"]
 }

--- a/packages/Themes/Welcome/tsconfig.json
+++ b/packages/Themes/Welcome/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["index.ts", "../../../types"]
 }

--- a/packages/Themes/WelcomeDark/tsconfig.json
+++ b/packages/Themes/WelcomeDark/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["index.ts", "../../../types"]
 }

--- a/packages/Themes/tsconfig.json
+++ b/packages/Themes/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.ts", "Dark", "Welcome", "../../types"]
+  "include": ["index.ts", "Dark/*.ts", "Welcome/*.ts", "../../types"]
 }

--- a/packages/Themes/tsconfig.json
+++ b/packages/Themes/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.ts", "Dark", "Welcome"]
+  "include": ["index.ts", "Dark", "Welcome", "../../types"]
 }

--- a/packages/TimePicker/package.json
+++ b/packages/TimePicker/package.json
@@ -45,7 +45,6 @@
     "react-datepicker": "^4.7.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/TimePicker/tsconfig.json
+++ b/packages/TimePicker/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Toast/Growl.tsx
+++ b/packages/Toast/Growl.tsx
@@ -29,14 +29,14 @@ export const Growl = forwardRef<'div', GrowlProps>(
       <S.Growl hasCloseButton={hasCloseButton} icon={icon} ref={ref} variant={variant}>
         {hasCloseButton && (
           <CloseButton
+            $position="absolute"
+            $right="sm"
+            $top="sm"
             data-testid={closeButtonDataTestId}
             onClick={onClose}
-            position="absolute"
-            right="sm"
-            top="sm"
           />
         )}
-        <Box pr="xl">{children}</Box>
+        <Box $pr="xl">{children}</Box>
       </S.Growl>
     )
   }

--- a/packages/Toast/Snackbar.tsx
+++ b/packages/Toast/Snackbar.tsx
@@ -22,7 +22,7 @@ export type SnackbarProps = CreateWuiProps<'div', SnackbarOptions>
 export const Snackbar = forwardRef<'div', SnackbarProps>(
   ({ children, hasCloseButton = true, icon, onClose, variant = 'default', ...rest }, ref) => (
     <S.Snackbar hasCloseButton={hasCloseButton} icon={icon} ref={ref} variant={variant} {...rest}>
-      <Box alignItems="center" display="flex">
+      <Box $alignItems="center" $display="flex">
         {children}
         {hasCloseButton && <CloseButton onClick={onClose} size="xs" />}
       </Box>

--- a/packages/Toast/index.tsx
+++ b/packages/Toast/index.tsx
@@ -1,5 +1,5 @@
 import React, { cloneElement, useCallback, useContext } from 'react'
-import { ThemeContext, ThemeProvider } from '@xstyled/styled-components'
+import { ThemeContext, ThemeProvider } from 'styled-components'
 import toast from 'toasted-notes'
 import { MessageOptionalOptions } from 'toasted-notes/lib/ToastManager'
 import { TextProps } from '@welcome-ui/text'

--- a/packages/Toast/package.json
+++ b/packages/Toast/package.json
@@ -51,7 +51,6 @@
     "toasted-notes": "^3.2.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Toast/styles.ts
+++ b/packages/Toast/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 import { Alert } from '@welcome-ui/alert'
 
@@ -6,18 +6,18 @@ import { GrowlOptions } from './Growl'
 import { SnackbarOptions } from './Snackbar'
 
 export const Toast = styled(Box)<{ isBottom: boolean }>(
-  ({ isBottom }) => css`
-    ${th('toasts.default')}
-    ${isBottom ? th('toasts.bottom') : th('toasts.top')}
+  ({ isBottom, theme }) => css`
+    ${theme.toasts.default}
+    ${isBottom ? theme.toasts.bottom : theme.toasts.top}
   `
 )
 
 export const Growl = styled(Alert)<GrowlOptions>(
-  () => css`
+  ({ theme }) => css`
     position: relative;
     max-width: 25rem;
-    padding: lg;
-    ${th('toasts.growls.default')};
+    padding: ${theme.space.lg};
+    ${theme.toasts.growls.default};
 
     div:first-of-type {
       align-self: baseline;
@@ -30,11 +30,11 @@ export const Growl = styled(Alert)<GrowlOptions>(
 )
 
 export const Title = styled(Box)(
-  () => css`
+  ({ theme }) => css`
     display: flex;
     align-items: center;
-    padding-bottom: xs;
-    ${th('toasts.growls.title')};
+    padding-bottom: ${theme.space.xs};
+    ${theme.toasts.growls.title};
 
     & > *:first-child {
       flex-shrink: 0;
@@ -43,10 +43,10 @@ export const Title = styled(Box)(
 )
 
 export const Snackbar = styled(Alert)<SnackbarOptions>(
-  ({ hasCloseButton }) => css`
+  ({ hasCloseButton, theme }) => css`
     display: flex;
     align-items: center;
-    padding: sm md;
+    padding: ${theme.space.sm} ${theme.space.md};
 
     svg {
       width: 16;
@@ -55,7 +55,7 @@ export const Snackbar = styled(Alert)<SnackbarOptions>(
 
     button {
       flex-shrink: 0;
-      margin-left: ${hasCloseButton ? 'sm' : 0};
+      margin-left: ${hasCloseButton ? theme.space.sm : 0};
     }
   `
 )

--- a/packages/Toast/styles.ts
+++ b/packages/Toast/styles.ts
@@ -49,8 +49,8 @@ export const Snackbar = styled(Alert)<SnackbarOptions>(
     padding: ${theme.space.sm} ${theme.space.md};
 
     svg {
-      width: 16;
-      height: 16;
+      width: 16px;
+      height: 16px;
     }
 
     button {

--- a/packages/Toast/tsconfig.json
+++ b/packages/Toast/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Toggle/package.json
+++ b/packages/Toggle/package.json
@@ -43,7 +43,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Toggle/styles.ts
+++ b/packages/Toggle/styles.ts
@@ -21,7 +21,7 @@ export const Toggle = styled(ReakitCheckbox)<ToggleOptions>(
       content: '';
       top: 0;
       bottom: 0;
-      left: 2;
+      left: 2px;
       position: absolute;
       margin: auto;
       transition: ${theme.transitions.medium};

--- a/packages/Toggle/styles.ts
+++ b/packages/Toggle/styles.ts
@@ -1,52 +1,52 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Checkbox as ReakitCheckbox } from 'reakit/Checkbox'
-import { shouldForwardProp } from '@welcome-ui/system'
+import { system } from '@welcome-ui/system'
 
 import { ToggleOptions } from './index'
 
-export const Toggle = styled(ReakitCheckbox).withConfig({ shouldForwardProp })<ToggleOptions>(
-  ({ order = '-1' }) => css`
-    ${th('toggles.item.default')};
+export const Toggle = styled(ReakitCheckbox)<ToggleOptions>(
+  ({ $order = '-1', theme }) => css`
+    ${theme.toggles.item.default};
     position: relative;
     display: block;
     appearance: none;
     background: transparent;
     outline: none !important; /* important for firefox */
     cursor: pointer;
-    transition: medium;
-    order: ${order};
+    transition: ${theme.transitions.medium};
+    order: ${$order};
 
     &::after {
-      ${th('toggles.after.default')};
+      ${theme.toggles.after.default};
       content: '';
       top: 0;
       bottom: 0;
       left: 2;
       position: absolute;
       margin: auto;
-      transition: medium;
+      transition: ${theme.transitions.medium};
     }
 
     &:disabled {
-      ${th('toggles.item.disabled')};
+      ${theme.toggles.item.disabled};
       cursor: not-allowed;
 
       &::after {
-        ${th('toggles.after.disabled')};
+        ${theme.toggles.after.disabled};
       }
     }
 
     &:checked {
       &::after {
         /* border + left padding + right padding */
-        transform: translateX(calc(${th('toggles.item.default.width')} - 100% - 0.3rem));
+        transform: translateX(calc(${theme.toggles.item.default.width} - 100% - 0.3rem));
       }
 
       &:not(:disabled) {
-        ${th('toggles.item.checked')};
+        ${theme.toggles.item.checked};
 
         &::after {
-          ${th('toggles.after.checked')};
+          ${theme.toggles.after.checked};
         }
       }
     }

--- a/packages/Toggle/tsconfig.json
+++ b/packages/Toggle/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -43,7 +43,6 @@
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Tooltip/styles.ts
+++ b/packages/Tooltip/styles.ts
@@ -1,5 +1,6 @@
-import styled, { system, th } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Tooltip as ReakitTooltip } from 'reakit/Tooltip'
+import { system } from '@welcome-ui/system'
 
 import { PlacementOptions } from './index'
 
@@ -29,25 +30,26 @@ const getFadeInDirection = (placement: string) => {
   }
 }
 
-export const FadeIn = styled.div<{
+type FadeInProps = {
   placement?: PlacementOptions
   fixed?: boolean
-}>`
-  ${th('tooltips')};
-  ${system};
-  transition: opacity ${th.transition('medium')}, transform ${th.transition('medium')},
-    visibility ${th.transition('medium')};
-  visibility: hidden;
-  opacity: 0;
-  transform-origin: top center;
-  transform: ${({ fixed, placement }) => {
-    if (!fixed) return
-    return getFadeInDirection(placement)
-    // return transformDirection[placementOption]
-  }};
-  [data-enter] & {
-    visibility: visible;
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-`
+}
+
+export const FadeIn = styled.div<FadeInProps>(
+  ({ fixed, placement, theme }) => css`
+    ${theme.tooltips};
+    ${system};
+    transition: opacity ${theme.transitions.medium}, transform ${theme.transitions.medium},
+      visibility ${theme.transitions.medium};
+    visibility: hidden;
+    opacity: 0;
+    transform-origin: top center;
+    transform: ${!fixed && getFadeInDirection(placement)};
+
+    [data-enter] & {
+      visibility: visible;
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+    }
+  `
+)

--- a/packages/Tooltip/styles.ts
+++ b/packages/Tooltip/styles.ts
@@ -1,12 +1,10 @@
-import styled, { css, system, th } from '@xstyled/styled-components'
+import styled, { system, th } from '@xstyled/styled-components'
 import { Tooltip as ReakitTooltip } from 'reakit/Tooltip'
-import { filterSystemProps } from '@welcome-ui/system'
 
 import { PlacementOptions } from './index'
 
-export const Tooltip = styled(ReakitTooltip).withConfig({ shouldForwardProp: filterSystemProps })(
-  () => css``
-)
+export const Tooltip = styled(ReakitTooltip)``
+
 const transformDirection = {
   top: 'translate3d(0, -4px, 0)',
   right: 'translate3d(4px, 0, 0)',

--- a/packages/Tooltip/tsconfig.json
+++ b/packages/Tooltip/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/UniversalLink/index.tsx
+++ b/packages/UniversalLink/index.tsx
@@ -12,7 +12,6 @@ export type UniversalLinkProps = CreateWuiProps<'a', UniversalLinkOptions>
 export const UniversalLink = forwardRef<'a', UniversalLinkProps>(
   ({ children, dataTestId, target, ...rest }, ref) => (
     <S.UniversalLink
-      color="inherit"
       data-testid={dataTestId}
       ref={ref}
       // for security

--- a/packages/UniversalLink/package.json
+++ b/packages/UniversalLink/package.json
@@ -41,7 +41,6 @@
     "@welcome-ui/system": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/UniversalLink/styles.ts
+++ b/packages/UniversalLink/styles.ts
@@ -1,7 +1,6 @@
 import styled from '@xstyled/styled-components'
-import { shouldForwardProp } from '@welcome-ui/system'
 
-export const UniversalLink = styled.aBox.withConfig({ shouldForwardProp })`
+export const UniversalLink = styled.aBox`
   color: inherit;
   text-decoration: none;
 `

--- a/packages/UniversalLink/styles.ts
+++ b/packages/UniversalLink/styles.ts
@@ -1,6 +1,8 @@
-import styled from '@xstyled/styled-components'
+import styled from 'styled-components'
+import { system } from '@welcome-ui/system'
 
-export const UniversalLink = styled.aBox`
+export const UniversalLink = styled.a`
   color: inherit;
   text-decoration: none;
+  ${system}
 `

--- a/packages/UniversalLink/tsconfig.json
+++ b/packages/UniversalLink/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/packages/Utils/card-styles.ts
+++ b/packages/Utils/card-styles.ts
@@ -1,5 +1,5 @@
-import { css, th } from '@xstyled/styled-components'
+import { css } from 'styled-components'
 
-export const cardStyles = (): ReturnType<typeof css> => css`
-  ${th('defaultCards')};
+export const cardStyles = () => css`
+  ${({ theme }) => theme.defaultCards};
 `

--- a/packages/Utils/center-content.ts
+++ b/packages/Utils/center-content.ts
@@ -1,4 +1,4 @@
-import { css } from '@xstyled/styled-components'
+import { css } from 'styled-components'
 
 export const centerContent = css`
   display: flex;

--- a/packages/Utils/field-styles.ts
+++ b/packages/Utils/field-styles.ts
@@ -1,4 +1,4 @@
-import { css, th } from '@xstyled/styled-components'
+import { css } from 'styled-components'
 
 import { getVariantColor, Variant } from './variants'
 
@@ -13,39 +13,41 @@ export type DefaultFieldStylesProps = Partial<{
 type DefaultFieldStyles = (args: DefaultFieldStylesProps) => ReturnType<typeof css>
 
 export const defaultFieldStyles: DefaultFieldStyles = ({ size, transparent, variant }) => css`
-  ${th('defaultFields.default')};
-  width: 100%;
-  border-color: ${getVariantColor(variant)};
-  transition: medium;
-  appearance: none;
-  ${size && th(`defaultFields.sizes.${size}`)};
+  ${({ theme }) => css`
+    ${theme.defaultFields.default};
+    width: 100%;
+    border-color: ${getVariantColor(variant)};
+    transition: ${theme.transitions.medium};
+    appearance: none;
+    ${size && theme.defaultFields.sizes[size]};
 
-  ${!variant &&
-  transparent &&
-  css`
-    border-color: transparent;
-    background-color: transparent;
+    ${!variant &&
+    transparent &&
+    css`
+      border-color: transparent;
+      background-color: transparent;
+    `}
+
+    &::placeholder {
+      ${theme.defaultFields.placeholder};
+    }
+
+    &:focus {
+      ${theme.defaultFields.focused.default};
+      ${variant === 'error' && theme.defaultFields.focused.error};
+      ${variant === 'warning' && theme.defaultFields.focused.warning};
+      ${variant === 'success' && theme.defaultFields.focused.success};
+      ${variant === 'info' && theme.defaultFields.focused.info};
+    }
+
+    &[disabled] {
+      ${theme.defaultFields.disabled};
+    }
+
+    &:invalid,
+    &:-moz-submit-invalid,
+    &:-moz-ui-invalid {
+      box-shadow: none;
+    }
   `}
-
-  &::placeholder {
-    ${th('defaultFields.placeholder')};
-  }
-
-  &:focus {
-    ${th('defaultFields.focused.default')};
-    ${variant === 'error' && th('defaultFields.focused.error')};
-    ${variant === 'warning' && th('defaultFields.focused.warning')};
-    ${variant === 'success' && th('defaultFields.focused.success')};
-    ${variant === 'info' && th('defaultFields.focused.info')};
-  }
-
-  &[disabled] {
-    ${th('defaultFields.disabled')};
-  }
-
-  &:invalid,
-  &:-moz-submit-invalid,
-  &:-moz-ui-invalid {
-    box-shadow: none;
-  }
 `

--- a/packages/Utils/hide-focus-rings-root.tsx
+++ b/packages/Utils/hide-focus-rings-root.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { createGlobalStyle, css } from '@xstyled/styled-components'
+import { createGlobalStyle, css } from 'styled-components'
 
 export const hideFocusRingsDataAttribute = 'data-wui-hidefocusrings'
 

--- a/packages/Utils/overflow-ellipsis.ts
+++ b/packages/Utils/overflow-ellipsis.ts
@@ -1,4 +1,4 @@
-import { css } from '@xstyled/styled-components'
+import { css } from 'styled-components'
 
 export const overflowEllipsis = css`
   white-space: nowrap;

--- a/packages/Utils/package.json
+++ b/packages/Utils/package.json
@@ -37,7 +37,6 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/Utils/tsconfig.json
+++ b/packages/Utils/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["index.ts", "../../types"]
 }

--- a/packages/Utils/variants.ts
+++ b/packages/Utils/variants.ts
@@ -1,16 +1,18 @@
-import { th } from '@xstyled/styled-components'
+import { DefaultTheme } from 'styled-components'
 
 export type Variant = 'error' | 'focused' | 'info' | 'success' | 'warning'
 
-export const VARIANTS: Record<Variant, string> = {
-  error: 'colors.danger-400',
-  focused: 'colors.primary-200',
-  info: 'colors.info-500',
-  success: 'colors.success-400',
-  warning: 'colors.warning-400',
+export const VARIANTS: Record<Variant, keyof DefaultTheme['colors']> = {
+  error: 'danger-400',
+  focused: 'primary-200',
+  info: 'info-500',
+  success: 'success-400',
+  warning: 'warning-400',
 }
 
-export const getVariantColor = (variant: Variant): ReturnType<typeof th> => {
-  const key = VARIANTS[variant]
-  return key ? th(key) : null
-}
+export const getVariantColor =
+  (variant: Variant) =>
+  ({ theme }: Record<string, unknown> & { theme: DefaultTheme }) => {
+    const key = VARIANTS[variant]
+    return key ? theme.colors?.[key] : null
+  }

--- a/packages/VariantIcon/index.tsx
+++ b/packages/VariantIcon/index.tsx
@@ -8,7 +8,7 @@ import * as S from './styles'
 
 type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'
 
-export type Variant = VariantFromUtils | 'default'
+export type Variant = Exclude<VariantFromUtils, 'focused'> | 'default'
 
 export interface VariantIconOptions {
   icon?: JSX.Element

--- a/packages/VariantIcon/package.json
+++ b/packages/VariantIcon/package.json
@@ -43,7 +43,6 @@
     "@welcome-ui/utils": "^5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@xstyled/styled-components": "^3.7.0",
     "react": "^16.10.2 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.3.6"
   },

--- a/packages/VariantIcon/styles.ts
+++ b/packages/VariantIcon/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@welcome-ui/box'
 import { getVariantColor, Variant } from '@welcome-ui/utils'
 

--- a/packages/VariantIcon/tsconfig.json
+++ b/packages/VariantIcon/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.tsx"]
+  "include": ["index.tsx", "../../types"]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,10 @@ const getBabelOptions = ({ babelConfigFile = '../../babel.config.js' }) => ({
   babelHelpers: 'inline',
 })
 
-const external = id => !id.startsWith('.') && !id.startsWith('/')
+const external = id => {
+  if (id === 'jsx-to-styled') return false // keep jsx-to-styled in @welcome-ui/system
+  return !id.startsWith('.') && !id.startsWith('/')
+}
 
 const PLUGINS = [
   replace({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,14 +4,8 @@
     "outDir": ".",
     "baseUrl": "./packages",
     "sourceMap": false,
-    "declaration": true,
+    "declaration": true
   },
-  "include": ["packages", "syled.d.ts"],
-  "exclude": [
-    "dist",
-    "icons/**/*",
-    "packages/**/node_modules",
-    "packages/**/dist",
-    "docs"
-  ]
+  "include": ["packages", "types"],
+  "exclude": ["dist", "icons/**/*", "packages/**/node_modules", "packages/**/dist", "docs"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
     "sourceMap": false,
     "declaration": true
   },
-  "include": ["packages", "types"],
+  "include": ["packages/**/*.ts", "types"],
   "exclude": ["dist", "icons/**/*", "packages/**/node_modules", "packages/**/dist", "docs"]
 }

--- a/types/styled.d.ts
+++ b/types/styled.d.ts
@@ -1,8 +1,11 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
+import 'jsx-to-styled'
 import 'styled-components'
-import '@xstyled/styled-components'
+import type { WuiTheme } from '@welcome-ui/core'
 
-import { WuiTheme } from '@welcome-ui/core'
+declare module 'jsx-to-styled' {
+  export interface Theme extends WuiTheme {}
+}
 
 declare module '@xstyled/styled-components' {
   export interface Theme extends WuiTheme {}

--- a/types/styled.d.ts
+++ b/types/styled.d.ts
@@ -7,10 +7,6 @@ declare module 'jsx-to-styled' {
   export interface Theme extends WuiTheme {}
 }
 
-declare module '@xstyled/styled-components' {
-  export interface Theme extends WuiTheme {}
-}
-
 declare module 'styled-components' {
   export interface DefaultTheme extends WuiTheme {}
 }

--- a/utils/tests.js
+++ b/utils/tests.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { ThemeProvider } from '@xstyled/styled-components'
+import { ThemeProvider } from 'styled-components'
 import { StaticRouter } from 'react-router-dom/server'
 import '@testing-library/jest-dom/extend-expect'
 import 'jest-styled-components'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4675,36 +4675,6 @@
     resolve-from "^5.0.0"
     rollup-pluginutils "^2.8.2"
 
-"@xstyled/core@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@xstyled/core/-/core-3.7.0.tgz#b6ea2c4b059ca9d808ffdf3800406eaddd2a9491"
-  integrity sha512-4U7PnDf4DnCWPwLRpyyCocQXod5T3Ap+h0nIwdJyZtHB35sjUXsEO8Cp8wP9lqbn/bnWkqhaL79StjUEmIIvrQ==
-  dependencies:
-    "@xstyled/system" "^3.7.0"
-    "@xstyled/util" "^3.7.0"
-
-"@xstyled/styled-components@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@xstyled/styled-components/-/styled-components-3.7.0.tgz#28c9ca3ee675fa320faeccbb4c20116b0c98ec25"
-  integrity sha512-5zUmlC6v3wvBPHrhFUawu0FBYwHzGTFlGZYrZob54QMu9Sv1tFjgMVwGCp4uOLK9kVrRVyTVwWXejKXpyeGFVg==
-  dependencies:
-    "@xstyled/core" "^3.7.0"
-    "@xstyled/system" "^3.7.0"
-    "@xstyled/util" "^3.7.0"
-
-"@xstyled/system@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@xstyled/system/-/system-3.7.0.tgz#ed2c4f87c62eead93e112e71147fd816699759a3"
-  integrity sha512-110+yxP3zJSCr6Qyy89GMvaKhrR/3ezVyAGVOYsyUBz2u0+p3uAJ7uHKro2Pcwbt7V6oc7D5nTQVaOLasKMPCg==
-  dependencies:
-    "@xstyled/util" "^3.7.0"
-    csstype "^3.1.1"
-
-"@xstyled/util@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@xstyled/util/-/util-3.7.0.tgz#513c045dda0847d43b39612b6d36cc38b507e82d"
-  integrity sha512-rYtXRcNh+pgRxGnciP0Mas21mpyOzcCTVy7w9uIByQk3EytwBQjDiN6wCasXibkw49Urfti5efsklRbCl5QZww==
-
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -7196,7 +7166,7 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2, csstype@^3.1.0, csstype@^3.1.1:
+csstype@^3.0.2, csstype@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7196,7 +7196,7 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2, csstype@^3.1.1:
+csstype@^3.0.2, csstype@^3.1.0, csstype@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
@@ -11668,6 +11668,13 @@ jsprim@^1.2.2:
   dependencies:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
+
+jsx-to-styled@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/jsx-to-styled/-/jsx-to-styled-1.5.2.tgz#a5ff7c7622897406a0392e055d072827593a5df3"
+  integrity sha512-b4zTt5z+D8ePhDA3zhTVKLRR1hLqViN3SYOLu2R6Kzm/AseJMgEVXPzu/eZZucNQSAkXrO+K8bhWbuUvRiCmjQ==
+  dependencies:
+    csstype "^3.1.0"
 
 junk@^3.1.0:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11669,10 +11669,10 @@ jsprim@^1.2.2:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
 
-jsx-to-styled@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/jsx-to-styled/-/jsx-to-styled-1.5.2.tgz#a5ff7c7622897406a0392e055d072827593a5df3"
-  integrity sha512-b4zTt5z+D8ePhDA3zhTVKLRR1hLqViN3SYOLu2R6Kzm/AseJMgEVXPzu/eZZucNQSAkXrO+K8bhWbuUvRiCmjQ==
+jsx-to-styled@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/jsx-to-styled/-/jsx-to-styled-1.5.3.tgz#f76f80ac9b462cf5d7615da34d419b9244aaa08a"
+  integrity sha512-0K/z8JNK6vm+zielH9CF3LPm92O0cn1mBSHsmU8cJaF7TlT50rUiZkTG3/8NjjWr4GSZpM0pO0bwDw0dUGrJUA==
   dependencies:
     csstype "^3.1.0"
 


### PR DESCRIPTION
# Refactoring: remove `@xstyled/styled-components`

### Why ?
// todo

### Breaking changes:

- `styled` is now coming from `styled-components`
same for `css` helper
```diff
- import styled from '@xstyled/styled-components'
+ import styled from 'styled-components'
```

- Remove `th` helper
We now use the [styled-components way](https://styled-components.com/docs/advanced) to access a theme value, it works very well since the theme is fully typed. 
```diff
- export const Breadcrumb = styled(Box)`
-   ${th('breadcrumbs.list')};
+ export const Breadcrumb = styled(Box)(({ theme }) => css`
+.  ${theme.breadcrumbs.list};
```

- Remove "magic styled components"
Same as above, we now access a theme value with props and get back autocomplete.
```diff
- export const Button = styled.button`
-   color: dark-400;
+ export const Button = styled.button`
+.  color: ${({ theme ) => theme.colors['dark-400'])}
```

- Remove `shouldForwardProp`
Following [styled-components v6 changelog](https://styled-components.com/releases#v6.0.0-beta.5), we prefer use props prefixed by a `$` to prevent forward props to html element. 
_(**cf** dropped automatic prop filtering, use transient props ($ prefix) for stuff you don't want to be passed to child component / HTML)_
All styled props are now beginning with `$` and have a better autocomplete than before.

```diff
- <Box color="dark-200" display="flex" flexDirection="column" onClick={handleClick}>...</Box>
+ <Box $color="dark-200" $display="flex" $flexDirection="column" onClick={handleClick}>...</Box>
```

- `system` is now coming from `@welcome-ui/stystem`
```diff
- import { system } from '@xstyled/styled-components'
+ import { system } from '@welcome-ui/system'
```

- `up`/`down` helpers are now coming from `welcome-ui/system`
New syntax:
```diff
- import { up, down } from '@xstyled/styled-components'
+ import { up, down } from '@welcome-ui/system'

const Test = styled.div`
  display: flex;
  flex-direction: column;

-  ${up(
-    'md', 
-    css`
-      flex-direction: row;
-   `)}
+  ${up('md')} { 
+    flex-direction: row;
+  )
`
```

