### PR TITLE
fix: align title and content for drawer

### DIFF
--- a/packages/Core/theme/drawers.ts
+++ b/packages/Core/theme/drawers.ts
@@ -37,7 +37,7 @@ export const getDrawers = (theme: WuiTheme): ThemeDrawers => {
       padding: `${space['xl']} ${space['5xl']} ${space['xl']} ${space['xl']}`,
     },
     content: {
-      padding: `${space['3xl']}`,
+      padding: `${space['xl']}`,
     },
     footer: {
       backgroundColor: colors['light-900'],


### PR DESCRIPTION
This is a review from the design team:
https://github.com/WTTJ/welcome-ui/issues/1906

The difference of padding between the drawer title and the drawer content was a mistake.