### PR TITLE
refactor: link isExternal prop & wrap span with underline

### DIFF
--- a/docs/pages/components/link.mdx
+++ b/docs/pages/components/link.mdx
@@ -56,7 +56,7 @@ Add `disabled` property
 
 ## What is underlined by default?
 
-`Link` will add an underline to text nodes & `Text` components
+`Link` will add an underline to text nodes, `Text` components & `span` tags
 
 ```jsx
 <Box>
@@ -72,7 +72,19 @@ Add `disabled` property
 <Box>
   <Link href="#">
     <Avatar name="jungle" size="lg" />
+    <span>This is a text in a span tag</span>
+  </Link>
+</Box>
+<Box>
+  <Link href="#">
+    <Avatar name="jungle" size="lg" />
     <Text>This is a text in a Text component</Text>
+  </Link>
+</Box>
+<Box>
+  <Link href="#">
+    <Avatar name="jungle" size="lg" />
+    <div>This is a text in a div tag (won't add an underline)</div>
   </Link>
 </Box>
 ```
@@ -89,10 +101,10 @@ For a target `_blank` we add `rel='noopener noreferrer'`
 
 ## External link
 
-`isExternalLink` add an `<ExternalLink />` icon, and add special effect on hover.
+`isExternal` add an `<ExternalLink />` icon, and add special effect on hover.
 
 ```jsx
-<Link href="#" target="_blank" isExternalLink>
+<Link href="#" target="_blank" isExternal>
   External link
 </Link>
 ```

--- a/docs/pages/upgrade.mdx
+++ b/docs/pages/upgrade.mdx
@@ -115,6 +115,10 @@ We change the name of variants to `xs` `s` `m` `lg` and remove useless variants.
 - The `shape` prop has been removed.
 - The icon size now adjusts to the size of the tag.
 
+### Link
+
+- the `isExternalLink` become `isExternal`
+
 ### Badges
 
 - new `Badge` component [show more](/components/badge)

--- a/packages/Link/styles.ts
+++ b/packages/Link/styles.ts
@@ -6,9 +6,9 @@ import { Variant } from './index'
 
 export const Link = styled(UniversalLink).withConfig({ shouldForwardProp })<{
   variant: Variant
-  isExternalLink?: boolean
+  isExternal?: boolean
 }>(
-  ({ isExternalLink, variant = 'primary' }) => css`
+  ({ isExternal, variant = 'primary' }) => css`
     display: inline-flex;
     flex-direction: row;
     align-items: center;
@@ -25,7 +25,7 @@ export const Link = styled(UniversalLink).withConfig({ shouldForwardProp })<{
       ${th('underline.default')};
       ${th('links.default')};
       ${th(`links.${variant}.default`)};
-      ${isExternalLink && th('links.withExternalLink')};
+      ${isExternal && th('links.withExternalLink')};
       ${typography};
     }
 


### PR DESCRIPTION
- `isExternalLink` prop become `isExternal`
- wrap every `<span />` with *WrapWithText* (add the underline) fix https://github.com/WTTJ/welcome-ui/issues/1877
- refactoring
