### PR TITLE
fix: loader size prop

### DIFF
--- a/packages/Loader/index.test.tsx
+++ b/packages/Loader/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { render } from '../../utils/tests'
+import { render, theme } from '../../utils/tests'
 
 import { Loader } from './index'
 
@@ -10,5 +10,32 @@ describe('<Loader>', () => {
 
     const childrenLength = getByTestId('loader').children.length
     expect(childrenLength).toEqual(3)
+  })
+
+  it('should have width and height when using the size prop with theme value', () => {
+    const { getByTestId } = render(<Loader color="black" dataTestId="loader" size="sm" />)
+    const loader = getByTestId('loader')
+    const dot = loader.firstChild
+
+    expect(dot).toHaveStyleRule('width', theme.loaders.sm)
+    expect(dot).toHaveStyleRule('height', theme.loaders.sm)
+  })
+
+  it('should have width and height when using the size prop with px value', () => {
+    const { getByTestId } = render(<Loader color="black" dataTestId="loader" size="10px" />)
+    const loader = getByTestId('loader')
+    const dot = loader.firstChild
+
+    expect(dot).toHaveStyleRule('width', '10px')
+    expect(dot).toHaveStyleRule('height', '10px')
+  })
+
+  it('should have width and height when using the size prop with no value', () => {
+    const { getByTestId } = render(<Loader color="black" dataTestId="loader" size="16" />)
+    const loader = getByTestId('loader')
+    const dot = loader.firstChild
+
+    expect(dot).toHaveStyleRule('width', theme.toRem(16))
+    expect(dot).toHaveStyleRule('height', theme.toRem(16))
   })
 })

--- a/packages/Loader/styles.ts
+++ b/packages/Loader/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css, keyframes, system, th } from '@xstyled/styled-components'
+import styled, { css, keyframes, system } from '@xstyled/styled-components'
 import { Shape } from '@welcome-ui/shape'
 import { shouldForwardProp } from '@welcome-ui/system'
 
@@ -25,7 +25,7 @@ export interface LoadingDotOptions {
 
 export const LoadingDot = styled(Shape).withConfig({ shouldForwardProp })<LoadingDotOptions>(
   ({ size, theme }) => {
-    const sizeValue = th(`loaders.${size}`) || size
+    const sizeValue = theme.loaders?.[size] || size
     const formattedSize = typeof sizeValue === 'number' ? theme.toRem(sizeValue) : sizeValue
     return css`
       width: ${formattedSize};

--- a/utils/tests.js
+++ b/utils/tests.js
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom/extend-expect'
 import 'jest-styled-components'
 
 import { createTheme } from '../packages/Core/theme/core'
-const theme = createTheme()
+export const theme = createTheme()
 
 const AllTheProviders = ({ children }) => {
   return (


### PR DESCRIPTION
BEFORE: 
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/319863/204249798-1ed2339d-bf3e-4746-bf1c-79bed787e2df.png">

AFTER:
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/319863/204250205-1f5bf9be-5867-425a-a2ee-4488909e4906.png">



Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>