### PR TITLE
fix: modal scrolling with header and footer fixed

### DIFF
--- a/packages/Modal/Content.tsx
+++ b/packages/Modal/Content.tsx
@@ -1,7 +1,8 @@
-import React, { Children, cloneElement, useMemo, useRef } from 'react'
+import React, { Children, cloneElement, useMemo, useState } from 'react'
 import { useTheme } from '@xstyled/styled-components'
 import { forwardRef } from '@welcome-ui/system'
-import { Box } from '@welcome-ui/box'
+
+import * as S from './styles'
 
 export interface ContentOptions {
   children: JSX.Element | JSX.Element[]
@@ -14,13 +15,7 @@ export type ContentProps = ContentOptions
  */
 export const Content = forwardRef<'div', ContentProps>(({ children, ...rest }, ref) => {
   const { borderWidths, space } = useTheme()
-  const headerRef = useRef(null)
-  const bodyRef = useRef(null)
-  const footerRef = useRef(null)
-  const headerHeight = headerRef?.current?.clientHeight
-  const footerHeight = footerRef?.current?.clientHeight
-  const bodyHeight = bodyRef?.current?.clientHeight
-  const bodyScrollHeight = bodyRef?.current?.scrollHeight
+  const [bodyRef, setBodyRef] = useState<HTMLElement>(null)
 
   const components = useMemo(
     () =>
@@ -31,18 +26,9 @@ export const Content = forwardRef<'div', ContentProps>(({ children, ...rest }, r
   )
 
   const setRef = (name?: string) => {
-    if (name === 'Header') {
-      return headerRef
-    }
-
     if (name === 'Body') {
-      return bodyRef
+      return setBodyRef
     }
-
-    if (name === 'Footer') {
-      return footerRef
-    }
-
     return undefined
   }
 
@@ -54,8 +40,6 @@ export const Content = forwardRef<'div', ContentProps>(({ children, ...rest }, r
     }
     if (name === 'Body') {
       return {
-        mt: { xs: headerHeight, md: 0 },
-        mb: { xs: footerHeight, md: 0 },
         pb: components.includes('Footer') ? space.lg : null,
         pr: components.includes('Header') ? space.xxl : null,
         pt: components.includes('Header') ? 0 : null,
@@ -65,7 +49,7 @@ export const Content = forwardRef<'div', ContentProps>(({ children, ...rest }, r
     if (name === 'Footer') {
       return {
         pt: components.includes('Header') || components.includes('Body') ? null : space.lg,
-        borderWidth: bodyScrollHeight > bodyHeight ? borderWidths.sm : '0',
+        borderWidth: bodyRef && bodyRef.scrollHeight > bodyRef.offsetHeight ? borderWidths.sm : '0',
       }
     }
 
@@ -73,7 +57,7 @@ export const Content = forwardRef<'div', ContentProps>(({ children, ...rest }, r
   }
 
   return (
-    <Box ref={ref} {...rest}>
+    <S.Content ref={ref} {...rest}>
       {Children.map(children, (child: JSX.Element) => {
         if (!child) return null
         const name = child?.type?.displayName || child?.type?.name
@@ -84,7 +68,7 @@ export const Content = forwardRef<'div', ContentProps>(({ children, ...rest }, r
           ...child.props,
         })
       })}
-    </Box>
+    </S.Content>
   )
 })
 

--- a/packages/Modal/Footer.tsx
+++ b/packages/Modal/Footer.tsx
@@ -19,7 +19,7 @@ export type FooterProps = FooterOptions & BoxProps
  */
 export const Footer = forwardRef<'div', FooterProps>(({ children, informations, ...rest }, ref) => {
   return (
-    <S.Footer bottom="0" position={{ xs: 'fixed', md: 'relative' }} ref={ref} w="100%" {...rest}>
+    <S.Footer ref={ref} w="100%" {...rest}>
       {children && <S.FooterChildrenWrapper>{children}</S.FooterChildrenWrapper>}
       {informations && (
         <S.FooterInformations>

--- a/packages/Modal/Header.tsx
+++ b/packages/Modal/Header.tsx
@@ -18,12 +18,7 @@ export type HeaderProps = HeaderOptions & Omit<BoxProps, keyof HeaderOptions>
  */
 export const Header = forwardRef<'div', HeaderProps>(({ icon, subtitle, title, ...rest }, ref) => {
   return (
-    <S.Header
-      position={{ xs: 'fixed', md: 'relative' }}
-      ref={ref}
-      textAlign={icon ? 'center' : null}
-      {...rest}
-    >
+    <S.Header ref={ref} textAlign={icon ? 'center' : null} w="100%" {...rest}>
       {icon}
       <Text mb={subtitle ? 'lg' : 0} mt={icon ? 'xl' : 0} variant="h4">
         {title}

--- a/packages/Modal/index.tsx
+++ b/packages/Modal/index.tsx
@@ -80,7 +80,7 @@ const ModalComponent = forwardRef<'div', ModalProps>(
 )
 
 const Body = forwardRef<'div', BoxProps>((props, ref) => {
-  return <S.Body flex="1" overflowY={{ md: 'auto' }} ref={ref} {...props} />
+  return <S.Body ref={ref} {...props} />
 })
 
 Body.displayName = 'Body'

--- a/packages/Modal/styles.ts
+++ b/packages/Modal/styles.ts
@@ -45,9 +45,9 @@ export const Dialog = styled(ReakitDialog)<{ size: Size }>(
     margin-top: xl;
     opacity: 0;
     height: 100%;
+    max-height: 100%;
     width: 100%;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
+    overflow: hidden;
 
     transition: opacity 250ms ease-in-out, margin-top 250ms ease-in-out;
     cursor: auto;
@@ -63,6 +63,10 @@ export const Dialog = styled(ReakitDialog)<{ size: Size }>(
       margin-top: 0;
     }
 
+    > div {
+      height: 100%;
+    }
+
     ${up(
       'md',
       css`
@@ -74,6 +78,14 @@ export const Dialog = styled(ReakitDialog)<{ size: Size }>(
   `
 )
 
+export const Content = styled(Box)`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-height: 100%;
+  overflow: hidden;
+`
+
 export const Header = styled.headerBox`
   ${({ theme }) => theme.modals.header}
 `
@@ -83,11 +95,19 @@ export const HeaderSubtitle = styled(Text)`
 `
 
 export const Body = styled.sectionBox`
-  ${({ theme }) => theme.modals.body}
+  ${({ theme }) => css`
+    max-height: 100%;
+    overflow-y: auto;
+    ${theme.modals.body}
+  `}
 `
 
 export const Footer = styled.footerBox`
-  ${({ theme }) => theme.modals.footer}
+  ${({ theme }) => css`
+    margin-top: auto;
+    flex-shrink: 0;
+    ${theme.modals.footer}
+  `}
 `
 
 export const FooterChildrenWrapper = styled(Box)`


### PR DESCRIPTION
Now, only the body is scrolling when the content is too big.
The header & the footer stay fixed in desktop and mobile device.

https://user-images.githubusercontent.com/36013102/212670883-7e451be3-bc11-4fe6-beb7-ae53df610c3a.mov

