### PR TITLE
fix: modal scroll on mobile device

### DIFF
--- a/packages/Modal/Content.tsx
+++ b/packages/Modal/Content.tsx
@@ -1,8 +1,10 @@
-import React, { Children, cloneElement, useMemo, useState } from 'react'
+import React, { Children, cloneElement, useEffect, useMemo, useState } from 'react'
 import { useTheme } from '@xstyled/styled-components'
 import { forwardRef } from '@welcome-ui/system'
+import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock'
 
 import * as S from './styles'
+import { useModal } from './context'
 
 export interface ContentOptions {
   children: JSX.Element | JSX.Element[]
@@ -15,6 +17,8 @@ export type ContentProps = ContentOptions
  */
 export const Content = forwardRef<'div', ContentProps>(({ children, ...rest }, ref) => {
   const { borderWidths, space } = useTheme()
+  const modalState = useModal()
+
   const [bodyRef, setBodyRef] = useState<HTMLElement>(null)
 
   const components = useMemo(
@@ -24,6 +28,18 @@ export const Content = forwardRef<'div', ContentProps>(({ children, ...rest }, r
       }),
     [children]
   )
+
+  /**
+   * As Reakit doesn't handle scrolling content we have to forward the modalState to the Modal.Content
+   * in order to check when the modal is visible and enable the scroll.
+   * @link https://github.com/ariakit/ariakit/issues/469
+   */
+  useEffect(() => {
+    if (modalState.visible && bodyRef) {
+      disableBodyScroll(bodyRef)
+    }
+    return () => enableBodyScroll(bodyRef)
+  }, [bodyRef, modalState.visible])
 
   const setRef = (name?: string) => {
     if (name === 'Body') {

--- a/packages/Modal/context.tsx
+++ b/packages/Modal/context.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, ReactNode, useContext, useMemo } from 'react'
+
+import { ModalStateReturn } from './'
+
+type ModalProviderProps = {
+  children?: ReactNode
+  modalState: ModalStateReturn
+}
+
+export const ModalContext = createContext<ModalStateReturn>({} as ModalStateReturn)
+
+/**
+ * As Reakit doesn't handle scrolling content we have to forward the modalState to the Modal.Content
+ * in order to check when the modal is visible and enable the scroll.
+ * @link https://github.com/ariakit/ariakit/issues/469
+ */
+export const ModalProvider = ({ children, modalState }: ModalProviderProps) => {
+  const state = useMemo(() => modalState, [modalState])
+
+  return <ModalContext.Provider value={state}>{children}</ModalContext.Provider>
+}
+
+export function useModal() {
+  return useContext(ModalContext)
+}

--- a/packages/Modal/index.tsx
+++ b/packages/Modal/index.tsx
@@ -16,6 +16,7 @@ import { Close } from './Close'
 import { Header } from './Header'
 import { Footer } from './Footer'
 import { Content } from './Content'
+import { ModalProvider } from './context'
 
 export type Size = 'xs' | 'sm' | 'md' | 'lg' | 'auto'
 
@@ -57,20 +58,23 @@ const ModalComponent = forwardRef<'div', ModalProps>(
     }
 
     return (
-      <S.Backdrop {...modalState} hideOnClickOutside={hideOnClickOutside}>
-        <S.Dialog
-          aria-label={ariaLabel}
-          hide={closeModal}
-          hideOnClickOutside={hideOnClickOutside}
-          ref={ref}
-          size={size}
-          {...modalState}
-          {...rest}
-        >
-          <CloseElement onClick={closeModal} />
-          {children}
-        </S.Dialog>
-      </S.Backdrop>
+      <ModalProvider modalState={modalState}>
+        <S.Backdrop {...modalState} hideOnClickOutside={hideOnClickOutside}>
+          <S.Dialog
+            aria-label={ariaLabel}
+            hide={closeModal}
+            hideOnClickOutside={hideOnClickOutside}
+            preventBodyScroll={false}
+            ref={ref}
+            size={size}
+            {...modalState}
+            {...rest}
+          >
+            <CloseElement onClick={closeModal} />
+            {children}
+          </S.Dialog>
+        </S.Backdrop>
+      </ModalProvider>
     )
   }
 )

--- a/packages/Modal/package.json
+++ b/packages/Modal/package.json
@@ -45,6 +45,7 @@
     "@welcome-ui/system": "^5.0.0-alpha.16",
     "@welcome-ui/text": "^5.0.0-alpha.16",
     "@welcome-ui/utils": "^5.0.0-alpha.16",
+    "body-scroll-lock": "=3.1.5 ",
     "reakit": "^1.3.11"
   },
   "peerDependencies": {
@@ -55,5 +56,8 @@
   "gitHead": "974e7bfd71f8cfe846cbffd678c3860a8952f9e9",
   "sideEffects": false,
   "component": "Modal",
-  "homepage": "https://welcome-ui.com/components/modal"
+  "homepage": "https://welcome-ui.com/components/modal",
+  "devDependencies": {
+    "@types/body-scroll-lock": "^3.1.0"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4157,6 +4157,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/body-scroll-lock@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/body-scroll-lock/-/body-scroll-lock-3.1.0.tgz#435f6abf682bf58640e1c2ee5978320b891970e7"
+  integrity sha512-3owAC4iJub5WPqRhxd8INarF2bWeQq1yQHBgYhN0XLBJMpd5ED10RrJ3aKiAwlTyL5wK7RkBD4SZUQz2AAAMdA==
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.2.tgz#c324da0197de0a98a2312156536ae262429ff6b9"
@@ -5795,7 +5800,7 @@ body-parser@1.20.1:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-body-scroll-lock@^3.1.5:
+"body-scroll-lock@=3.1.5 ", body-scroll-lock@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz#c1392d9217ed2c3e237fee1e910f6cdd80b7aaec"
   integrity sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==


### PR DESCRIPTION
Related issue: #1922 

As Reakit doesn't handle scrolling content we have to forward the modalState to the Modal.Content in order to check when the modal is visible and enable the scroll.
_Reakit issue:_ https://github.com/ariakit/ariakit/issues/469

I preferred to use a context to keep the logic internally and not expose a misleading prop which could be use in the implementation and also as we render children and not the Modal.Content directly, thanks to the context we avoid using `children.map` and `cloneElement`.
