### PR TITLE
fix #1745 icons size inside buttons

### DIFF
--- a/docs/pages/components/icons-font.mdx
+++ b/docs/pages/components/icons-font.mdx
@@ -10,7 +10,7 @@ import {
   version={version}
   name={name}
   component={component}
-  customUsage="import { AvatarIcon } from '@welcome-ui/icons.font'"
+  customUsage="import { Icons } from '@welcome-ui/icons.font'"
 />
 
 ## Icons import

--- a/packages/Button/index.test.tsx
+++ b/packages/Button/index.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { Link } from '@welcome-ui/link'
+import { SunIcon } from '@welcome-ui/icons'
+import { Icons } from '@welcome-ui/icons.font'
 
 import { createTheme } from '../Core/theme/core'
 import { render } from '../../utils/tests'
@@ -126,5 +128,79 @@ describe('<Button>', () => {
     expect(button.tagName.toLowerCase()).toBe('a')
     expect(button).toHaveClass('wui-test')
     expect(button).toHaveAttribute('rel', 'noopener noreferrer') // added by target="_blank" on Link
+  })
+
+  it('should have correct Icon size with Icon and text', () => {
+    const theme = createTheme()
+    const { getByTestId } = render(
+      <Button dataTestId="button" size="sm">
+        <SunIcon dataTestId="sun" />
+        <span>{content}</span>
+      </Button>
+    )
+
+    const button = getByTestId('button')
+    const icon = getByTestId('icon-sun')
+    expect(button).toHaveStyleRule('height', theme.buttons.sizes.sm.height)
+    expect(icon).toHaveStyle({
+      width: theme.buttons.icon.default.sm,
+      height: theme.buttons.icon.default.sm,
+      'font-size': theme.buttons.icon.default.sm,
+    })
+  })
+
+  it('should have correct Icon size with Icon only', () => {
+    const theme = createTheme()
+    const { getByTestId } = render(
+      <Button dataTestId="button" size="md">
+        <SunIcon dataTestId="sun" />
+      </Button>
+    )
+
+    const button = getByTestId('button')
+    const icon = getByTestId('icon-sun')
+    expect(button).toHaveStyleRule('height', theme.buttons.sizes.md.height)
+    expect(icon).toHaveStyle({
+      width: theme.buttons.icon.only.md,
+      height: theme.buttons.icon.only.md,
+      'font-size': theme.buttons.icon.only.md,
+    })
+  })
+
+  it('should have correct IconFont size with IconFont and text', () => {
+    const theme = createTheme()
+    const { getByTestId } = render(
+      <Button dataTestId="button" size="sm">
+        <Icons.Sun dataTestId="sun" />
+        <span>{content}</span>
+      </Button>
+    )
+
+    const button = getByTestId('button')
+    const icon = getByTestId('icon-font-sun')
+    expect(button).toHaveStyleRule('height', theme.buttons.sizes.sm.height)
+    expect(icon).toHaveStyle({
+      width: theme.buttons.icon.default.sm,
+      height: theme.buttons.icon.default.sm,
+      'font-size': theme.buttons.icon.default.sm,
+    })
+  })
+
+  it('should have correct IconFont size with IconFont only', () => {
+    const theme = createTheme()
+    const { getByTestId } = render(
+      <Button dataTestId="button" size="md">
+        <Icons.Sun dataTestId="sun" />
+      </Button>
+    )
+
+    const button = getByTestId('button')
+    const icon = getByTestId('icon-font-sun')
+    expect(button).toHaveStyleRule('height', theme.buttons.sizes.md.height)
+    expect(icon).toHaveStyle({
+      width: theme.buttons.icon.only.md,
+      height: theme.buttons.icon.only.md,
+      'font-size': theme.buttons.icon.only.md,
+    })
   })
 })

--- a/packages/Button/package.json
+++ b/packages/Button/package.json
@@ -39,6 +39,8 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
+    "@welcome-ui/icon": "^5.0.0-alpha.1",
+    "@welcome-ui/icons.font": "^5.0.0-alpha.1",
     "@welcome-ui/system": "^5.0.0-alpha.1",
     "@welcome-ui/utils": "^5.0.0-alpha.1",
     "reakit": "^1.3.11"

--- a/packages/Button/package.json
+++ b/packages/Button/package.json
@@ -39,8 +39,6 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "@welcome-ui/icon": "^5.0.0-alpha.1",
-    "@welcome-ui/icons.font": "^5.0.0-alpha.1",
     "@welcome-ui/system": "^5.0.0-alpha.1",
     "@welcome-ui/utils": "^5.0.0-alpha.1",
     "reakit": "^1.3.11"

--- a/packages/Button/styles.ts
+++ b/packages/Button/styles.ts
@@ -2,6 +2,8 @@ import styled, { css, system, th } from '@xstyled/styled-components'
 import { Button as ReakitButton } from 'reakit/Button'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { hideFocusRingsDataAttribute } from '@welcome-ui/utils'
