### PR TITLE
fix: force label color

### DIFF
--- a/packages/Core/src/theme/labels.ts
+++ b/packages/Core/src/theme/labels.ts
@@ -5,10 +5,11 @@ import { WuiTheme } from './types'
 export type ThemeLabels = CSSObject
 
 export const getLabels = (theme: WuiTheme): ThemeLabels => {
-  const { fontSizes, fontWeights } = theme
+  const { fontSizes, fontWeights, colors } = theme
 
   return {
     fontSize: fontSizes.sm,
     fontWeight: fontWeights.medium,
+    color: colors['dark-500']
   }
 }

--- a/packages/Core/src/theme/labels.ts
+++ b/packages/Core/src/theme/labels.ts
@@ -5,11 +5,11 @@ import { WuiTheme } from './types'
 export type ThemeLabels = CSSObject
 
 export const getLabels = (theme: WuiTheme): ThemeLabels => {
-  const { fontSizes, fontWeights, colors } = theme
+  const { colors, fontSizes, fontWeights } = theme
 
   return {
+    color: colors['dark-500'],
     fontSize: fontSizes.sm,
     fontWeight: fontWeights.medium,
-    color: colors['dark-500']
   }
 }


### PR DESCRIPTION
We need to force label color because we got an issue on modal, the Modal.Body is in black-900 color and the label get the dark 900 color.