### PR TITLE
fix: filedrop props v5

### DIFF
--- a/packages/FileDrop/index.tsx
+++ b/packages/FileDrop/index.tsx
@@ -66,7 +66,8 @@ export interface FileDropOptions {
   wordings?: WordingsType
 }
 
-export type FileDropProps = CreateWuiProps<'div', FileDropOptions> & Omit<DropzoneProps, 'children'>
+export type FileDropProps = CreateWuiProps<'div', FileDropOptions> &
+  Omit<DropzoneProps, 'children' | 'onError'>
 
 export const FileDrop = forwardRef<'div', FileDropProps>(
   (


### PR DESCRIPTION
In order to avoid conflict with the `react-dropzone` props definition, we omit the `onError` props from the `DropzoneProps`, and we keep our definition for the `FileDropProps` type.