+import { IconFont } from '@welcome-ui/icons.font'
+import { StyledIcon } from '@welcome-ui/icon'
 
 import { ButtonOptions } from './index'
 
@@ -36,14 +38,17 @@ export const Button = styled(ReakitButton).withConfig({ shouldForwardProp })<But
     ${shape && shapeStyles(size, shape)};
     ${system};
 
-    & > svg:only-child {
-      width: ${th(`buttons.icon.only.${size}`)};
-      height: ${th(`buttons.icon.only.${size}`)};
-    }
-
-    & > svg:not(:only-child) {
-      width: ${th(`buttons.icon.default.${size}`)};
-      height: ${th(`buttons.icon.default.${size}`)};
+    & > ${IconFont}, & > ${StyledIcon} {
+      &:only-child {
+        width: ${th(`buttons.icon.only.${size}`)};
+        height: ${th(`buttons.icon.only.${size}`)};
+        font-size: ${th(`buttons.icon.only.${size}`)};
+      }
+      &:not(:only-child) {
+        width: ${th(`buttons.icon.default.${size}`)};
+        height: ${th(`buttons.icon.default.${size}`)};
+        font-size: ${th(`buttons.icon.default.${size}`)};
+      }
     }
 
     & > *:not(:only-child):not(:last-child) {

--- a/packages/Button/styles.ts
+++ b/packages/Button/styles.ts
@@ -2,8 +2,6 @@ import styled, { css, system, th } from '@xstyled/styled-components'
 import { Button as ReakitButton } from 'reakit/Button'
 import { shouldForwardProp } from '@welcome-ui/system'
 import { hideFocusRingsDataAttribute } from '@welcome-ui/utils'
-import { IconFont } from '@welcome-ui/icons.font'
-import { StyledIcon } from '@welcome-ui/icon'
 
 import { ButtonOptions } from './index'
 
@@ -38,7 +36,8 @@ export const Button = styled(ReakitButton).withConfig({ shouldForwardProp })<But
     ${shape && shapeStyles(size, shape)};
     ${system};
 
-    & > ${IconFont}, & > ${StyledIcon} {
+    & > svg.wui-icon,
+    & > i.wui-icon-font {
       &:only-child {
         width: ${th(`buttons.icon.only.${size}`)};
         height: ${th(`buttons.icon.only.${size}`)};

--- a/packages/Icon/index.tsx
+++ b/packages/Icon/index.tsx
@@ -26,6 +26,7 @@ export type IconProps = CreateWuiProps<typeof S.Icon, IconOptions>
 
 export const Icon = forwardRef<'svg', IconProps>(
   ({ content, dataTestId, size = 'md', title, ...props }, ref) => {
+    const className = props.className || ''
     if (!content) {
       return null
     }
@@ -43,6 +44,7 @@ export const Icon = forwardRef<'svg', IconProps>(
         title={title}
         viewBox={content.viewBox || '0 0 100 100'}
         {...props}
+        className={`${className} wui-icon`}
       />
     )
   }

--- a/packages/IconFont/index.tsx
+++ b/packages/IconFont/index.tsx
@@ -20,7 +20,14 @@ export const Icons = Object.keys(unicodeMap).reduce(
     const key = toPascalCase(name) as keyof typeof unicodeMap
     prev[key] = (props: IconProps) => {
       const className = props.className || ''
-      return <Icon {...props} className={`${className} wui-icon-font`} name={name} />
+      return (
+        <Icon
+          {...props}
+          className={`${className} wui-icon-font`}
+          data-testid={props.dataTestId && `icon-font-${props.dataTestId}`}
+          name={name}
+        />
+      )
     }
     return prev
   },

--- a/packages/IconFont/index.tsx
+++ b/packages/IconFont/index.tsx
@@ -18,7 +18,10 @@ const toPascalCase = (str: string) => {
 export const Icons = Object.keys(unicodeMap).reduce(
   (prev: Record<string, (props: IconProps) => JSX.Element>, name: keyof typeof unicodeMap) => {
     const key = toPascalCase(name) as keyof typeof unicodeMap
-    prev[key] = (props: IconProps) => <Icon {...props} name={name} />
+    prev[key] = (props: IconProps) => {
+      const className = props.className || ''
+      return <Icon {...props} className={`${className} wui-icon-font`} name={name} />
+    }
     return prev
   },
   {}

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: './node_modules/wttj-config-front/lib/stylelint',
+  rules: {
+    'selector-type-no-unknown': [true, { ignoreTypes: ['/-styled-mixin/', '$dummyValue'] }],
+  },
 }


### PR DESCRIPTION
BEFORE:
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/319863/205680989-954d44c1-d9ab-4ade-9469-244d091356d7.png">
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/319863/205680662-4543f724-7fba-404d-bdff-0e0ca08c568f.png">


AFTER:
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/319863/205680079-f4b8daa1-4660-46fb-811d-ffd28860916a.png">
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/319863/205680330-feb87d60-bc06-4bf2-9a94-bc1f44b2b51d.png">



Fixes #1745 

Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>