### PR TITLE
feat: rework Toast component

### DIFF
--- a/docs/components/App.js
+++ b/docs/components/App.js
@@ -1,10 +1,10 @@
-
 import React, { useEffect, useState } from 'react'
 import { createTheme, WuiProvider } from '@welcome-ui/core'
 import { MDXProvider } from '@mdx-js/react'
 import { welcomeTheme } from '@welcome-ui/themes.welcome'
 import { darkTheme } from '@welcome-ui/themes.dark'
 import { welcomeDarkTheme } from '@welcome-ui/themes.welcome-dark'
+import { Notifications } from '@welcome-ui/toast'
 
 import { useThemeContext } from '../context/theme'
 
@@ -44,6 +44,7 @@ export function App({ component: Component, pageProps }) {
         <Layouts>
           <Component {...pageProps} />
         </Layouts>
+        <Notifications />
       </MDXProvider>
     </WuiProvider>
   )

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -1,4 +1,3 @@
-
 /* eslint-disable react/display-name */
 import React from 'react'
 import { Provider } from 'reakit'

--- a/docs/pages/components/toast.mdx
+++ b/docs/pages/components/toast.mdx
@@ -25,7 +25,7 @@ Notification component with [react-hot-toast](https://react-hot-toast.com/) and 
 
 ## Notifications
 
-Before use `Toast` component, you must to integrate `Notifications` component at root of your project. This component will contains all of your toasts in your DOM.
+Before using the `Toast` component, you must add the `Notifications` component in your project root. This component will contain all your toasts.
 
 ```
 function App() {

--- a/docs/pages/components/toast.mdx
+++ b/docs/pages/components/toast.mdx
@@ -65,8 +65,6 @@ function() {
 }
 ```
 
-**Note:** The `useToast` hook is deprecated. Instead, you can directly use `toast` function.
-
 ## Options
 
 The `toast` function takes a component to be displayed and an `options` object:

--- a/docs/pages/components/toast.mdx
+++ b/docs/pages/components/toast.mdx
@@ -18,19 +18,31 @@ import {
 
 ## About
 
-Notification component with [toasted-note](https://toasted-notes.netlify.com) and 2 components:
+Notification component with [react-hot-toast](https://react-hot-toast.com/) and 2 components:
 
 - Growl
 - Snackbar
 
-## useToast
+## Notifications
 
-Use `useToast` hook to show the toast element. Example below with a custom component.
+Before use `Toast` component, you must to integrate `Notifications` component at root of your project. This component will contains all of your toasts in your DOM.
+
+```
+function App() {
+  // ...
+  <Notifications pauseOnHover={false} />
+  // ...
+}
+```
+
+You can pass a boolean value to `pauseOnHover` prop (default to `true`) to pause duration of all notifications on mouse hover.
+
+## toast()
+
+Use `toast` function to show the toast element. Example below with a custom component.
 
 ```jsx
 function() {
-  const toast = useToast()
-
   const Notification = () => (
     <Box
       backgroundColor="light-900"
@@ -53,17 +65,17 @@ function() {
 }
 ```
 
+**Note:** The `useToast` hook is deprecated. Instead, you can directly use `toast` function.
+
 ## Options
 
 The `toast` function takes a component to be displayed and an `options` object:
 
-- **position** : one of `top-left`, `top`, `top-right`, `bottom-left`, `bottom` (default) or `bottom-right`
+- **position** : one of `top-left`, `top-center`, `top-right`, `bottom-left`, `bottom-center` (default) or `bottom-right`
 - **duration** : before closing element, in ms, with default `7000`. Can also be set to `null` if not automatic close your element.
 
 ```jsx
 function() {
-  const toast = useToast()
-
   const Notification = () => (
     <Box
       backgroundColor="light-900"
@@ -80,7 +92,7 @@ function() {
 
   return (
     <Stack direction="row">
-      {['top-left', 'top', 'top-right', 'bottom-left', 'bottom', 'bottom-right'].map(position => (
+      {['top-left', 'top-center', 'top-right', 'bottom-left', 'bottom-center', 'bottom-right'].map(position => (
         <Button
           key={position}
           onClick={() =>
@@ -111,8 +123,6 @@ In general :
 
 ```jsx
 function() {
-  const toast = useToast()
-
   return (
     <Stack direction="row">
       <Button
@@ -203,8 +213,6 @@ function() {
 
 ```jsx
 function() {
-  const toast = useToast()
-
   return (
     <Stack direction="row">
       <Button
@@ -340,8 +348,6 @@ You can add your custom function when user click on close button
 
 ```jsx
 function() {
-  const toast = useToast()
-
   function onClose() {
     alert('Toast hidden!')
   }
@@ -372,8 +378,6 @@ You can choose not to show a close button on Growl or Snackbar with the `hasClos
 
 ```jsx
 function() {
-  const toast = useToast()
-
   function onClose() {
     alert('Toast hidden!')
   }

--- a/docs/pages/upgrade.mdx
+++ b/docs/pages/upgrade.mdx
@@ -78,6 +78,9 @@ We change the name of variants to `XS` `S` `M` and remove useless variants.
 - We have adjusted colors and spacing.
 - The props `icon` is now given to the **Alert** component and not to **Alert.Title**.
 - The props `icon` is now given to **Toast.Growl** / **Toast.Snackbar** component and not to **Toast.Title**.
+- Position `top` has been replaced with `top-center` and position `bottom` has been replaced with `bottom-center`.
+- The `useToast` hook is deprecated. Instead, you can directly use `toast` function.
+- In order to use `Toast` component, you must to integrate `Notifications` component at root of your project.
 
 #### Buttons
 

--- a/docs/pages/upgrade.mdx
+++ b/docs/pages/upgrade.mdx
@@ -80,7 +80,7 @@ We change the name of variants to `XS` `S` `M` and remove useless variants.
 - The props `icon` is now given to **Toast.Growl** / **Toast.Snackbar** component and not to **Toast.Title**.
 - Position `top` has been replaced with `top-center` and position `bottom` has been replaced with `bottom-center`.
 - The `useToast` hook is deprecated. Instead, you can directly use `toast` function.
-- In order to use `Toast` component, you must to integrate `Notifications` component at root of your project.
+- In order to use `Toast` component, you must add the `Notifications` component in your project root.
 
 #### Buttons
 

--- a/packages/Toast/ToastWrapper.tsx
+++ b/packages/Toast/ToastWrapper.tsx
@@ -57,7 +57,14 @@ export const ToastWrapper: React.FC<ToastWrapperProps> = ({
   }
 
   return (
-    <S.ToastWrapper isBottom={bottom} ref={ref} style={toastStyle} {...toast.ariaProps}>
+    <S.ToastWrapper
+      isBottom={bottom}
+      opacity={toastStyle.opacity}
+      ref={ref}
+      style={toastStyle}
+      transform={toastStyle.transform}
+      {...toast.ariaProps}
+    >
       {cloneElement(toast.message as JSX.Element, { onClose })}
     </S.ToastWrapper>
   )

--- a/packages/Toast/ToastWrapper.tsx
+++ b/packages/Toast/ToastWrapper.tsx
@@ -2,17 +2,16 @@ import React, { cloneElement } from 'react'
 import toastRHT, { Toast, ToastPosition } from 'react-hot-toast/headless'
 
 import * as S from './styles'
+import { POSITION_STYLE } from './utils'
 
 type ToastWrapperProps = {
   calculateOffset: (
     toast: Toast,
-    opts?:
-      | {
-          reverseOrder?: boolean | undefined
-          gutter?: number | undefined
-          defaultPosition?: ToastPosition | undefined
-        }
-      | undefined
+    opts?: {
+      reverseOrder?: boolean
+      gutter?: number
+      defaultPosition?: ToastPosition
+    }
   ) => number
   toast: Toast & CustomToastOptions
   updateHeight: (toastId: string, height: number) => void
@@ -46,15 +45,6 @@ export const ToastWrapper: React.FC<ToastWrapperProps> = ({
   const top = toast.position?.includes('top')
   const bottom = toast.position?.includes('bottom')
 
-  const positionStyle = {
-    'top-left': { top: 0, left: 0 },
-    'top-center': { top: 0, left: '50%' },
-    'top-right': { top: 0, right: 0 },
-    'bottom-left': { bottom: 0, left: 0 },
-    'bottom-center': { bottom: 0, left: '50%' },
-    'bottom-right': { bottom: 0, right: 0 },
-  }
-
   const onClose = () => {
     if (toast.onClose) toast.onClose()
     toastRHT.dismiss(toast.id)
@@ -63,7 +53,7 @@ export const ToastWrapper: React.FC<ToastWrapperProps> = ({
   const toastStyle = {
     opacity: toast.visible ? 1 : 0,
     transform: `translate(${center ? '-50%' : '0'}, ${offset * (top ? 1 : -1)}px)`,
-    ...positionStyle[toast.position],
+    ...POSITION_STYLE[toast.position],
   }
 
   return (

--- a/packages/Toast/ToastWrapper.tsx
+++ b/packages/Toast/ToastWrapper.tsx
@@ -1,0 +1,74 @@
+import React, { cloneElement } from 'react'
+import toastRHT, { Toast, ToastPosition } from 'react-hot-toast/headless'
+
+import * as S from './styles'
+
+type ToastWrapperProps = {
+  calculateOffset: (
+    toast: Toast,
+    opts?:
+      | {
+          reverseOrder?: boolean | undefined
+          gutter?: number | undefined
+          defaultPosition?: ToastPosition | undefined
+        }
+      | undefined
+  ) => number
+  toast: Toast & CustomToastOptions
+  updateHeight: (toastId: string, height: number) => void
+}
+
+type CustomToastOptions = {
+  onClose?: () => void
+}
+
+export const ToastWrapper: React.FC<ToastWrapperProps> = ({
+  calculateOffset,
+  toast,
+  updateHeight,
+}) => {
+  if (typeof toast.message === 'string') {
+    // eslint-disable-next-line no-console
+    console.warn('You must pass a React component or a HTML element.')
+    return null
+  }
+
+  const offset = calculateOffset(toast, { reverseOrder: false, gutter: 0 })
+
+  const ref = (element: HTMLElement | null) => {
+    if (element && typeof toast.height !== 'number') {
+      const height = element.getBoundingClientRect().height
+      updateHeight(toast.id, height)
+    }
+  }
+
+  const center = toast.position?.includes('center')
+  const top = toast.position?.includes('top')
+  const bottom = toast.position?.includes('bottom')
+
+  const positionStyle = {
+    'top-left': { top: 0, left: 0 },
+    'top-center': { top: 0, left: '50%' },
+    'top-right': { top: 0, right: 0 },
+    'bottom-left': { bottom: 0, left: 0 },
+    'bottom-center': { bottom: 0, left: '50%' },
+    'bottom-right': { bottom: 0, right: 0 },
+  }
+
+  const onClose = () => {
+    if (toast.onClose) toast.onClose()
+    toastRHT.dismiss(toast.id)
+  }
+
+  const toastStyle = {
+    opacity: toast.visible ? 1 : 0,
+    transform: `translate(${center ? '-50%' : '0'}, ${offset * (top ? 1 : -1)}px)`,
+    ...positionStyle[toast.position],
+  }
+
+  return (
+    <S.ToastWrapper isBottom={bottom} ref={ref} style={toastStyle} {...toast.ariaProps}>
+      {cloneElement(toast.message as JSX.Element, { onClose })}
+    </S.ToastWrapper>
+  )
+}

--- a/packages/Toast/index.tsx
+++ b/packages/Toast/index.tsx
@@ -16,21 +16,18 @@ import * as S from './styles'
 
 export type Variant = 'default' | 'error' | 'warning' | 'info' | 'success'
 
-type NotificationsProps = {
-  options?: { pauseOnHover?: boolean }
-}
+type NotificationsProps = { pauseOnHover?: boolean }
 
 type ToastOptions = {
   duration?: number
   position?: ToastPosition
 }
 
-export const Notifications: React.FC<NotificationsProps> = ({ options }) => {
+export const Notifications: React.FC<NotificationsProps> = ({ pauseOnHover = true }) => {
   const themeContext = useContext(ThemeContext)
   const { handlers, toasts } = useToaster()
   const { calculateOffset, endPause, startPause, updateHeight } = handlers
 
-  const pauseOnHover = options?.pauseOnHover || true
   const onMouseEnter = pauseOnHover ? startPause : undefined
   const onMouseLeave = pauseOnHover ? endPause : undefined
 
@@ -54,7 +51,7 @@ const Title: React.FC<TextProps> = ({ children, ...rest }) => (
   <S.Title {...rest}>{children}</S.Title>
 )
 
-export const toast = (component: ValueFunction<Renderable, ToastRHT>, options: ToastOptions) => {
+export const toast = (component: ValueFunction<Renderable, ToastRHT>, options?: ToastOptions) => {
   const toastOptions = {
     duration: 7000,
     position: 'bottom-center' as ToastPosition,

--- a/packages/Toast/package.json
+++ b/packages/Toast/package.json
@@ -47,8 +47,7 @@
     "@welcome-ui/system": "^5.0.0-alpha.0",
     "@welcome-ui/utils": "^5.0.0-alpha.0",
     "@welcome-ui/variant-icon": "^5.0.0-alpha.0",
-    "react-spring": "^8.0.27",
-    "toasted-notes": "^3.2.0"
+    "react-hot-toast": "^2.4.0"
   },
   "peerDependencies": {
     "@xstyled/styled-components": "^3.7.0",
@@ -57,6 +56,6 @@
   },
   "gitHead": "974e7bfd71f8cfe846cbffd678c3860a8952f9e9",
   "sideEffects": false,
-  "component": "Toast, useToast",
+  "component": "Notifications, Toast, toast",
   "homepage": "https://welcome-ui.com/components/toast"
 }

--- a/packages/Toast/styles.ts
+++ b/packages/Toast/styles.ts
@@ -5,10 +5,14 @@ import { Alert } from '@welcome-ui/alert'
 import { GrowlOptions } from './Growl'
 import { SnackbarOptions } from './Snackbar'
 
-export const Toast = styled(Box)<{ isBottom: boolean }>(
+export const ToastWrapper = styled(Box)<{ isBottom: boolean }>(
   ({ isBottom }) => css`
     ${th('toasts.default')}
     ${isBottom ? th('toasts.bottom') : th('toasts.top')}
+
+    position: fixed;
+    z-index: 9999;
+    transition: all 400ms ease-out;
   `
 )
 

--- a/packages/Toast/utils.ts
+++ b/packages/Toast/utils.ts
@@ -1,0 +1,8 @@
+export const POSITION_STYLE = {
+  'top-left': { top: 0, left: 0 },
+  'top-center': { top: 0, left: '50%' },
+  'top-right': { top: 0, right: 0 },
+  'bottom-left': { bottom: 0, left: 0 },
+  'bottom-center': { bottom: 0, left: '50%' },
+  'bottom-right': { bottom: 0, right: 0 },
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,7 +1396,7 @@
     core-js-pure "^3.25.1"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.3.1", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
   integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
@@ -3708,24 +3708,6 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
-"@reach/alert@^0.1.2":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@reach/alert/-/alert-0.1.5.tgz#4da79add0055fa4295f51e5295ed3b80257e9153"
-  integrity sha512-Ow+SB7rokGWxmm+AdOpf4eo29OaEYDqlJ1Kc9qulVX2cKjYiHQqAvkiCkSaIPkQbbyNmEXJ0c/rVpzPVvCVIAw==
-  dependencies:
-    "@reach/component-component" "^0.1.3"
-    "@reach/visually-hidden" "^0.1.4"
-
-"@reach/component-component@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@reach/component-component/-/component-component-0.1.3.tgz#5d156319572dc38995b246f81878bc2577c517e5"
-  integrity sha512-a1USH7L3bEfDdPN4iNZGvMEFuBfkdG+QNybeyDv8RloVFgZYRoM+KGXyy2KOfEnTUM8QWDRSROwaL3+ts5Angg==
-
-"@reach/visually-hidden@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.1.4.tgz#0dc4ecedf523004337214187db70a46183bd945b"
-  integrity sha512-QHbzXjflSlCvDd6vJwdwx16mSB+vUCCQMiU/wK/CgVNPibtpEiIbisyxkpZc55DyDFNUIqP91rSUsNae+ogGDQ==
-
 "@remix-run/router@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.0.3.tgz#953b88c20ea00d0eddaffdc1b115c08474aa295d"
@@ -4266,13 +4248,6 @@
     date-fns "^2.0.1"
     react-popper "^2.2.5"
 
-"@types/react-dom@^16.8.3":
-  version "16.9.16"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.16.tgz#c591f2ed1c6f32e9759dfa6eb4abfd8041f29e39"
-  integrity sha512-Oqc0RY4fggGA3ltEgyPLc3IV9T73IGoWjkONbsyJ3ZBn+UPPCYpU2ec0i3cEbJuEdZtkqcCF2l1zf2pBdgUGSg==
-  dependencies:
-    "@types/react" "^16"
-
 "@types/react-dom@^18.0.0", "@types/react-dom@^18.0.9":
   version "18.0.9"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.9.tgz#ffee5e4bfc2a2f8774b15496474f8e7fe8d0b504"
@@ -4291,15 +4266,6 @@
   version "18.0.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.24.tgz#2f79ed5b27f08d05107aab45c17919754cc44c20"
   integrity sha512-wRJWT6ouziGUy+9uX0aW4YOJxAY0bG6/AOk5AW5QSvZqI7dk6VBIbXvcVgIw/W5Jrl24f77df98GEKTJGOLx7Q==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16", "@types/react@^16.8.10":
-  version "16.14.32"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.32.tgz#d4e4fe5ece3c27fcb4608b1f4a614f7dec881392"
-  integrity sha512-hvEy4vGVADbtj/U6+CA5SRC5QFIjdxD7JslAie8EuAYZwhYY9bgforpXNyF1VFzhnkEOesDy1278t1wdjN74cw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -9685,6 +9651,11 @@ gonzales-pe@^4.2.3, gonzales-pe@^4.3.0:
   dependencies:
     minimist "^1.2.5"
 
+goober@^2.1.10:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.11.tgz#bbd71f90d2df725397340f808dbe7acc3118e610"
+  integrity sha512-5SS2lmxbhqH0u9ABEWq7WPU69a4i2pYcHeCxqaNq6Cw3mnrF0ghWNM4tEGid4dKy8XNIAUbuThuozDHHKJVh3A==
+
 got@^10.0.0, got@^10.7.0:
   version "10.7.0"
   resolved "https://registry.yarnpkg.com/got/-/got-10.7.0.tgz#62889dbcd6cca32cd6a154cc2d0c6895121d091f"
@@ -14887,7 +14858,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -15190,6 +15161,13 @@ react-hook-form@^7.39.4:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.39.4.tgz#7d9edf4e778a0cec4383f0119cd0699e3826a14a"
   integrity sha512-B0e78r9kR9L2M4A4AXGbHoA/vyv34sB/n8QWJAw33TFz8f5t9helBbYAeqnbvcQf1EYzJxKX/bGQQh9K+evCyQ==
 
+react-hot-toast@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.0.tgz#b91e7a4c1b6e3068fc599d3d83b4fb48668ae51d"
+  integrity sha512-qnnVbXropKuwUpriVVosgo8QrB+IaPJCpL8oBI6Ov84uvHZ5QQcTp2qg6ku2wNfgJl6rlQXJIQU5q+5lmPOutA==
+  dependencies:
+    goober "^2.1.10"
+
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -15248,14 +15226,6 @@ react-simplemde-editor@5.2.0:
   integrity sha512-GkTg1MlQHVK2Rks++7sjuQr/GVS/xm6y+HchZ4GPBWrhcgLieh4CjK04GTKbsfYorSRYKa0n37rtNSJmOzEDkQ==
   dependencies:
     "@types/codemirror" "~5.60.5"
-
-react-spring@^8.0.27:
-  version "8.0.27"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
-  integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    prop-types "^15.5.8"
 
 react-window@^1.8.8:
   version "1.8.8"
@@ -17381,15 +17351,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-toasted-notes@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/toasted-notes/-/toasted-notes-3.2.0.tgz#dc9bdc9d0083ba2af8bf26b2f71619d014acc089"
-  integrity sha512-PucSn+SUdFSYNaaL1eNw7wYkEMJ7LULCR6j1YXPlRySHgWVgf+bXjq4dYd3hdA4mvmGz9HANmI1RnzhZ8av52Q==
-  dependencies:
-    "@reach/alert" "^0.1.2"
-    "@types/react" "^16.8.10"
-    "@types/react-dom" "^16.8.3"
 
 toggle-selection@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
Hey! 🖖 

Je viens de remplacer le package `toasted-notes` par `react-hot-toast`. Celui-ci gère mieux les notifications en les montant au même endroit dans le DOM. De plus, j'ai utilisé la partie _headless_ du package qui a le moins de dépendance et nous permet de l'intégrer exactement comme on le souhaite. Malheureusement cela implique quelques breaking changes que j'ai essayé de limiter au maximum.

Voici la liste des changements majeurs :

- `useToast()` est _deprecated_. On peut encore l'utiliser mais clairement ce hook devient inutile. Avant on faisait :
```jsx
const toast = useToast()

return (
  <Button onClick={() => toast(<div>Message</div>)}>
      Show Toast
  </Button>
)
```
Maintenant on peut directement importer et utiliser `toast()` :
```jsx
<Button onClick={() => toast(<div>Message</div>)}>
    Show Toast
</Button>
```

- On doit importer le composant `Notifications` au plus haut niveau de sa structure. En effet, c'est ce composant qui génère la liste des notifications dans le DOM. Il y a d'ailleurs une petite option qui permet de mettre en pause la disparition des notifications lorsqu'on survole l'un d'entre elles : `pauseOnHover`.

- Pour avoir une notification centrée en haut ou en bas, on doit maintenant utiliser les valeurs `top-center` et `bottom-center`. Le positionnement par défaut reste inchangé (`bottom-center`).

---

A part ça, tout s'utilise comme avant. L'utilisation de la fonction `toast()` reste identique. Les 2 composants `Growl` et `Snackbar` restent inchangés.

Juste un dernier petit point, la première notification qui apparaît n'est pas animé. Cela ne me plaît pas mais j'ai galéré à trouver une solution (cela peut sembler simple au premier abord mais en fait non 😓). Je suis donc ouvert à vos propositions si vous souhaitez améliorer ce point.