### PR TITLE
chore: prepare to ariakit

### DIFF
--- a/docs/components/Header/ThemeSelector.js
+++ b/docs/components/Header/ThemeSelector.js
@@ -1,20 +1,20 @@
 import React from 'react'
 import { DropdownMenu, useDropdownMenuState } from '@welcome-ui/dropdown-menu'
 import { Box } from '@welcome-ui/box'
-import { StarIcon, SunIcon, CrescentMoonIcon, StarOutlineIcon } from '@welcome-ui/icons'
+import { CrescentMoonIcon, StarIcon, StarOutlineIcon, SunIcon } from '@welcome-ui/icons'
 import { Button } from '@welcome-ui/button'
 import { Badge } from '@welcome-ui/badge'
 
 import { useSetThemeContext, useThemeContext } from '../../context/theme'
 
-export function ThemeSelector(props) {
+export const ThemeSelector = props => {
   const setTheme = useSetThemeContext()
-  const menu = useDropdownMenuState({ gutter: 10 })
+  const menuState = useDropdownMenuState({ gutter: 10 })
   const theme = useThemeContext()
 
   const handleSetTheme = theme => {
     setTheme(theme)
-    menu.hide()
+    menuState.hide()
   }
 
   const options = [
@@ -26,22 +26,24 @@ export function ThemeSelector(props) {
 
   return (
     <>
-      <DropdownMenu.Trigger as={Button} h={30} shape="circle" w={30} {...menu} {...props}>
+      <DropdownMenu.Trigger as={Button} h={30} shape="circle" state={menuState} w={30} {...props}>
         <SunIcon />
       </DropdownMenu.Trigger>
-      <DropdownMenu {...menu} aria-label="Theme selector">
-        {options?.map(({ icon: Icon, label, value, isBeta }) => (
+      <DropdownMenu aria-label="Theme selector" state={menuState}>
+        {options?.map(({ icon: Icon, isBeta, label, value }) => (
           <DropdownMenu.Item
             color={theme === value ? 'dark-900' : undefined}
             fontWeight={theme === value ? 'bold' : undefined}
             key={value}
             onClick={() => handleSetTheme(value)}
-            {...menu}
+            state={menuState}
           >
             <Icon mr="md" size="sm" />
             <Box>{label}</Box>
             {isBeta && (
-              <Badge size="sm" ml="xs">beta</Badge>
+              <Badge ml="xs" size="sm">
+                beta
+              </Badge>
             )}
           </DropdownMenu.Item>
         ))}

--- a/docs/components/Header/index.js
+++ b/docs/components/Header/index.js
@@ -19,7 +19,7 @@ import * as S from './styles'
 import { NavBar } from './NavBar'
 
 export const Header = () => {
-  const mobileMenuDrawer = useDrawerState()
+  const mobileMenuDrawerState = useDrawerState()
   const modal = useModalState()
   const { pathname } = useRouter()
   const variants = {
@@ -63,18 +63,18 @@ export const Header = () => {
       {hasBeenHydrated && (
         <>
           <Drawer.Trigger
-            {...mobileMenuDrawer}
             as={Button}
             display={{ md: 'none' }}
             shape="circle"
             size="sm"
+            state={mobileMenuDrawerState}
           >
-            {mobileMenuDrawer.visible ? <CrossIcon /> : <MenuIcon />}
+            {mobileMenuDrawerState.visible ? <CrossIcon /> : <MenuIcon />}
           </Drawer.Trigger>
-          <Drawer.Backdrop {...mobileMenuDrawer} backdropVisible={false}>
-            <S.MenuMobileDrawer aria-label="Menu backdrop" {...mobileMenuDrawer}>
-              <NavBar isMobileMenu mb="lg" drawerState={mobileMenuDrawer} />
-              <ComponentsList onClick={() => mobileMenuDrawer.hide()} />
+          <Drawer.Backdrop backdropVisible={false} state={mobileMenuDrawerState}>
+            <S.MenuMobileDrawer aria-label="Menu backdrop" state={mobileMenuDrawerState}>
+              <NavBar drawerState={mobileMenuDrawerState} isMobileMenu mb="lg" />
+              <ComponentsList onClick={() => mobileMenuDrawerState.hide()} />
             </S.MenuMobileDrawer>
           </Drawer.Backdrop>
         </>

--- a/docs/components/Header/index.js
+++ b/docs/components/Header/index.js
@@ -3,7 +3,7 @@ import { Box } from '@welcome-ui/box'
 import { InformationIcon, MenuIcon } from '@welcome-ui/icons'
 import NextLink from 'next/link'
 import { Drawer, useDrawerState } from '@welcome-ui/drawer'
-import { Modal, useModalState } from '@welcome-ui/modal'
+import { useModalState } from '@welcome-ui/modal'
 import { Button } from '@welcome-ui/button'
 import { CrossIcon } from '@welcome-ui/icons'
 import { DocSearch } from '@docsearch/react'
@@ -20,7 +20,7 @@ import { NavBar } from './NavBar'
 
 export const Header = () => {
   const mobileMenuDrawerState = useDrawerState()
-  const modal = useModalState()
+  const modalState = useModalState()
   const { pathname } = useRouter()
   const variants = {
     '/': 'gray',
@@ -34,7 +34,7 @@ export const Header = () => {
   }, [])
 
   function openThemeHelper() {
-    modal.show()
+    modalState.show()
   }
 
   return (
@@ -79,7 +79,7 @@ export const Header = () => {
           </Drawer.Backdrop>
         </>
       )}
-      <ThemeHelper modal={modal} />
+      <ThemeHelper modalState={modalState} />
     </S.Header>
   )
 }

--- a/docs/components/Mdx/Headings/index.js
+++ b/docs/components/Mdx/Headings/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React from 'react'
 import { Text } from '@welcome-ui/text'
 
@@ -7,7 +6,7 @@ import { slugify } from '../../../utils'
 import * as S from './styles'
 
 // eslint-disable-next-line react/prop-types
-function Title({ children, ...props }) {
+const Title = ({ children, ...props }) => {
   const slug = slugify(children)
 
   return (
@@ -17,18 +16,18 @@ function Title({ children, ...props }) {
   )
 }
 
-export function H1(props) {
+export const H1 = props => {
   return <Text m="0" pb="md" pt="3xl" variant="h1" {...props} />
 }
 
-export function H2(props) {
+export const H2 = props => {
   return <Title pt="3xl" variant="h3" {...props} />
 }
 
-export function H3(props) {
+export const H3 = props => {
   return <Title pt="xxl" variant="h5" {...props} />
 }
 
-export function H4(props) {
+export const H4 = props => {
   return <Title pt="lg" variant="h5" {...props} />
 }

--- a/docs/components/Mdx/Props.js
+++ b/docs/components/Mdx/Props.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-max-depth */
-/* eslint-disable react/no-multi-comp */
 
 /* eslint-disable react/forbid-foreign-prop-types */
 import React from 'react'
@@ -18,7 +17,7 @@ const isArray = Array.isArray
 
 const reactTypes = ['ElementType<any>']
 
-function Type({ type }) {
+const Type = ({ type }) => {
   if (!type) {
     return null
   }
@@ -66,7 +65,7 @@ function Type({ type }) {
   return name
 }
 
-export function Props({ propTypes }) {
+export const Props = ({ propTypes }) => {
   if (!propTypes) {
     return (
       <Box as="p" pt="lg">

--- a/docs/components/ThemeHelper.js
+++ b/docs/components/ThemeHelper.js
@@ -1,16 +1,16 @@
 import { Box } from '@welcome-ui/box'
 import { Modal } from '@welcome-ui/modal'
-import { useThemeContext } from '../context/theme'
-
 import { Tab, useTabState } from '@welcome-ui/tabs'
 import { Text } from '@welcome-ui/text'
 import { useEffect, useState } from 'react'
+
+import { useThemeContext } from '../context/theme'
 
 import { ThemeConfiguration } from './ThemeConfiguration'
 
 const KEY_CODE_HELP = 'KeyI'
 
-export function ThemeHelper({ modal }) {
+export const ThemeHelper = ({ modalState }) => {
   const currentTheme = useThemeContext()
   const [hasBeenHydrated, setHasBeenHydrated] = useState(false)
   const tabState = useTabState({ orientation: 'vertical' })
@@ -39,12 +39,12 @@ export function ThemeHelper({ modal }) {
   return (
     <>
       {hasBeenHydrated && (
-        <Modal modalState={modal} ariaLabel="theme configuration" title={title}>
+        <Modal ariaLabel="theme configuration" state={modalState} title={title}>
           <Modal.Content>
-            <Modal.Header title={title} subtitle="Documentation for the core theme entries" />
+            <Modal.Header subtitle="Documentation for the core theme entries" title={title} />
             <Modal.Body mt="xl">
               <Box display="flex">
-                <Tab.List w={200} mr="lg" aria-label="Tabs" {...tabState}>
+                <Tab.List aria-label="Tabs" mr="lg" w={200} {...tabState}>
                   {categories.map(category => (
                     <Tab key={category} {...tabState} id={category}>
                       {category}
@@ -55,16 +55,16 @@ export function ThemeHelper({ modal }) {
                 {categories.map(category => (
                   <Tab.Panel key={category} {...tabState} tabId={category}>
                     <Box
+                      columnGap={16}
                       display="grid"
                       gridTemplateColumns="1fr 1fr"
-                      rowGap={8}
-                      columnGap={16}
                       mb="md"
+                      rowGap={8}
                     >
-                      <Text variant="h5" mb="md" mt="0">
+                      <Text mb="md" mt="0" variant="h5">
                         Key
                       </Text>
-                      <Text variant="h5" mb="md" mt="0">
+                      <Text mb="md" mt="0" variant="h5">
                         Value
                       </Text>
                       <ThemeConfiguration category={category} />

--- a/docs/components/ThemeHelper.js
+++ b/docs/components/ThemeHelper.js
@@ -44,16 +44,16 @@ export const ThemeHelper = ({ modalState }) => {
             <Modal.Header subtitle="Documentation for the core theme entries" title={title} />
             <Modal.Body mt="xl">
               <Box display="flex">
-                <Tab.List aria-label="Tabs" mr="lg" w={200} {...tabState}>
+                <Tab.List aria-label="Tabs" mr="lg" state={tabState} w={200}>
                   {categories.map(category => (
-                    <Tab key={category} {...tabState} id={category}>
+                    <Tab id={category} key={category} state={tabState}>
                       {category}
                     </Tab>
                   ))}
                 </Tab.List>
 
                 {categories.map(category => (
-                  <Tab.Panel key={category} {...tabState} tabId={category}>
+                  <Tab.Panel key={category} state={tabState} tabId={category}>
                     <Box
                       columnGap={16}
                       display="grid"

--- a/docs/pages/components/accordion.mdx
+++ b/docs/pages/components/accordion.mdx
@@ -46,7 +46,7 @@ Built with [Reakit](https://reakit.io/docs/disclosure/) for a better accessibili
 Add `visible` property to open at start the accordion
 
 ```jsx
-<Accordion title="Accordion title" visible>
+<Accordion title="Accordion title" open>
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
   labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
   nisi ut aliquip ex ea commodo consequat.

--- a/docs/pages/components/drawer.mdx
+++ b/docs/pages/components/drawer.mdx
@@ -25,16 +25,16 @@ The most basic drawer needs `useDrawerState()`, `<Drawer.Trigger />`, `<Drawer.B
 
 ```jsx
 function DefaultDrawer() {
-  const drawer = useDrawerState()
+  const drawerState = useDrawerState()
 
   return (
     <>
-      <Drawer.Trigger as={Button} {...drawer}>
+      <Drawer.Trigger as={Button} state={drawerState}>
         Open Drawer
       </Drawer.Trigger>
-      <Drawer.Backdrop {...drawer} backdropVisible={false}>
-        <Drawer aria-label="Default drawer" {...drawer}>
-          <Drawer.Close {...drawer} />
+      <Drawer.Backdrop state={drawerState} backdropVisible={false}>
+        <Drawer aria-label="Default drawer" state={drawerState}>
+          <Drawer.Close state={drawerState} />
           Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam
           nec, convallis sit amet erat. Mauris auctor blandit porta.
         </Drawer>
@@ -50,16 +50,16 @@ You have to wrap `<Drawer />` with `<Drawer.Backdrop />`. It can be either visib
 
 ```jsx
 function BackdropDrawer() {
-  const drawer = useDrawerState()
+  const drawerState = useDrawerState()
 
   return (
     <>
-      <Drawer.Trigger as={Button} {...drawer}>
+      <Drawer.Trigger as={Button} state={drawerState}>
         Open Drawer
       </Drawer.Trigger>
-      <Drawer.Backdrop {...drawer}>
-        <Drawer aria-label="Backdrop drawer" {...drawer}>
-          <Drawer.Close {...drawer} />
+      <Drawer.Backdrop state={drawerState}>
+        <Drawer aria-label="Backdrop drawer" state={drawerState}>
+          <Drawer.Close state={drawerState} />
           Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis aliquam
           nec, convallis sit amet erat. Mauris auctor blandit porta.
         </Drawer>
@@ -75,23 +75,23 @@ We provide basic layout components for your drawer: `<Drawer.Close />`, `<Drawer
 
 ```jsx
 function ContentDrawer() {
-  const drawer = useDrawerState()
+  const drawerState = useDrawerState()
 
   return (
     <>
-      <Drawer.Trigger as={Button} {...drawer}>
+      <Drawer.Trigger as={Button} state={drawerState}>
         Open Drawer
       </Drawer.Trigger>
-      <Drawer.Backdrop {...drawer}>
-        <Drawer aria-label="Layout drawer" {...drawer}>
-          <Drawer.Close {...drawer} />
+      <Drawer.Backdrop state={drawerState}>
+        <Drawer aria-label="Layout drawer" state={drawerState}>
+          <Drawer.Close state={drawerState} />
           <Drawer.Title>Hello</Drawer.Title>
           <Drawer.Content>
             Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
             aliquam nec, convallis sit amet erat. Mauris auctor blandit porta.
           </Drawer.Content>
           <Drawer.Footer>
-            <Button onClick={drawer.hide}>Close Drawer</Button>
+            <Button onClick={drawerState.hide}>Close Drawer</Button>
           </Drawer.Footer>
         </Drawer>
       </Drawer.Backdrop>
@@ -106,7 +106,7 @@ By default the `placement` of the drawer will be on the `right` but you can set 
 
 ```jsx
 function PlacementDrawer() {
-  const drawer = useDrawerState()
+  const drawerState = useDrawerState()
   const [placement, setPlacement] = React.useState('right')
 
   return (
@@ -125,11 +125,11 @@ function PlacementDrawer() {
           />
         </Field>
       </Box>
-      <Drawer.Trigger as={Button} {...drawer}>
+      <Drawer.Trigger as={Button} state={drawerState}>
         Open Drawer
       </Drawer.Trigger>
-      <Drawer.Backdrop {...drawer}>
-        <Drawer aria-label="Placement drawer" {...drawer} placement={placement}>
+      <Drawer.Backdrop state={drawerState}>
+        <Drawer aria-label="Placement drawer" state={drawerState} placement={placement}>
           Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
           aliquam nec, convallis sit amet erat. Mauris auctor blandit porta.
         </Drawer>
@@ -145,7 +145,7 @@ By default the `size` of the drawer will be `lg` which is set in the theme. We p
 
 ```jsx
 function SizeDrawer() {
-  const drawer = useDrawerState()
+  const drawerState = useDrawerState()
   const [size, setSize] = React.useState('lg')
   const [placement, setPlacement] = React.useState('right')
 
@@ -186,11 +186,11 @@ function SizeDrawer() {
           />
         </Field>
       </Box>
-      <Drawer.Trigger as={Button} {...drawer}>
+      <Drawer.Trigger as={Button} state={drawerState}>
         Open Drawer
       </Drawer.Trigger>
-      <Drawer.Backdrop {...drawer}>
-        <Drawer aria-label="Size drawer" {...drawer} size={size} placement={placement}>
+      <Drawer.Backdrop state={drawerState}>
+        <Drawer aria-label="Size drawer" state={drawerState} size={size} placement={placement}>
           Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
           aliquam nec, convallis sit amet erat. Mauris auctor blandit porta.
         </Drawer>
@@ -206,16 +206,16 @@ All the elements can be styled as you see fit, by extending drawer's theme or di
 
 ```jsx
 function StylingDrawer() {
-  const drawer = useDrawerState()
+  const drawerState = useDrawerState()
 
   return (
     <>
-      <Drawer.Trigger as={Button} {...drawer}>
+      <Drawer.Trigger as={Button} state={drawerState}>
         Open Drawer
       </Drawer.Trigger>
-      <Drawer.Backdrop {...drawer}>
-        <Drawer aria-label="Default drawer" {...drawer} backgroundColor="nude-200">
-          <Drawer.Close {...drawer} w={30} h={30} />
+      <Drawer.Backdrop state={drawerState}>
+        <Drawer aria-label="Default drawer" state={drawerState} backgroundColor="nude-200">
+          <Drawer.Close state={drawerState} w={30} h={30} />
           <Drawer.Title borderBottom="1px solid" borderBottomColor="dark-200">
             Hello
           </Drawer.Title>
@@ -225,8 +225,8 @@ function StylingDrawer() {
           </Drawer.Content>
           <Drawer.Footer borderTop="1px solid" borderTopColor="dark-200">
             <Stack direction="row">
-              <Button onClick={drawer.hide}>Save</Button>
-              <Button onClick={drawer.hide} variant="tertiary">
+              <Button onClick={drawerState.hide}>Save</Button>
+              <Button onClick={drawerState.hide} variant="tertiary">
                 Close
               </Button>
             </Stack>

--- a/docs/pages/components/dropdown-menu.mdx
+++ b/docs/pages/components/dropdown-menu.mdx
@@ -24,32 +24,32 @@ Menu from [Reakit](https://reakit.io/docs/menu/) with a really nice theme 👀
 
 ```jsx
 function() {
-  const menuState = useDropdownMenuState({
+  const dropdownMenuState = useDropdownMenuState({
     gutter: 10
   })
 
   const handleClick = e => {
     console.log(`Clicked on ${e.target.innerText}`)
-    menuState.hide()
+    dropdownMenuState.hide()
   }
 
   return (
     <>
-      <DropdownMenu.Trigger state={menuState} as={Button}>
+      <DropdownMenu.Trigger state={dropdownMenuState} as={Button}>
         Dropdown Menu
       </DropdownMenu.Trigger>
-      <DropdownMenu state={menuState} aria-label="Example">
-        <DropdownMenu.Item state={menuState} onClick={handleClick}>
+      <DropdownMenu state={dropdownMenuState} aria-label="Example">
+        <DropdownMenu.Item state={dropdownMenuState} onClick={handleClick}>
           Twitter
         </DropdownMenu.Item>
-        <DropdownMenu.Item state={menuState} onClick={handleClick} disabled>
+        <DropdownMenu.Item state={dropdownMenuState} onClick={handleClick} disabled>
           Facebook
         </DropdownMenu.Item>
-        <DropdownMenu.Item state={menuState} onClick={handleClick}>
+        <DropdownMenu.Item state={dropdownMenuState} onClick={handleClick}>
           Instagram
         </DropdownMenu.Item>
-        <DropdownMenu.Separator state={menuState} />
-        <DropdownMenu.Item state={menuState} onClick={handleClick}>
+        <DropdownMenu.Separator state={dropdownMenuState} />
+        <DropdownMenu.Item state={dropdownMenuState} onClick={handleClick}>
           Github
         </DropdownMenu.Item>
       </DropdownMenu>
@@ -62,11 +62,11 @@ function() {
 
 ```jsx
 function() {
-  const menuState = useDropdownMenuState({ gutter: 10, placement: 'bottom-end' })
+  const dropdownMenuState = useDropdownMenuState({ gutter: 10, placement: 'bottom-end' })
 
   const handleClick = e => {
     console.log(`Clicked on ${e.target.innerText}`)
-    menuState.hide()
+    dropdownMenuState.hide()
   }
 
   return (
@@ -76,16 +76,16 @@ function() {
           <AddIcon />
           <span>First Action</span>
         </Button>
-        <DropdownMenu.Trigger state={menuState} as={Button}>
-          {menuState.open ? <UpIcon /> : <DownIcon />}
+        <DropdownMenu.Trigger state={dropdownMenuState} as={Button}>
+          {dropdownMenuState.open ? <UpIcon /> : <DownIcon />}
         </DropdownMenu.Trigger>
       </ButtonGroup>
-      <DropdownMenu state={menuState} aria-label="Complexity">
-        <DropdownMenu.Item state={menuState} onClick={handleClick}>
+      <DropdownMenu state={dropdownMenuState} aria-label="Complexity">
+        <DropdownMenu.Item state={dropdownMenuState} onClick={handleClick}>
           <TrashIcon mr="sm" size="sm" />
           <Box>Second Action</Box>
         </DropdownMenu.Item>
-        <DropdownMenu.Item state={menuState} onClick={handleClick}>
+        <DropdownMenu.Item state={dropdownMenuState} onClick={handleClick}>
           <AttachmentIcon mr="sm" size="sm" />
           <Box>Third Action</Box>
         </DropdownMenu.Item>
@@ -101,33 +101,33 @@ Use `DropdownMenu.Arrow` to add an arrow to the dropdown menu
 
 ```jsx
 function() {
-  const menuState = useDropdownMenuState({
+  const dropdownMenuState = useDropdownMenuState({
     gutter: 10
   })
 
   const handleClick = e => {
     console.log(`Clicked on ${e.target.innerText}`)
-    menuState.hide()
+    dropdownMenuState.hide()
   }
 
   return (
     <>
-      <DropdownMenu.Trigger state={menuState} as={Button}>
+      <DropdownMenu.Trigger state={dropdownMenuState} as={Button}>
         Dropdown Menu
       </DropdownMenu.Trigger>
-      <DropdownMenu state={menuState} aria-label="Example">
-        <DropdownMenu.Arrow state={menuState} />
-        <DropdownMenu.Item state={menuState} onClick={handleClick}>
+      <DropdownMenu state={dropdownMenuState} aria-label="Example">
+        <DropdownMenu.Arrow state={dropdownMenuState} />
+        <DropdownMenu.Item state={dropdownMenuState} onClick={handleClick}>
           Twitter
         </DropdownMenu.Item>
-        <DropdownMenu.Item state={menuState} onClick={handleClick} disabled>
+        <DropdownMenu.Item state={dropdownMenuState} onClick={handleClick} disabled>
           Facebook
         </DropdownMenu.Item>
-        <DropdownMenu.Item state={menuState} onClick={handleClick}>
+        <DropdownMenu.Item state={dropdownMenuState} onClick={handleClick}>
           Instagram
         </DropdownMenu.Item>
-        <DropdownMenu.Separator state={menuState} />
-        <DropdownMenu.Item state={menuState} onClick={handleClick}>
+        <DropdownMenu.Separator state={dropdownMenuState} />
+        <DropdownMenu.Item state={dropdownMenuState} onClick={handleClick}>
           Github
         </DropdownMenu.Item>
       </DropdownMenu>

--- a/docs/pages/components/dropdown-menu.mdx
+++ b/docs/pages/components/dropdown-menu.mdx
@@ -24,32 +24,32 @@ Menu from [Reakit](https://reakit.io/docs/menu/) with a really nice theme 👀
 
 ```jsx
 function() {
-  const menu = useDropdownMenuState({
+  const menuState = useDropdownMenuState({
     gutter: 10
   })
 
   const handleClick = e => {
     console.log(`Clicked on ${e.target.innerText}`)
-    menu.hide()
+    menuState.hide()
   }
 
   return (
     <>
-      <DropdownMenu.Trigger {...menu} as={Button}>
+      <DropdownMenu.Trigger state={menuState} as={Button}>
         Dropdown Menu
       </DropdownMenu.Trigger>
-      <DropdownMenu {...menu} aria-label="Example">
-        <DropdownMenu.Item {...menu} onClick={handleClick}>
+      <DropdownMenu state={menuState} aria-label="Example">
+        <DropdownMenu.Item state={menuState} onClick={handleClick}>
           Twitter
         </DropdownMenu.Item>
-        <DropdownMenu.Item {...menu} onClick={handleClick} disabled>
+        <DropdownMenu.Item state={menuState} onClick={handleClick} disabled>
           Facebook
         </DropdownMenu.Item>
-        <DropdownMenu.Item {...menu} onClick={handleClick}>
+        <DropdownMenu.Item state={menuState} onClick={handleClick}>
           Instagram
         </DropdownMenu.Item>
-        <DropdownMenu.Separator {...menu} />
-        <DropdownMenu.Item {...menu} onClick={handleClick}>
+        <DropdownMenu.Separator state={menuState} />
+        <DropdownMenu.Item state={menuState} onClick={handleClick}>
           Github
         </DropdownMenu.Item>
       </DropdownMenu>
@@ -62,11 +62,11 @@ function() {
 
 ```jsx
 function() {
-  const menu = useDropdownMenuState({ gutter: 10, placement: 'bottom-end' })
+  const menuState = useDropdownMenuState({ gutter: 10, placement: 'bottom-end' })
 
   const handleClick = e => {
     console.log(`Clicked on ${e.target.innerText}`)
-    menu.hide()
+    menuState.hide()
   }
 
   return (
@@ -76,16 +76,16 @@ function() {
           <AddIcon />
           <span>First Action</span>
         </Button>
-        <DropdownMenu.Trigger {...menu} as={Button}>
-          {menu.visible ? <UpIcon /> : <DownIcon />}
+        <DropdownMenu.Trigger state={menuState} as={Button}>
+          {menuState.open ? <UpIcon /> : <DownIcon />}
         </DropdownMenu.Trigger>
       </ButtonGroup>
-      <DropdownMenu {...menu} aria-label="Complexity">
-        <DropdownMenu.Item {...menu} onClick={handleClick}>
+      <DropdownMenu state={menuState} aria-label="Complexity">
+        <DropdownMenu.Item state={menuState} onClick={handleClick}>
           <TrashIcon mr="sm" size="sm" />
           <Box>Second Action</Box>
         </DropdownMenu.Item>
-        <DropdownMenu.Item {...menu} onClick={handleClick}>
+        <DropdownMenu.Item state={menuState} onClick={handleClick}>
           <AttachmentIcon mr="sm" size="sm" />
           <Box>Third Action</Box>
         </DropdownMenu.Item>
@@ -101,33 +101,33 @@ Use `DropdownMenu.Arrow` to add an arrow to the dropdown menu
 
 ```jsx
 function() {
-  const menu = useDropdownMenuState({
+  const menuState = useDropdownMenuState({
     gutter: 10
   })
 
   const handleClick = e => {
     console.log(`Clicked on ${e.target.innerText}`)
-    menu.hide()
+    menuState.hide()
   }
 
   return (
     <>
-      <DropdownMenu.Trigger {...menu} as={Button}>
+      <DropdownMenu.Trigger state={menuState} as={Button}>
         Dropdown Menu
       </DropdownMenu.Trigger>
-      <DropdownMenu {...menu} aria-label="Example">
-        <DropdownMenu.Arrow {...menu} />
-        <DropdownMenu.Item {...menu} onClick={handleClick}>
+      <DropdownMenu state={menuState} aria-label="Example">
+        <DropdownMenu.Arrow state={menuState} />
+        <DropdownMenu.Item state={menuState} onClick={handleClick}>
           Twitter
         </DropdownMenu.Item>
-        <DropdownMenu.Item {...menu} onClick={handleClick} disabled>
+        <DropdownMenu.Item state={menuState} onClick={handleClick} disabled>
           Facebook
         </DropdownMenu.Item>
-        <DropdownMenu.Item {...menu} onClick={handleClick}>
+        <DropdownMenu.Item state={menuState} onClick={handleClick}>
           Instagram
         </DropdownMenu.Item>
-        <DropdownMenu.Separator {...menu} />
-        <DropdownMenu.Item {...menu} onClick={handleClick}>
+        <DropdownMenu.Separator state={menuState} />
+        <DropdownMenu.Item state={menuState} onClick={handleClick}>
           Github
         </DropdownMenu.Item>
       </DropdownMenu>

--- a/docs/pages/components/emoji-picker.mdx
+++ b/docs/pages/components/emoji-picker.mdx
@@ -27,16 +27,16 @@ The most basic emoji picker needs `useEmojiPicker()`, `<EmojiPicker.Trigger />` 
 
 ```jsx
 function Default() {
-  const emojiPicker = useEmojiPicker()
+  const emojiPickerState = useEmojiPicker()
   const [emoji, setEmoji] = React.useState()
 
   return (
     <>
-      <EmojiPicker.Trigger as={Button} {...emojiPicker}>
+      <EmojiPicker.Trigger as={Button} state={emojiPickerState}>
         {emoji ? <Emoji emoji={emoji} /> : 'Open Emoji Picker'}
       </EmojiPicker.Trigger>
 
-      <EmojiPicker onChange={setEmoji} value={emoji} {...emojiPicker} />
+      <EmojiPicker onChange={setEmoji} value={emoji} state={emojiPickerState} />
     </>
   )
 }
@@ -48,16 +48,16 @@ function Default() {
 
 ```jsx
 function Default() {
-  const emojiPicker = useEmojiPicker()
+  const emojiPickerState = useEmojiPicker()
   const [emoji, setEmoji] = React.useState(':dog:')
 
   return (
     <>
-      <EmojiPicker.Trigger as={Button} {...emojiPicker}>
+      <EmojiPicker.Trigger as={Button} state={emojiPickerState}>
         {emoji ? <Emoji emoji={emoji} /> : 'Open Emoji Picker'}
       </EmojiPicker.Trigger>
 
-      <EmojiPicker onChange={setEmoji} value={emoji} {...emojiPicker} />
+      <EmojiPicker onChange={setEmoji} value={emoji} state={emojiPickerState} />
     </>
   )
 }
@@ -69,7 +69,7 @@ function Default() {
 
 ```jsx
 function Tabs() {
-  const emojiPicker = useEmojiPicker()
+  const emojiPickerState = useEmojiPicker()
   const [emoji, setEmoji] = React.useState()
   const defaultTabState = {
     selectedId: 'Second tab',
@@ -77,7 +77,7 @@ function Tabs() {
 
   return (
     <>
-      <EmojiPicker.Trigger as={Button} {...emojiPicker}>
+      <EmojiPicker.Trigger as={Button} state={emojiPickerState}>
         {emoji ? <Emoji emoji={emoji} /> : 'Open Emoji Picker'}
       </EmojiPicker.Trigger>
 
@@ -85,7 +85,7 @@ function Tabs() {
         onChange={setEmoji}
         value={emoji}
         defaultTabState={defaultTabState}
-        {...emojiPicker}
+        state={emojiPickerState}
       >
         <EmojiPicker.Tab name="First tab">
           <Box display="flex" alignItems="center" justifyContent="center">
@@ -122,7 +122,7 @@ All the field, with the expection of `url`, will be used for the search.
 
 ```jsx
 function Custom() {
-  const emojiPicker = useEmojiPicker()
+  const emojiPickerState = useEmojiPicker()
   const [emoji, setEmoji] = React.useState()
 
   const emojis = [
@@ -141,7 +141,7 @@ function Custom() {
 
   return (
     <>
-      <EmojiPicker.Trigger as={Button} {...emojiPicker}>
+      <EmojiPicker.Trigger as={Button} state={emojiPickerState}>
         {currentEmoji ? (
           <Emoji emoji={currentEmoji.url || currentEmoji.alias} />
         ) : (
@@ -149,7 +149,7 @@ function Custom() {
         )}
       </EmojiPicker.Trigger>
 
-      <EmojiPicker onChange={setEmoji} {...emojiPicker}>
+      <EmojiPicker onChange={setEmoji} state={emojiPickerState}>
         <EmojiPicker.Tab name="Custom">
           <EmojiPicker.List emojis={emojis} />
         </EmojiPicker.Tab>
@@ -165,16 +165,16 @@ When using `<EmojiPicker />` witjout children, it will automatically add `<Emoji
 
 ```jsx
 function BasicList() {
-  const emojiPicker = useEmojiPicker()
+  const emojiPickerState = useEmojiPicker()
   const [emoji, setEmoji] = React.useState()
 
   return (
     <>
-      <EmojiPicker.Trigger as={Button} {...emojiPicker}>
+      <EmojiPicker.Trigger as={Button} state={emojiPickerState}>
         {emoji ? <Emoji emoji={emoji} /> : 'Open Emoji Picker'}
       </EmojiPicker.Trigger>
 
-      <EmojiPicker onChange={setEmoji} {...emojiPicker}>
+      <EmojiPicker onChange={setEmoji} state={emojiPickerState}>
         <EmojiPicker.Tab name="Basic">
           <EmojiPicker.BasicList />
         </EmojiPicker.Tab>
@@ -191,7 +191,7 @@ function BasicList() {
               value={emoji}
               onChange={e => setEmoji(e.target.value)}
             />
-            <Button onClick={emojiPicker.hide}>Close emoji picker</Button>
+            <Button onClick={emojiPickerState.hide}>Close emoji picker</Button>
           </Box>
         </EmojiPicker.Tab>
       </EmojiPicker>
@@ -206,16 +206,16 @@ You can set some props on `<EmojiPicker />` & `<EmojiPicker.List />` to change s
 
 ```jsx
 function BasicList() {
-  const emojiPicker = useEmojiPicker()
+  const emojiPickerState = useEmojiPicker()
   const [emoji, setEmoji] = React.useState()
 
   return (
     <>
-      <EmojiPicker.Trigger as={Button} {...emojiPicker}>
+      <EmojiPicker.Trigger as={Button} state={emojiPickerState}>
         {emoji ? <Emoji emoji={emoji} /> : "Ouvrir l'Emoji Picker"}
       </EmojiPicker.Trigger>
 
-      <EmojiPicker onChange={setEmoji} {...emojiPicker} emptyList="Pas d'emojis">
+      <EmojiPicker onChange={setEmoji} state={emojiPickerState} emptyList="Pas d'emojis">
         <EmojiPicker.Tab name="Basique">
           <EmojiPicker.BasicList inputSearchPlaceholder="Chercher un emoji" />
         </EmojiPicker.Tab>

--- a/docs/pages/components/markdown-editor.mdx
+++ b/docs/pages/components/markdown-editor.mdx
@@ -73,11 +73,11 @@ function () {
         onChange={handleChange}
         value={value}
         toolbar={[
-          { name: 'bold', icon: <i className="fa fa-bold" />, title: 'Bold 🌴' },
-          { name: 'italic', icon: <i className="fa fa-italic" /> },
+          { name: 'bold', icon: <span>Bold</span>, title: 'Bold 🌴' },
+          { name: 'italic', icon: <span>Italic</span> },
           { name: 'divider' },
-          { name: 'strikethrough', icon: <i className="zmdi zmdi-format-strikethrough-s" /> },
-          { name: 'link', icon: <i className="zmdi zmdi-link" /> },
+          { name: 'strikethrough', icon: <span>Strikethrough</span> },
+          { name: 'link', icon: <span>Link</span> },
           { name: 'divider' },
           { name: 'code' },
           { name: 'quote', title: 'Quote 🌴' },

--- a/docs/pages/components/modal.mdx
+++ b/docs/pages/components/modal.mdx
@@ -25,14 +25,14 @@ Use `useModalState`, `Modal`, `Modal.Trigger` and `Modal.Body` to create a simpl
 
 ```jsx
 function() {
-  const modal = useModalState()
+  const modalState = useModalState()
 
   return (
     <>
-      <Modal.Trigger as={Button} {...modal}>
+      <Modal.Trigger as={Button} state={modalState}>
         Open modal
       </Modal.Trigger>
-      <Modal modalState={modal} ariaLabel="example">
+      <Modal state={modalState} ariaLabel="example">
         <Modal.Content>
           <Modal.Body>
             Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
@@ -58,27 +58,27 @@ By default size is set to `lg`. If you don't want a size (fit on content), set s
 
 ```jsx
 function() {
-  const modal = useModalState()
+  const modalState = useModalState()
   const [size, setSize] = React.useState()
 
   return (
     <Stack direction="row">
-      <Modal.Trigger as={Button} {...modal} onClick={() => setSize('xs')}>
+      <Modal.Trigger as={Button} state={modalState} onClick={() => setSize('xs')}>
         xs
       </Modal.Trigger>
-      <Modal.Trigger as={Button} {...modal} onClick={() => setSize('sm')}>
+      <Modal.Trigger as={Button} state={modalState} onClick={() => setSize('sm')}>
         sm
       </Modal.Trigger>
-      <Modal.Trigger as={Button} {...modal} onClick={() => setSize('md')}>
+      <Modal.Trigger as={Button} state={modalState} onClick={() => setSize('md')}>
         md
       </Modal.Trigger>
-      <Modal.Trigger as={Button} {...modal} onClick={() => setSize('lg')}>
+      <Modal.Trigger as={Button} state={modalState} onClick={() => setSize('lg')}>
         lg
       </Modal.Trigger>
-      <Modal.Trigger as={Button} {...modal} onClick={() => setSize('auto')}>
+      <Modal.Trigger as={Button} state={modalState} onClick={() => setSize('auto')}>
         auto
       </Modal.Trigger>
-      <Modal modalState={modal} size={size} ariaLabel="size example">
+      <Modal state={modalState} size={size} ariaLabel="size example">
         <Modal.Content>
           <Modal.Body>
           Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
@@ -104,9 +104,9 @@ Use `Modal.Header` and `Modal.Footer` to style your Modal.
 
 ```jsx
 function() {
-  const modal = useModalState()
-  const modal2 = useModalState()
-  const modal3 = useModalState()
+  const modalState = useModalState()
+  const modalState2 = useModalState()
+  const modalState3 = useModalState()
   const title = "Nullam non lacinia"
   const subtitle = "Praesent sit amet quam ac velit faucibus dapibus, quisque sapien ligula."
   const icon = <ActionsIcon w={40} h={40} color="dark-900" />
@@ -118,10 +118,10 @@ function() {
 
   return (
     <Stack direction="row">
-      <Modal.Trigger as={Button} {...modal}>
+      <Modal.Trigger as={Button} state={modalState}>
         Example modal
       </Modal.Trigger>
-      <Modal modalState={modal} ariaLabel="example">
+      <Modal state={modalState} ariaLabel="example">
         <Modal.Content>
           <Modal.Header title={title} subtitle={subtitle} icon={icon}/>
           <Modal.Body>
@@ -154,10 +154,10 @@ function() {
         </Modal.Content>
       </Modal>
 
-      <Modal.Trigger as={Button} {...modal2}>
+      <Modal.Trigger as={Button} state={modalState2}>
         Example modal 2
       </Modal.Trigger>
-      <Modal  modalState={modal2} ariaLabel="example-2">
+      <Modal state={modalState2} ariaLabel="example-2">
         <Modal.Content>
           <Modal.Header title={title} subtitle={subtitle} />
           <Modal.Body>
@@ -190,10 +190,10 @@ function() {
         </Modal.Content>
       </Modal>
 
-      <Modal.Trigger as={Button} {...modal3}>
+      <Modal.Trigger as={Button} state={modalState3}>
         Example modal 3
       </Modal.Trigger>
-      <Modal modalState={modal3} ariaLabel="example-3">
+      <Modal state={modalState3} ariaLabel="example-3">
         <Modal.Content>
           <Modal.Header title={title} icon={icon} />
           <Modal.Body>

--- a/docs/pages/components/popover.mdx
+++ b/docs/pages/components/popover.mdx
@@ -26,14 +26,14 @@ Use `usePopoverState`, `Popover`, `Popover.Content` and `Popover.Trigger` to cre
 
 ```jsx
 function() {
-  const popover = usePopoverState()
+  const popoverState = usePopoverState()
 
   return (
     <>
-      <Popover.Trigger as={Button} {...popover}>
+      <Popover.Trigger as={Button} state={popoverState}>
         Open Popover
       </Popover.Trigger>
-      <Popover aria-label="usage popover" {...popover}>
+      <Popover aria-label="usage popover" state={popoverState}>
         <Popover.Content>
           Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
           aliquam nec, convallis sit amet erat. Mauris auctor blandit porta.
@@ -50,14 +50,14 @@ Use `Popover.Title` props to create a predefined title block.
 
 ```jsx
 function() {
-  const popover = usePopoverState({ placement: 'top' })
+  const popoverState = usePopoverState({ placement: 'top' })
 
   return (
     <>
-      <Popover.Trigger as={Button} {...popover}>
+      <Popover.Trigger as={Button} state={popoverState}>
         Open Popover
       </Popover.Trigger>
-      <Popover aria-label="title popover" {...popover}>
+      <Popover aria-label="title popover" state={popoverState}>
           <Popover.Title>Amazing title</Popover.Title>
           <Popover.Content>
             Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
@@ -75,14 +75,14 @@ function() {
 
 ```jsx
 function() {
-  const popover = usePopoverState({ withCloseButton: true })
+  const popoverState = usePopoverState({ withCloseButton: true })
 
   return (
     <>
-      <Popover.Trigger as={Button} {...popover}>
+      <Popover.Trigger as={Button} state={popoverState}>
         Open Popover
       </Popover.Trigger>
-      <Popover aria-label="close button popover" {...popover}>
+      <Popover aria-label="close button popover" state={popoverState}>
           <Popover.Title>Amazing title</Popover.Title>
           <Popover.Content>
             Praesent sit amet quam ac velit faucibus dapibus.<br />
@@ -101,14 +101,14 @@ Use `triggerMethod='hover'` on `usePopoverState` to open and close the popover b
 
 ```jsx
 function() {
-  const popover = usePopoverState({ triggerMethod: 'hover' })
+  const popoverState = usePopoverState({ triggerMethod: 'hover' })
 
   return (
     <>
-      <Popover.Trigger as={Button} {...popover}>
+      <Popover.Trigger as={Button} state={popoverState}>
         Open Popover
       </Popover.Trigger>
-      <Popover aria-label="hover to open popover" {...popover}>
+      <Popover aria-label="hover to open popover" state={popoverState}>
           <Popover.Title>Amazing title</Popover.Title>
           <Popover.Content>
             Praesent sit amet quam ac velit faucibus dapibus.<br />

--- a/docs/pages/components/tabs.mdx
+++ b/docs/pages/components/tabs.mdx
@@ -26,40 +26,40 @@ Set the tab activated by default using `selectedId` on `useTabState`.
 
 ```jsx
 function() {
-  const tab = useTabState({ selectedId: 'tab1' })
+  const tabState = useTabState({ selectedId: 'tab1' })
 
   return (
     <>
-      <Tab.List aria-label="Tabs" {...tab}>
-        <Tab {...tab} id="tab1">
+      <Tab.List aria-label="Tabs" state={tabState}>
+        <Tab state={tabState} id="tab1">
           Tab 1
         </Tab>
-        <Tab {...tab} id="tab2">
+        <Tab state={tabState} id="tab2">
           Tab 2
         </Tab>
-        <Tab {...tab} id="tab3">
+        <Tab state={tabState} id="tab3">
           Tab 3
         </Tab>
-        <Tab {...tab} id="tab4">
+        <Tab state={tabState} id="tab4">
           Tab 4
         </Tab>
-        <Tab {...tab} disabled id="tab5">
+        <Tab state={tabState} disabled id="tab5">
           Tab 5
         </Tab>
       </Tab.List>
-      <Tab.Panel {...tab} tabId="tab1">
+      <Tab.Panel state={tabState} tabId="tab1">
         Tab.Panel 1
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab2">
+      <Tab.Panel state={tabState} tabId="tab2">
         Tab.Panel 2
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab3">
+      <Tab.Panel state={tabState} tabId="tab3">
         Tab.Panel 3
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab4">
+      <Tab.Panel state={tabState} tabId="tab4">
         Tab.Panel 4
       </Tab.Panel>
-      <Tab.Panel {...tab} disabled tabId="tab5">
+      <Tab.Panel state={tabState} disabled tabId="tab5">
         Tab.Panel 5
       </Tab.Panel>
     </>
@@ -73,49 +73,49 @@ Size is set on Tab.List. Available sizes are `sm` and `md`. By default size is s
 
 ```jsx
 function() {
-  const tab = useTabState({ selectedId: 'tab1' })
+  const tabState = useTabState({ selectedId: 'tab1' })
 
   return (
     <>
-      <Tab.List aria-label="Tabs" {...tab}>
-        <Tab {...tab} id="tab1">
+      <Tab.List aria-label="Tabs" state={tabState}>
+        <Tab state={tabState} id="tab1">
           Tab 1
         </Tab>
-        <Tab {...tab} id="tab2">
+        <Tab state={tabState} id="tab2">
           Tab 2
         </Tab>
-        <Tab {...tab} id="tab3">
+        <Tab state={tabState} id="tab3">
           Tab 3
         </Tab>
       </Tab.List>
-      <Tab.Panel {...tab} tabId="tab1">
+      <Tab.Panel state={tabState} tabId="tab1">
         Tab.Panel 1
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab2">
+      <Tab.Panel state={tabState} tabId="tab2">
         Tab.Panel 2
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab3">
+      <Tab.Panel state={tabState} tabId="tab3">
         Tab.Panel 3
       </Tab.Panel>
       <br/>
-      <Tab.List aria-label="Tabs" size="sm" {...tab}>
-        <Tab {...tab} id="tab1">
+      <Tab.List aria-label="Tabs" size="sm" state={tabState}>
+        <Tab state={tabState} id="tab1">
           Tab 1
         </Tab>
-        <Tab {...tab} id="tab2">
+        <Tab state={tabState} id="tab2">
           Tab 2
         </Tab>
-        <Tab {...tab} id="tab3">
+        <Tab state={tabState} id="tab3">
           Tab 3
         </Tab>
       </Tab.List>
-      <Tab.Panel {...tab} tabId="tab1">
+      <Tab.Panel state={tabState} tabId="tab1">
         Tab.Panel 1
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab2">
+      <Tab.Panel state={tabState} tabId="tab2">
         Tab.Panel 2
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab3">
+      <Tab.Panel state={tabState} tabId="tab3">
         Tab.Panel 3
       </Tab.Panel>
     </>
@@ -129,40 +129,40 @@ The border on `Tab.List` is an inset shadow that you can customize or disable vi
 
 ```jsx
 function() {
-  const tab = useTabState({ selectedId: 'tab1' })
+  const tabState = useTabState({ selectedId: 'tab1' })
 
   return (
     <>
-      <Tab.List aria-label="Tabs" boxShadow="none" {...tab}>
-        <Tab {...tab} id="tab1">
+      <Tab.List aria-label="Tabs" boxShadow="none" state={tabState}>
+        <Tab state={tabState} id="tab1">
           Tab 1
         </Tab>
-        <Tab {...tab} id="tab2">
+        <Tab state={tabState} id="tab2">
           Tab 2
         </Tab>
-        <Tab {...tab} id="tab3">
+        <Tab state={tabState} id="tab3">
           Tab 3
         </Tab>
-        <Tab {...tab} id="tab4">
+        <Tab state={tabState} id="tab4">
           Tab 4
         </Tab>
-        <Tab {...tab} disabled id="tab5">
+        <Tab state={tabState} disabled id="tab5">
           Tab 5
         </Tab>
       </Tab.List>
-      <Tab.Panel {...tab} tabId="tab1">
+      <Tab.Panel state={tabState} tabId="tab1">
         Tab.Panel 1
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab2">
+      <Tab.Panel state={tabState} tabId="tab2">
         Tab.Panel 2
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab3">
+      <Tab.Panel state={tabState} tabId="tab3">
         Tab.Panel 3
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab4">
+      <Tab.Panel state={tabState} tabId="tab4">
         Tab.Panel 4
       </Tab.Panel>
-      <Tab.Panel {...tab} disabled tabId="tab5">
+      <Tab.Panel state={tabState} disabled tabId="tab5">
         Tab.Panel 5
       </Tab.Panel>
     </>
@@ -176,19 +176,19 @@ Add badges, icons and images in tab.
 
 ```jsx
 function() {
-  const tab = useTabState({ selectedId: 'tab2' })
-  const getVariant = item => (tab.selectedId === item ? 'primary' : 'default')
+  const tabState = useTabState({ selectedId: 'tab2' })
+  const getVariant = item => (tabState.selectedId === item ? 'primary' : 'default')
 
   return (
     <>
-      <Tab.List aria-label="Tabs" {...tab}>
-        <Tab {...tab} id="tab1">
+      <Tab.List aria-label="Tabs" state={tabState}>
+        <Tab state={tabState} id="tab1">
           Tab 1
           <Badge variant={getVariant('tab1')}>
             new
           </Badge>
         </Tab>
-        <Tab {...tab} id="tab2">
+        <Tab state={tabState} id="tab2">
           Tab 2
           <Badge variant={getVariant('tab2')}>
             old
@@ -197,25 +197,25 @@ function() {
           2
           </Badge>
         </Tab>
-        <Tab {...tab} id="tab3">
+        <Tab state={tabState} id="tab3">
           Tab 3
           <HeartIcon />
         </Tab>
-        <Tab {...tab} id="tab4">
+        <Tab state={tabState} id="tab4">
           <img src="https://cdn.welcometothejungle.com/wttj-front/production/assets/images/logos/wttj.svg?v=3a3dbd7122a01600fb67e66b889bb47c" />
           Tab 4
         </Tab>
       </Tab.List>
-      <Tab.Panel {...tab} tabId="tab1">
+      <Tab.Panel state={tabState} tabId="tab1">
         Tab.Panel 1
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab2">
+      <Tab.Panel state={tabState} tabId="tab2">
         Tab.Panel 2
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab3">
+      <Tab.Panel state={tabState} tabId="tab3">
         Tab.Panel 3
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab4">
+      <Tab.Panel state={tabState} tabId="tab4">
         Tab.Panel 4
       </Tab.Panel>
     </>
@@ -229,28 +229,28 @@ Use another component in tab.
 
 ```jsx
 function() {
-  const tab = useTabState({ selectedId: 'tab1' })
+  const tabState = useTabState({ selectedId: 'tab1' })
 
   return (
     <>
-      <Tab.List aria-label="Tabs" {...tab}>
-        <Tab {...tab} as="a" id="tab1">
+      <Tab.List aria-label="Tabs" state={tabState}>
+        <Tab state={tabState} as="a" id="tab1">
           Tab 1
         </Tab>
-        <Tab {...tab} as="a" id="tab2">
+        <Tab state={tabState} as="a" id="tab2">
           Tab 2
         </Tab>
-        <Tab {...tab} as="a" id="tab3">
+        <Tab state={tabState} as="a" id="tab3">
           Tab 3
         </Tab>
       </Tab.List>
-      <Tab.Panel {...tab} tabId="tab1">
+      <Tab.Panel state={tabState} tabId="tab1">
         Tab.Panel 1
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab2">
+      <Tab.Panel state={tabState} tabId="tab2">
         Tab.Panel 2
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab3">
+      <Tab.Panel state={tabState} tabId="tab3">
         Tab.Panel 3
       </Tab.Panel>
     </>
@@ -264,16 +264,16 @@ Active bar doesn't display with only one tab.
 
 ```jsx
 function() {
-  const tab = useTabState({ selectedId: 'tab1' })
+  const tabState = useTabState({ selectedId: 'tab1' })
 
   return (
     <>
-      <Tab.List aria-label="Tabs" {...tab}>
-        <Tab {...tab} id="tab1">
+      <Tab.List aria-label="Tabs" state={tabState}>
+        <Tab state={tabState} id="tab1">
           Tab 1
         </Tab>
       </Tab.List>
-      <Tab.Panel {...tab} tabId="tab1">
+      <Tab.Panel state={tabState} tabId="tab1">
         Tab.Panel 1
       </Tab.Panel>
     </>
@@ -287,34 +287,34 @@ Set the tab orientation by providing the `orientation` prop to the tab state
 
 ```jsx
 function() {
-  const tab = useTabState({ orientation: 'vertical', selectedId: 'tab2' })
+  const tabState = useTabState({ orientation: 'vertical', selectedId: 'tab2' })
 
   return (
     <Box display="flex">
-      <Tab.List w={200} mr="lg" aria-label="Tabs" {...tab}>
-        <Tab {...tab} id="tab1">
+      <Tab.List w={200} mr="lg" aria-label="Tabs" state={tabState}>
+        <Tab state={tabState} id="tab1">
           Tab 1
         </Tab>
-        <Tab {...tab} id="tab2">
+        <Tab state={tabState} id="tab2">
           Tab 2
         </Tab>
-        <Tab {...tab} id="tab3">
+        <Tab state={tabState} id="tab3">
           Tab 3
         </Tab>
-        <Tab {...tab} id="tab4">
+        <Tab state={tabState} id="tab4">
           Tab 4
         </Tab>
       </Tab.List>
-      <Tab.Panel {...tab} tabId="tab1">
+      <Tab.Panel state={tabState} tabId="tab1">
         Tab.Panel 1
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab2">
+      <Tab.Panel state={tabState} tabId="tab2">
         Tab.Panel 2
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab3">
+      <Tab.Panel state={tabState} tabId="tab3">
         Tab.Panel 3
       </Tab.Panel>
-      <Tab.Panel {...tab} tabId="tab4">
+      <Tab.Panel state={tabState} tabId="tab4">
         Tab.Panel 4
       </Tab.Panel>
     </Box>

--- a/docs/pages/upgrade.mdx
+++ b/docs/pages/upgrade.mdx
@@ -87,23 +87,22 @@ To prepare to the migration from reakit to ariakit, visible property is now depr
 
 ### Alert / Toast / Growl
 
-### All
+- All
 
-- We have adjusted colors and spacing.
-- Position `top` has been replaced with `top-center` and position `bottom` has been replaced with `bottom-center`.
-- We removed property `closeButtonDataTestId`, now we add `-close-button` after your `dataTestId` perperty.
+  - We have adjusted colors and spacing.
+  - Position `top` has been replaced with `top-center` and position `bottom` has been replaced with `bottom-center`.
+  - We removed property `closeButtonDataTestId`, now we add `-close-button` after your `dataTestId` perperty.
 
-#### Alert
+- Alert
 
-- The props `icon` is now given to the **Alert** component and not to **Alert.Title**.
-- You must use the `cta` prop instead of pass the **Alert.Button** as a Children
-- You must use the `isFullWidth` prop to have an alert with a 100% max width
+  - The props `icon` is now given to the **Alert** component and not to **Alert.Title**.
+  - You must use the `cta` prop instead of pass the **Alert.Button** as a Children
+  - You must use the `isFullWidth` prop to have an alert with a 100% max width
 
-#### Toast
-
-- In order to use `Toast` component, you must add the `Notifications` component in your project root.
-- The `useToast` hook is deprecated. Instead, you can directly use `toast` function.
-- The props `icon` is now given to **Toast.Growl** / **Toast.Snackbar** component and not to **Toast.Title**.
+- Toast
+  - In order to use `Toast` component, you must add the `Notifications` component in your project root.
+  - The `useToast` hook is deprecated. Instead, you can directly use `toast` function.
+  - The props `icon` is now given to **Toast.Growl** / **Toast.Snackbar** component and not to **Toast.Title**.
 
 ### Badges
 
@@ -137,6 +136,65 @@ const drawerState = useDrawerState()
 <Drawer state={drawerState}>
   ...
 </Drawer>
+```
+
+### DropdownMenu
+
+To prepare to the migration from reakit to ariakit, we need now to pass a state property who contain the state from useDropdownMenuState:
+
+```jsx live=false
+const dropdownMenuState = useDropdownMenuState()
+
+<DropdownMenu.Trigger {...dropdownMenuState}>
+  ...
+</DropdownMenu.Trigger>
+<DropdownMenu {...dropdownMenuState}>
+  <DropdownMenu.Item {...dropdownMenuState}>
+    ...
+  </DropdownMenu.Item>
+  ...
+</DropdownMenu>
+
+
+Before
+---
+After
+
+const dropdownMenuState = useDropdownMenuState()
+
+<DropdownMenu.Trigger state={dropdownMenuState}>
+  ...
+</DropdownMenu.Trigger>
+<DropdownMenu state={dropdownMenuState}>
+  <DropdownMenu.Item state={dropdownMenuState}>
+    ...
+  </DropdownMenu.Item>
+  ...
+</DropdownMenu>
+```
+
+### EmojiPicker
+
+To prepare to the migration from reakit to ariakit, we need now to pass a state property who contain the state from useEmojiPicker:
+
+```jsx live=false
+const emojiPickerState = useEmojiPicker()
+
+<EmojiPicker.Trigger {...emojiPickerState}>
+  ...
+</EmojiPicker.Trigger>
+<EmojiPicker {...emojiPickerState} />
+
+Before
+---
+After
+
+const emojiPickerState = useEmojiPicker()
+
+<EmojiPicker.Trigger state={emojiPickerState}>
+  ...
+</EmojiPicker.Trigger>
+<EmojiPicker state={emojiPickerState} />
 ```
 
 and visible property is now deprecated and replaced by open.
@@ -213,9 +271,75 @@ const modalState = useModalState()
 
 and visible property is now deprecated and replaced by open.
 
+### Popover
+
+To prepare to the migration from reakit to ariakit, we need now to pass a state property who contain the state from usePopoverState:
+
+```jsx live=false
+const popoverState = usePopoverState()
+
+<Popover.Trigger {...popoverState}>
+  ...
+</Popover.Trigger>
+<Popover {...popoverState}>
+  <Popover.Content>
+    ...
+  </Popover.Content>
+</Popover>
+
+Before
+---
+After
+
+const popoverState = usePopoverState()
+
+<Popover.Trigger state={popoverState}>
+  ...
+</Popover.Trigger>
+<Popover state={popoverState}>
+  <Popover.Content>
+    ...
+  </Popover.Content>
+</Popover>
+```
+
+and visible property is now deprecated and replaced by open.
+
 ### RadioGroup
 
 We removed the check icon on radio input and change the style of it.
+
+### Tabs
+
+To prepare to the migration from reakit to ariakit, we need now to pass a state property who contain the state from useTabState:
+
+```jsx live=false
+const tabState = useTabState()
+
+<Tab.List {...tabState}>
+  <Tab {...tabState}>
+    ...
+  </Tab>
+</Tab.List>
+<Tab.Panel {...tabState}>
+  ...
+</Tab.Panel>
+
+Before
+---
+After
+
+const tabState = useTabState()
+
+<Tab.List state={tabState}>
+  <Tab state={tabState}>
+    ...
+  </Tab>
+</Tab.List>
+<Tab.Panel state={tabState}>
+  ...
+</Tab.Panel>
+```
 
 ### Tag
 

--- a/docs/pages/upgrade.mdx
+++ b/docs/pages/upgrade.mdx
@@ -81,26 +81,33 @@ We change the name of variants to `xs` `s` `m` `lg` and remove useless variants.
 
 ## Components
 
-### Modal
+### Accordion
 
-- We have adjusted colors and spacing.
-- **Modal.Title** is now named **Modal.Header** and has props `title` (mandatory) and `subtitle` (optional).
-- **Modal.Content** is replaced by **Modal.Body**.
-- To ensure **good spacing** between modal's sub-components, they **must** be wrapped with **Modal.Content**.
-- **Modal.Cover** has been removed.
-- In order to fix an issue that made attributes duplicating, you will now have to pass the modalState to it props `modalState`
+To prepare to the migration from reakit to ariakit, visible property is now deprecated and replaced by open.
 
 ### Alert / Toast / Growl
 
+### All
+
 - We have adjusted colors and spacing.
+- Position `top` has been replaced with `top-center` and position `bottom` has been replaced with `bottom-center`.
+- We removed property `closeButtonDataTestId`, now we add `-close-button` after your `dataTestId` perperty.
+
+#### Alert
+
 - The props `icon` is now given to the **Alert** component and not to **Alert.Title**.
 - You must use the `cta` prop instead of pass the **Alert.Button** as a Children
 - You must use the `isFullWidth` prop to have an alert with a 100% max width
-- The props `icon` is now given to **Toast.Growl** / **Toast.Snackbar** component and not to **Toast.Title**.
-- Position `top` has been replaced with `top-center` and position `bottom` has been replaced with `bottom-center`.
-- The `useToast` hook is deprecated. Instead, you can directly use `toast` function.
+
+#### Toast
+
 - In order to use `Toast` component, you must add the `Notifications` component in your project root.
-- We removed property `closeButtonDataTestId`, now we add `-close-button` after your `dataTestId` perperty.
+- The `useToast` hook is deprecated. Instead, you can directly use `toast` function.
+- The props `icon` is now given to **Toast.Growl** / **Toast.Snackbar** component and not to **Toast.Title**.
+
+### Badges
+
+- new `Badge` component [show more](/components/badge)
 
 ### Buttons
 
@@ -110,24 +117,29 @@ We change the name of variants to `xs` `s` `m` `lg` and remove useless variants.
 - The `quaternary` variant is now named `ghost`.
 - The icon size now adjusts to the size of the button.
 
-### Tag
+### Drawer
 
-- We have adjusted colors and spacing.
-- The `lg` size has been removed.
-- The `shape` prop has been removed.
-- The icon size now adjusts to the size of the tag.
+To prepare to the migration from reakit to ariakit, we need now to pass a state property who contain the state from useDrawer:
 
-### Link
+```jsx live=false
+const drawerState = useDrawerState()
 
-- the `isExternalLink` become `isExternal`
+<Drawer {...drawerState}>
+  ...
+</Drawer>
 
-### Badges
+Before
+---
+After
 
-- new `Badge` component [show more](/components/badge)
+const drawerState = useDrawerState()
 
-### RadioGroup
+<Drawer state={drawerState}>
+  ...
+</Drawer>
+```
 
-We removed the check icon on radio input and change the style of it.
+and visible property is now deprecated and replaced by open.
 
 ### FileDrop
 
@@ -167,6 +179,30 @@ We renamed some icons:
 - `<ChevronIcon>` become `<CodeIcon>`
 - `<DuplicateIcon>` become `<CopyIcon>`
 - `<TagsIcon>` become `<TagIcon>`
+
+### Link
+
+- the `isExternalLink` become `isExternal`
+
+### Modal
+
+- We have adjusted colors and spacing.
+- **Modal.Title** is now named **Modal.Header** and has props `title` (mandatory) and `subtitle` (optional).
+- **Modal.Content** is replaced by **Modal.Body**.
+- To ensure **good spacing** between modal's sub-components, they **must** be wrapped with **Modal.Content**.
+- **Modal.Cover** has been removed.
+- In order to fix an issue that made attributes duplicating, you will now have to pass the modalState to it props `modalState`
+
+### RadioGroup
+
+We removed the check icon on radio input and change the style of it.
+
+### Tag
+
+- We have adjusted colors and spacing.
+- The `lg` size has been removed.
+- The `shape` prop has been removed.
+- The icon size now adjusts to the size of the tag.
 
 ### Tooltip
 

--- a/docs/pages/upgrade.mdx
+++ b/docs/pages/upgrade.mdx
@@ -119,7 +119,7 @@ To prepare to the migration from reakit to ariakit, visible property is now depr
 
 ### Drawer
 
-To prepare to the migration from reakit to ariakit, we need now to pass a state property who contain the state from useDrawer:
+To prepare to the migration from reakit to ariakit, we need now to pass a state property who contain the state from useDrawerState:
 
 ```jsx live=false
 const drawerState = useDrawerState()
@@ -191,7 +191,27 @@ We renamed some icons:
 - **Modal.Content** is replaced by **Modal.Body**.
 - To ensure **good spacing** between modal's sub-components, they **must** be wrapped with **Modal.Content**.
 - **Modal.Cover** has been removed.
-- In order to fix an issue that made attributes duplicating, you will now have to pass the modalState to it props `modalState`
+- In order to fix an issue that made attributes duplicating, and to prepare to the migration from reakit to ariakit, you will now have to pass the modalState to it props `state` who contain the state from useModalState:
+
+```jsx live=false
+const modalState = useModalState()
+
+<Modal {...modalState}>
+  ...
+</Modal>
+
+Before
+---
+After
+
+const modalState = useModalState()
+
+<Modal state={modalState}>
+  ...
+</Modal>
+```
+
+and visible property is now deprecated and replaced by open.
 
 ### RadioGroup
 

--- a/packages/Accordion/package.json
+++ b/packages/Accordion/package.json
@@ -50,5 +50,5 @@
   "gitHead": "974e7bfd71f8cfe846cbffd678c3860a8952f9e9",
   "sideEffects": false,
   "component": "Accordion",
-  "homepage": "https://welcome-ui.com/components/alert"
+  "homepage": "https://welcome-ui.com/components/accordion"
 }

--- a/packages/Accordion/src/index.tsx
+++ b/packages/Accordion/src/index.tsx
@@ -9,14 +9,22 @@ import * as S from './styles'
 export interface AccordionOptions {
   title: string | JSX.Element
   icon?: JSX.Element
+  /**
+   * @deprecated
+   * will be replace by open on ariakit (reakit v2)
+   **/
   visible?: boolean
+  /**
+   * Open the hidden content on load
+   */
+  open?: boolean
 }
 
 export type AccordionProps = CreateWuiProps<'div', AccordionOptions>
 
 export const Accordion = forwardRef<'div', AccordionProps>(
-  ({ children, icon = <RightIcon />, title, visible = false, ...rest }, ref) => {
-    const disclosure = useDisclosureState({ visible, animated: true })
+  ({ children, icon = <RightIcon />, title, visible = false, open = false, ...rest }, ref) => {
+    const disclosure = useDisclosureState({ visible: open || visible, animated: true })
     const isVisible = disclosure.visible
 
     return (

--- a/packages/Alert/src/index.tsx
+++ b/packages/Alert/src/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React, { Children, cloneElement } from 'react'
 import { Stack } from '@welcome-ui/stack'
 import { Box } from '@welcome-ui/box'

--- a/packages/Core/src/theme/paginations.ts
+++ b/packages/Core/src/theme/paginations.ts
@@ -6,6 +6,7 @@ export interface ThemePaginations {
   default: CSSObject
   item: CSSObject
   active: CSSObject
+  disabled: CSSObject
 }
 
 export const getPaginations = (theme: WuiTheme): ThemePaginations => {
@@ -31,6 +32,10 @@ export const getPaginations = (theme: WuiTheme): ThemePaginations => {
       '&:hover, &:focus': {
         backgroundColor: colors['dark-900'],
       },
+    },
+    disabled: {
+      backgroundColor: colors['nude-400'],
+      color: colors['nude-700'],
     },
   }
 }

--- a/packages/Core/src/theme/radios.ts
+++ b/packages/Core/src/theme/radios.ts
@@ -24,7 +24,7 @@ export const getRadios = (theme: WuiTheme): ThemeRadios => {
       height: toRem(16),
     },
     checked: {
-      color: theme.colors['dark-900'],
+      color: colors['dark-900'],
       borderColor: colors['primary-500'],
     },
     checkedCenteredColor: {

--- a/packages/Drawer/src/index.tsx
+++ b/packages/Drawer/src/index.tsx
@@ -4,12 +4,13 @@ import {
   Dialog,
   DialogBackdropProps,
   DialogDisclosure,
-  DialogInitialState,
+  DialogDisclosureProps,
   DialogOptions,
+  DialogProps,
+  DialogState,
   DialogStateReturn,
   useDialogState,
 } from 'reakit/Dialog'
-import { SealedInitialState } from 'reakit-utils/ts/useSealedState'
 import { Box, BoxProps } from '@welcome-ui/box'
 import { CloseButtonProps } from '@welcome-ui/close-button'
 import { Text, TextProps } from '@welcome-ui/text'
@@ -23,16 +24,17 @@ export type Size = 'sm' | 'md' | 'lg' | 'auto' | string
 export interface DrawerOptions {
   placement?: Placement
   size?: Size
+  state?: DialogOptions
 }
 
-export type DrawerProps = CreateWuiProps<'div', DrawerOptions & DialogOptions>
+export type DrawerProps = CreateWuiProps<'div', DrawerOptions>
 
 const DrawerComponent = forwardRef<'div', DrawerProps>(
-  ({ as, children, placement = 'right', size = 'lg', ...rest }, ref) => {
+  ({ as, children, placement = 'right', size = 'lg', state, ...rest }, ref) => {
     return (
       // Needed to allow to style the backdrop
       // see: https://reakit.io/docs/styling/#css-in-js
-      <Dialog as={as} ref={ref} {...rest}>
+      <Dialog as={as} ref={ref} {...state} {...rest}>
         {props => (
           <S.Drawer {...props} placement={placement} size={size}>
             {children}
@@ -43,21 +45,37 @@ const DrawerComponent = forwardRef<'div', DrawerProps>(
   }
 )
 
-export type DrawerStateReturn = DialogStateReturn
+export type DrawerStateReturn = DialogStateReturn & {
+  open: DialogStateReturn['visible']
+}
 
 export function useDrawerState(
-  options?: SealedInitialState<DialogInitialState>
+  options?: DialogState & {
+    /**
+     * @deprecated
+     * will be replace by open on ariakit (reakit v2)
+     **/
+    visible?: DialogState['visible']
+    /**
+     * Open the drawer on load
+     */
+    open?: DialogState['visible']
+  }
 ): DrawerStateReturn {
-  return useDialogState({ animated: true, ...options })
+  const { open, visible, ...restOptions } = options || {}
+  const dialogState = useDialogState({ animated: true, visible: visible || open, ...restOptions })
+
+  return { open: dialogState.visible, ...dialogState }
 }
 
 export interface DrawerBackdropOptions {
   hideOnClickOutside?: boolean
   backdropVisible?: boolean
+  state: DialogBackdropProps
   children: React.ReactElement
 }
 
-export type DrawerBackdropProps = DrawerBackdropOptions & DialogBackdropProps
+export type DrawerBackdropProps = DrawerBackdropOptions
 
 // Needed to allow to style the backdrop
 // see: https://reakit.io/docs/styling/#css-in-js
@@ -68,6 +86,7 @@ export const DrawerBackdrop: React.FC<DrawerBackdropProps> = ({
   backdropVisible = true,
   children,
   hideOnClickOutside = true,
+  state,
   ...rest
 }) => {
   const Wrapper = backdropVisible ? S.Backdrop : S.NoBackdropWrapper
@@ -79,16 +98,18 @@ export const DrawerBackdrop: React.FC<DrawerBackdropProps> = ({
   }
 
   return (
-    <Wrapper {...rest} hideOnClickOutside={hideOnClickOutside} {...optionalWrapperProps}>
+    <Wrapper {...state} {...rest} hideOnClickOutside={hideOnClickOutside} {...optionalWrapperProps}>
       {cloneElement(children, { hideOnClickOutside })}
     </Wrapper>
   )
 }
 
-export type CloseOptions = { hide: VoidFunction }
+export type CloseOptions = { state: DialogProps }
 export type CloseProps = CloseOptions & CloseButtonProps
 
-export const Close: React.FC<CloseProps> = ({ hide, zIndex = '2', ...props }) => {
+export const Close: React.FC<CloseProps> = ({ state, zIndex = '2', ...props }) => {
+  const { hide } = state
+
   return (
     <Box
       display="flex"
@@ -138,8 +159,15 @@ export const Footer: React.FC<BoxProps> = props => {
   )
 }
 
+export const Trigger: React.FC<{ state: DialogDisclosureProps; children: React.ReactNode }> = ({
+  state,
+  ...rest
+}) => {
+  return <DialogDisclosure {...state} {...rest} />
+}
+
 export const Drawer = Object.assign(DrawerComponent, {
-  Trigger: DialogDisclosure,
+  Trigger,
   Backdrop: DrawerBackdrop,
   Close,
   Title,

--- a/packages/Drawer/src/index.tsx
+++ b/packages/Drawer/src/index.tsx
@@ -5,9 +5,9 @@ import {
   DialogBackdropProps,
   DialogDisclosure,
   DialogDisclosureProps,
+  DialogInitialState,
   DialogOptions,
   DialogProps,
-  DialogState,
   DialogStateReturn,
   useDialogState,
 } from 'reakit/Dialog'
@@ -48,20 +48,19 @@ const DrawerComponent = forwardRef<'div', DrawerProps>(
 export type DrawerStateReturn = DialogStateReturn & {
   open: DialogStateReturn['visible']
 }
+export type DrawerInitialState = DialogInitialState & {
+  /**
+   * @deprecated
+   * will be replace by open on ariakit (reakit v2)
+   **/
+  visible?: DialogInitialState['visible']
+  /**
+   * Open the drawer on load
+   */
+  open?: DialogInitialState['visible']
+}
 
-export function useDrawerState(
-  options?: DialogState & {
-    /**
-     * @deprecated
-     * will be replace by open on ariakit (reakit v2)
-     **/
-    visible?: DialogState['visible']
-    /**
-     * Open the drawer on load
-     */
-    open?: DialogState['visible']
-  }
-): DrawerStateReturn {
+export function useDrawerState(options?: DrawerInitialState): DrawerStateReturn {
   const { open, visible, ...restOptions } = options || {}
   const dialogState = useDialogState({ animated: true, visible: visible || open, ...restOptions })
 

--- a/packages/Drawer/src/index.tsx
+++ b/packages/Drawer/src/index.tsx
@@ -46,6 +46,11 @@ const DrawerComponent = forwardRef<'div', DrawerProps>(
 )
 
 export type DrawerStateReturn = DialogStateReturn & {
+  /**
+   * @deprecated
+   * will be replace by open on ariakit (reakit v2)
+   **/
+  visible?: DialogStateReturn['visible']
   open: DialogStateReturn['visible']
 }
 export type DrawerInitialState = DialogInitialState & {

--- a/packages/Drawer/src/index.tsx
+++ b/packages/Drawer/src/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React, { cloneElement } from 'react'
 import {
   Dialog,

--- a/packages/Drawer/tests/index.test.tsx
+++ b/packages/Drawer/tests/index.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 

--- a/packages/Drawer/tests/index.test.tsx
+++ b/packages/Drawer/tests/index.test.tsx
@@ -8,11 +8,12 @@ import { Drawer, useDrawerState } from '../src'
 describe('<Drawer>', () => {
   it('should render correctly', () => {
     const Test = () => {
-      const drawer = useDrawerState()
+      const drawerState = useDrawerState()
+
       return (
         <>
-          <Drawer.Trigger {...drawer}>open</Drawer.Trigger>
-          <Drawer aria-label="drawer" {...drawer}>
+          <Drawer.Trigger state={drawerState}>open</Drawer.Trigger>
+          <Drawer aria-label="drawer" state={drawerState}>
             test
           </Drawer>
         </>
@@ -27,11 +28,12 @@ describe('<Drawer>', () => {
 
   it('should render its size & placement correctly', () => {
     const Test = () => {
-      const drawer = useDrawerState()
+      const drawerState = useDrawerState()
+
       return (
         <>
-          <Drawer.Trigger {...drawer}>open</Drawer.Trigger>
-          <Drawer aria-label="drawer" placement="bottom" size="50%" {...drawer}>
+          <Drawer.Trigger state={drawerState}>open</Drawer.Trigger>
+          <Drawer aria-label="drawer" placement="bottom" size="50%" state={drawerState}>
             test
           </Drawer>
         </>

--- a/packages/DropdownMenu/src/Arrow.tsx
+++ b/packages/DropdownMenu/src/Arrow.tsx
@@ -4,6 +4,8 @@ import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 
 import * as S from './Arrow.styled'
 
+import { DropdownMenuOptions } from '.'
+
 const transformMap: Record<string, string> = {
   top: 'rotateZ(180deg)',
   right: 'rotateZ(-90deg)',
@@ -11,16 +13,20 @@ const transformMap: Record<string, string> = {
   left: 'rotateZ(90deg)',
 }
 
-export type ArrowProps = CreateWuiProps<'div', MenuArrowOptions>
+export type ArrowProps = CreateWuiProps<
+  'div',
+  MenuArrowOptions & { state: DropdownMenuOptions['state'] }
+>
 
-export const Arrow = forwardRef<'div', ArrowProps>((props, ref) => {
+export const Arrow = forwardRef<'div', ArrowProps>(({ state, ...rest }, ref) => {
   // get the correct transform style for arrow
-  const { placement } = props
+  const { placement } = state
   // get the parent placement (top, bottom...)
-  const transform = transformMap[placement.split('-')[0]]
+  const parentPlacement = placement.split('-')[0]
+  const transform = transformMap[parentPlacement]
 
   return (
-    <S.Arrow {...props} ref={ref}>
+    <S.Arrow {...state} {...rest} ref={ref}>
       <S.ArrowItem
         $transform={transform}
         h={30}

--- a/packages/DropdownMenu/src/Arrow.tsx
+++ b/packages/DropdownMenu/src/Arrow.tsx
@@ -22,7 +22,7 @@ export const Arrow = forwardRef<'div', ArrowProps>(({ state, ...rest }, ref) => 
   // get the correct transform style for arrow
   const { placement } = state
   // get the parent placement (top, bottom...)
-  const parentPlacement = placement.split('-')[0]
+  const [parentPlacement] = placement.split('-')
   const transform = transformMap[parentPlacement]
 
   return (

--- a/packages/DropdownMenu/src/Item.tsx
+++ b/packages/DropdownMenu/src/Item.tsx
@@ -1,14 +1,19 @@
 import React from 'react'
-import { MenuItem, MenuItemOptions } from 'reakit/Menu'
+import { MenuItem, MenuItemProps } from 'reakit/Menu'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 
 import * as S from './Item.styled'
 
-export type ItemProps = CreateWuiProps<'button', MenuItemOptions>
+import { DropdownMenuOptions } from '.'
 
-export const Item = forwardRef<'button', ItemProps>(({ as, children, ...props }, ref) => {
+export type ItemProps = CreateWuiProps<
+  'button',
+  MenuItemProps & { state: DropdownMenuOptions['state'] }
+>
+
+export const Item = forwardRef<'button', ItemProps>(({ as, children, state, ...rest }, ref) => {
   return (
-    <MenuItem as={undefined} type="button" {...props} ref={ref}>
+    <MenuItem as={undefined} type="button" {...state} {...rest} ref={ref}>
       {menuItemProps => {
         return (
           <S.Item as={as} {...menuItemProps}>

--- a/packages/DropdownMenu/src/Separator.tsx
+++ b/packages/DropdownMenu/src/Separator.tsx
@@ -4,8 +4,13 @@ import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 
 import * as S from './Separator.styled'
 
-export type SeparatorProps = CreateWuiProps<'div', MenuSeparatorProps>
+import { DropdownMenuOptions } from '.'
 
-export const Separator = forwardRef<'div', SeparatorProps>((props, ref) => {
-  return <MenuSeparator as={S.Separator} ref={ref} {...props} />
+export type SeparatorProps = CreateWuiProps<
+  'div',
+  MenuSeparatorProps & { state: DropdownMenuOptions['state'] }
+>
+
+export const Separator = forwardRef<'div', SeparatorProps>(({ state, ...rest }, ref) => {
+  return <MenuSeparator as={S.Separator} ref={ref} {...state} {...rest} />
 })

--- a/packages/DropdownMenu/src/index.tsx
+++ b/packages/DropdownMenu/src/index.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import { MenuButton, MenuOptions, Menu as ReakitMenu, useMenuState } from 'reakit/Menu'
+import {
+  MenuButton,
+  MenuInitialState,
+  MenuOptions,
+  MenuStateReturn,
+  Menu as ReakitMenu,
+  useMenuState,
+} from 'reakit/Menu'
 import { useNextFrame } from '@welcome-ui/utils'
 import { CreateWuiProps, forwardRef, WuiProps } from '@welcome-ui/system'
 
@@ -58,12 +65,40 @@ const DropdownMenuComponent = forwardRef<'div', DropdownMenuProps>(
   }
 )
 
+export type DropdownMenuStateReturn = MenuStateReturn & {
+  /**
+   * @deprecated
+   * will be replace by open on ariakit (reakit v2)
+   **/
+  visible?: MenuStateReturn['visible']
+  open: MenuStateReturn['visible']
+}
+export type DropdownMenuInitialState = MenuInitialState & {
+  /**
+   * @deprecated
+   * will be replace by open on ariakit (reakit v2)
+   **/
+  visible?: MenuInitialState['visible']
+  /**
+   * Open the drawer on load
+   */
+  open?: MenuInitialState['visible']
+}
+
+export function useDropdownMenuState(options?: DropdownMenuInitialState): DropdownMenuStateReturn {
+  const { open, visible, ...restOptions } = options || {}
+  const dropdownMenuState = useMenuState({
+    animated: true,
+    visible: visible || open,
+    ...restOptions,
+  })
+
+  return { open: dropdownMenuState.visible, ...dropdownMenuState }
+}
+
 export const DropdownMenu = Object.assign(DropdownMenuComponent, {
   Trigger: MenuButton,
   Item,
   Separator,
   Arrow,
 })
-
-export { useMenuState as useDropdownMenuState }
-export type DropdownMenuStateReturn = ReturnType<typeof useMenuState>

--- a/packages/DropdownMenu/src/index.tsx
+++ b/packages/DropdownMenu/src/index.tsx
@@ -11,14 +11,25 @@ import * as S from './styles'
 export interface DropdownMenuOptions {
   /** add custom props from styled system on DropdownMenu inner */
   innerProps?: WuiProps
-  visible?: boolean
+  state: MenuOptions & {
+    /**
+     * @deprecated
+     * will be replace by open on ariakit (reakit v2)
+     **/
+    visible?: MenuOptions['visible']
+    /**
+     * Open the menu on load
+     */
+    open?: MenuOptions['visible']
+  }
 }
 
-export type DropdownMenuProps = CreateWuiProps<'div', DropdownMenuOptions & MenuOptions>
+export type DropdownMenuProps = CreateWuiProps<'div', DropdownMenuOptions>
 
 const DropdownMenuComponent = forwardRef<'div', DropdownMenuProps>(
-  ({ children, dataTestId, innerProps = {}, visible = false, ...props }, ref) => {
-    const delayedVisible = useNextFrame(visible)
+  ({ children, dataTestId, innerProps = {}, state = {}, ...props }, ref) => {
+    const { open, visible } = state
+    const delayedVisible = useNextFrame(open || visible)
 
     return (
       <ReakitMenu
@@ -27,7 +38,7 @@ const DropdownMenuComponent = forwardRef<'div', DropdownMenuProps>(
         data-testid={dataTestId}
         ref={ref}
         tabIndex={0}
-        visible={visible}
+        {...state}
         {...props}
       >
         {menuProps => (

--- a/packages/DropdownMenu/tests/index.test.tsx
+++ b/packages/DropdownMenu/tests/index.test.tsx
@@ -10,11 +10,11 @@ describe('<DropdownMenu>', () => {
   it('should render correctly', () => {
     const dataTestId = 'dropdownMenu'
     const {
-      result: { current: menu },
+      result: { current: menuState },
     } = renderHook(() => useDropdownMenuState())
 
     const { getByTestId } = render(
-      <DropdownMenu {...menu} dataTestId={dataTestId}>
+      <DropdownMenu dataTestId={dataTestId} state={menuState}>
         {content}
       </DropdownMenu>
     )

--- a/packages/EmojiPicker/src/List.tsx
+++ b/packages/EmojiPicker/src/List.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { InputText } from '@welcome-ui/input-text'
 import { FixedSizeList, ListChildComponentProps } from 'react-window'

--- a/packages/EmojiPicker/src/List.tsx
+++ b/packages/EmojiPicker/src/List.tsx
@@ -240,7 +240,7 @@ export const List: React.FC<ListProps> = ({
         <InputText
           autoFocus
           data-testid="emoji-search-input"
-          icon={<SearchIcon color="light-100" />}
+          icon={<SearchIcon />}
           onChange={debouncedHandleChangeQuery}
           onKeyDown={handleKeyDown}
           placeholder={inputSearchPlaceholder}
@@ -297,7 +297,6 @@ const EmojiRow: React.FC<EmojiRowProps> = ({ data, index, style }) => {
       <Text
         alignItems="center"
         as="span"
-        color="light-100"
         display="flex"
         px="xl"
         style={style}

--- a/packages/EmojiPicker/src/index.tsx
+++ b/packages/EmojiPicker/src/index.tsx
@@ -114,15 +114,15 @@ const EmojiPickerComponent = forwardRef<'div', EmojiPickerProps>(
       <S.Popover aria-label={popoverAriaLabel} ref={ref} state={state}>
         {hasTabs && (
           <>
-            <S.TabList aria-label={tabListAriaLabel} {...tabState}>
+            <S.TabList aria-label={tabListAriaLabel} state={tabState}>
               {tabs.map(tab => (
-                <Tab id={tab.name} key={tab.name} {...tabState}>
+                <Tab id={tab.name} key={tab.name} state={tabState}>
                   {tab.name}
                 </Tab>
               ))}
             </S.TabList>
             {tabs.map(tab => (
-              <Tab.Panel key={tab.name} tabId={tab.name} {...tabState}>
+              <Tab.Panel key={tab.name} state={tabState} tabId={tab.name}>
                 <Panel>{tab.content}</Panel>
               </Tab.Panel>
             ))}

--- a/packages/EmojiPicker/src/index.tsx
+++ b/packages/EmojiPicker/src/index.tsx
@@ -4,7 +4,7 @@ import {
   Popover,
   PopoverProps,
   usePopoverState,
-  UsePopoverStateProps,
+  UsePopoverStateOptions,
   UsePopoverStateReturn,
 } from '@welcome-ui/popover'
 import { Tab } from '@welcome-ui/tabs'
@@ -24,10 +24,10 @@ export interface EmojiPickerOptions {
   onChange?: (value: string) => void
   popoverAriaLabel?: string
   tabListAriaLabel?: string
-  value: string
+  value: string | null
 }
 
-export type EmojiPickerProps = CreateWuiProps<'div', PopoverProps & EmojiPickerOptions>
+export type EmojiPickerProps = CreateWuiProps<'div', EmojiPickerOptions & PopoverProps>
 
 const EmojiPickerComponent = forwardRef<'div', EmojiPickerProps>(
   (
@@ -40,13 +40,13 @@ const EmojiPickerComponent = forwardRef<'div', EmojiPickerProps>(
       popoverAriaLabel = 'Emoji picker',
       tabListAriaLabel = 'Emoji picker tabs',
       value,
-      ...popoverState
+      state,
     },
     ref
   ) => {
     const tabState = useTabState(defaultTabState)
 
-    const hidePopover = useMemo(() => popoverState.hide, [popoverState.hide])
+    const hidePopover = useMemo(() => state.hide, [state.hide])
     const handleChange = useCallback(
       (value: string) => {
         hidePopover()
@@ -64,7 +64,7 @@ const EmojiPickerComponent = forwardRef<'div', EmojiPickerProps>(
               // Disabling type check since missing props are injected below with the "cloneElement"
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore
-              <BasicList isVisible={popoverState.visible} onChange={handleChange} value={value} />
+              <BasicList isVisible={state.visible} onChange={handleChange} value={value} />
             ),
           },
         ]
@@ -85,8 +85,7 @@ const EmojiPickerComponent = forwardRef<'div', EmojiPickerProps>(
                 emptyList,
                 inputSearchPlaceholder,
                 isVisible:
-                  popoverState.visible &&
-                  (!tabState.selectedId || tabState.selectedId === tab.props.name),
+                  state.visible && (!tabState.selectedId || tabState.selectedId === tab.props.name),
                 onChange: handleChange,
                 value,
                 ...child.props,
@@ -104,7 +103,7 @@ const EmojiPickerComponent = forwardRef<'div', EmojiPickerProps>(
       emptyList,
       handleChange,
       inputSearchPlaceholder,
-      popoverState.visible,
+      state.visible,
       tabState.selectedId,
       value,
     ])
@@ -112,7 +111,7 @@ const EmojiPickerComponent = forwardRef<'div', EmojiPickerProps>(
     const onlyTabContent = tabs[0].content
 
     return (
-      <S.Popover aria-label={popoverAriaLabel} ref={ref} {...popoverState}>
+      <S.Popover aria-label={popoverAriaLabel} ref={ref} state={state}>
         {hasTabs && (
           <>
             <S.TabList aria-label={tabListAriaLabel} {...tabState}>
@@ -137,11 +136,12 @@ const EmojiPickerComponent = forwardRef<'div', EmojiPickerProps>(
 
 EmojiPickerComponent.displayName = 'EmojiPicker'
 
-export const useEmojiPicker: (options?: UsePopoverStateProps) => UsePopoverStateReturn = options =>
-  usePopoverState({
+export function useEmojiPicker(options?: UsePopoverStateOptions): UsePopoverStateReturn {
+  return usePopoverState({
     placement: 'bottom-start',
     ...options,
   })
+}
 
 export const EmojiPicker = Object.assign(EmojiPickerComponent, {
   Trigger: Popover.Trigger,

--- a/packages/EmojiPicker/src/styles.ts
+++ b/packages/EmojiPicker/src/styles.ts
@@ -4,12 +4,21 @@ import { Popover as WUIPopover } from '@welcome-ui/popover'
 import { Box } from '@welcome-ui/box'
 
 export const Popover = styled(WUIPopover)`
-  background-color: light-900;
+  background-color: ${th('defaultCards.backgroundColor')};
   border-width: sm;
   border-style: solid;
   border-color: border;
   color: dark-900;
   ${system};
+
+  /** we change the arrow item color from popover component */
+  > div > div > svg {
+    color: ${th('defaultCards.backgroundColor')};
+
+    #stroke {
+      color: ${th('defaultCards.borderColor')};
+    }
+  }
 `
 
 export const TabList = styled(Tab.List)`
@@ -52,6 +61,7 @@ export const Tooltip = styled(Box)`
   ${th('tooltips')};
   position: absolute;
   pointer-events: none;
+
   &:empty {
     display: none;
   }

--- a/packages/EmojiPicker/tests/index.test.tsx
+++ b/packages/EmojiPicker/tests/index.test.tsx
@@ -7,12 +7,12 @@ import { EmojiPicker, useEmojiPicker } from '../src'
 describe('<EmojiPicker>', () => {
   it('should render correctly', () => {
     const Test = () => {
-      const emojiPicker = useEmojiPicker()
+      const emojiPickerState = useEmojiPicker()
 
       return (
         <>
-          <EmojiPicker.Trigger {...emojiPicker}>open</EmojiPicker.Trigger>
-          <EmojiPicker aria-label="emoji-picker" value={null} {...emojiPicker} />
+          <EmojiPicker.Trigger state={emojiPickerState}>open</EmojiPicker.Trigger>
+          <EmojiPicker aria-label="emoji-picker" state={emojiPickerState} value={null} />
         </>
       )
     }

--- a/packages/Modal/src/Content.tsx
+++ b/packages/Modal/src/Content.tsx
@@ -33,6 +33,7 @@ export const Content = forwardRef<'div', ContentProps>(({ children, ...rest }, r
    * As Reakit doesn't handle scrolling content we have to forward the modalState to the Modal.Content
    * in order to check when the modal is visible and enable the scroll.
    * @link https://github.com/ariakit/ariakit/issues/469
+   * TODO: remove with the migration to ariakit
    */
   useEffect(() => {
     if (modalState.visible && bodyRef) {

--- a/packages/Modal/src/context.tsx
+++ b/packages/Modal/src/context.tsx
@@ -4,7 +4,7 @@ import { ModalStateReturn } from './index'
 
 type ModalProviderProps = {
   children?: ReactNode
-  modalState: ModalStateReturn
+  state: ModalStateReturn
 }
 
 export const ModalContext = createContext<ModalStateReturn>({} as ModalStateReturn)
@@ -14,10 +14,10 @@ export const ModalContext = createContext<ModalStateReturn>({} as ModalStateRetu
  * in order to check when the modal is visible and enable the scroll.
  * @link https://github.com/ariakit/ariakit/issues/469
  */
-export const ModalProvider = ({ children, modalState }: ModalProviderProps) => {
-  const state = useMemo(() => modalState, [modalState])
+export const ModalProvider = ({ children, state }: ModalProviderProps) => {
+  const modalState = useMemo(() => state, [state])
 
-  return <ModalContext.Provider value={state}>{children}</ModalContext.Provider>
+  return <ModalContext.Provider value={modalState}>{children}</ModalContext.Provider>
 }
 
 export function useModal() {

--- a/packages/Modal/src/index.tsx
+++ b/packages/Modal/src/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React from 'react'
 import {
   DialogDisclosure,

--- a/packages/Modal/tests/index.test.tsx
+++ b/packages/Modal/tests/index.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { fireEvent } from '@testing-library/react'
+
+import { render } from '../../../utils/tests'
+import { Modal, useModalState } from '../src'
+
+describe('<Modal>', () => {
+  it('should render correctly', () => {
+    const Test = () => {
+      const modalState = useModalState()
+
+      return (
+        <>
+          <Modal.Trigger state={modalState}>open</Modal.Trigger>
+          <Modal ariaLabel="modal" state={modalState}>
+            <div>Modal open</div>
+          </Modal>
+        </>
+      )
+    }
+
+    const { getByText, queryByRole } = render(<Test />)
+    expect(queryByRole('dialog')).toBeNull()
+    fireEvent.click(getByText('open'))
+    expect(queryByRole('dialog')).toHaveTextContent('Modal open')
+  })
+})

--- a/packages/Popover/src/Trigger.tsx
+++ b/packages/Popover/src/Trigger.tsx
@@ -1,69 +1,67 @@
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 import React, { useLayoutEffect, useRef } from 'react'
-import { PopoverDisclosureProps } from 'reakit/Popover'
 
 import { UsePopoverStateReturn } from './usePopoverState'
 import * as S from './styles'
 
-export type TriggerProps = CreateWuiProps<'button', PopoverDisclosureProps & UsePopoverStateReturn>
+export type TriggerProps = CreateWuiProps<'button', { state: UsePopoverStateReturn }>
 
-export const Trigger = forwardRef<'button', TriggerProps>(
-  ({ as, triggerMethod = 'click', ...rest }, ref) => {
-    const hoverable = triggerMethod === 'hover'
-    const disclosureRef = useRef<HTMLButtonElement>(null)
-    const popoverRef = rest.unstable_popoverRef
+export const Trigger = forwardRef<'button', TriggerProps>(({ as, state, ...rest }, ref) => {
+  const { triggerMethod } = state
+  const hoverable = triggerMethod === 'hover'
+  const disclosureRef = useRef<HTMLButtonElement>(null)
+  const popoverRef = state.unstable_popoverRef
 
-    const showPopover: () => void = () => {
-      if (hoverable) {
-        // remove listeners on mouseenter
-        disclosureRef.current?.removeEventListener('mouseenter', showPopover)
-        popoverRef.current?.removeEventListener('mouseenter', showPopover)
-        // add listeners on mouseleave
-        disclosureRef.current?.addEventListener('mouseleave', hidePopover)
-        popoverRef.current?.addEventListener('mouseleave', hidePopover)
-        // show popover
-        rest.show()
-      }
+  const showPopover: () => void = () => {
+    if (hoverable) {
+      // remove listeners on mouseenter
+      disclosureRef.current?.removeEventListener('mouseenter', showPopover)
+      popoverRef.current?.removeEventListener('mouseenter', showPopover)
+      // add listeners on mouseleave
+      disclosureRef.current?.addEventListener('mouseleave', hidePopover)
+      popoverRef.current?.addEventListener('mouseleave', hidePopover)
+      // show popover
+      state.show()
     }
-
-    const setRef = (triggerElement: HTMLButtonElement) => {
-      disclosureRef.current = triggerElement
-      rest.unstable_disclosureRef.current = triggerElement
-      if (typeof ref === 'function') {
-        ref(triggerElement)
-      } else if (ref?.current) {
-        ref.current = triggerElement
-      }
-    }
-
-    const hidePopover: () => void = () => {
-      if (hoverable) {
-        // remove listeners on mouseleave
-        disclosureRef.current?.removeEventListener('mouseleave', hidePopover)
-        popoverRef.current?.removeEventListener('mouseleave', hidePopover)
-        // add listeners on mouseenter
-        disclosureRef.current?.addEventListener('mouseenter', showPopover)
-        popoverRef.current?.addEventListener('mouseenter', showPopover)
-        // hide popover
-        rest.hide()
-      }
-    }
-
-    useLayoutEffect(() => {
-      const disclosure = disclosureRef.current
-      if (hoverable && disclosure) {
-        // add listeners on mount
-        disclosure.addEventListener('mouseenter', showPopover)
-        disclosure.addEventListener('mouseleave', hidePopover)
-        return () => {
-          // remove listeners on unmount
-          disclosure.removeEventListener('mouseenter', showPopover)
-          disclosure.removeEventListener('mouseleave', hidePopover)
-        }
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [disclosureRef])
-
-    return <S.PopoverTrigger {...rest} forwardedAs={as} ref={setRef} />
   }
-)
+
+  const setRef = (triggerElement: HTMLButtonElement) => {
+    disclosureRef.current = triggerElement
+    state.unstable_disclosureRef.current = triggerElement
+    if (typeof ref === 'function') {
+      ref(triggerElement)
+    } else if (ref?.current) {
+      ref.current = triggerElement
+    }
+  }
+
+  const hidePopover: () => void = () => {
+    if (hoverable) {
+      // remove listeners on mouseleave
+      disclosureRef.current?.removeEventListener('mouseleave', hidePopover)
+      popoverRef.current?.removeEventListener('mouseleave', hidePopover)
+      // add listeners on mouseenter
+      disclosureRef.current?.addEventListener('mouseenter', showPopover)
+      popoverRef.current?.addEventListener('mouseenter', showPopover)
+      // hide popover
+      state.hide()
+    }
+  }
+
+  useLayoutEffect(() => {
+    const disclosure = disclosureRef.current
+    if (hoverable && disclosure) {
+      // add listeners on mount
+      disclosure.addEventListener('mouseenter', showPopover)
+      disclosure.addEventListener('mouseleave', hidePopover)
+      return () => {
+        // remove listeners on unmount
+        disclosure.removeEventListener('mouseenter', showPopover)
+        disclosure.removeEventListener('mouseleave', hidePopover)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disclosureRef])
+
+  return <S.PopoverTrigger {...state} {...rest} forwardedAs={as} ref={setRef} />
+})

--- a/packages/Popover/src/index.tsx
+++ b/packages/Popover/src/index.tsx
@@ -3,7 +3,6 @@ import { Box } from '@welcome-ui/box'
 import { Button } from '@welcome-ui/button'
 import { CrossIcon } from '@welcome-ui/icons'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
-import { PopoverOptions as ReakitPopoverOptions } from 'reakit/Popover'
 
 import * as S from './styles'
 import { Trigger } from './Trigger'
@@ -12,49 +11,34 @@ import { UsePopoverStateReturn } from './usePopoverState'
 export interface PopoverOptions {
   /** call a function when popover closed */
   onClose?: () => void
-  /** the method to open and close the popover */
-  triggerMethod?: UsePopoverStateReturn['triggerMethod']
-  /** show or hide a close button */
-  withCloseButton?: boolean
+  state: UsePopoverStateReturn
 }
 
-export type PopoverProps = CreateWuiProps<
-  'div',
-  PopoverOptions & ReakitPopoverOptions & UsePopoverStateReturn
->
+export type PopoverProps = CreateWuiProps<'div', PopoverOptions>
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export const PopoverComponent = forwardRef<'div', PopoverProps>(
-  (
-    {
-      children,
-      onClose,
-      // catch triggerMethod for it not to appear in the dom
-      triggerMethod = 'click',
-      withCloseButton = false,
-      ...rest
-    },
-    ref
-  ) => {
+  ({ children, onClose, state, ...rest }, ref) => {
     const closePopover = () => {
       if (onClose) onClose()
-      rest?.hide()
+      state?.hide()
     }
 
+    const { placement, withCloseButton } = state
     // get the correct transform style for arrow
-    const [placement] = rest.placement.split('-')
+    const [parentPlacement] = placement.split('-')
     const transformMap: { [key: string]: string } = {
       top: 'rotateZ(180deg)',
       right: 'rotateZ(-90deg)',
       bottom: 'rotateZ(360deg)',
       left: 'rotateZ(90deg)',
     }
-    const transform = transformMap[placement]
+    const transform = transformMap[parentPlacement]
 
     return (
-      <S.Popover {...rest} $withCloseButton={withCloseButton} ref={ref}>
+      <S.Popover {...state} {...rest} $withCloseButton={withCloseButton} ref={ref}>
         <Box position="relative">
-          <S.Arrow {...rest}>
+          <S.Arrow {...state}>
             <S.ArrowItem $transform={transform} h={30} w={30} xmlns="http://www.w3.org/2000/svg">
               <path d="M6 30l9-10 9 10z" fill="currentColor" fillRule="nonzero" />
             </S.ArrowItem>
@@ -68,7 +52,7 @@ export const PopoverComponent = forwardRef<'div', PopoverProps>(
               position="absolute"
               right={1}
               shape="square"
-              size="sm"
+              size="xs"
               top={1}
               variant="secondary"
             >

--- a/packages/Popover/src/index.tsx
+++ b/packages/Popover/src/index.tsx
@@ -40,7 +40,8 @@ export const PopoverComponent = forwardRef<'div', PopoverProps>(
         <Box position="relative">
           <S.Arrow {...state}>
             <S.ArrowItem $transform={transform} h={30} w={30} xmlns="http://www.w3.org/2000/svg">
-              <path d="M6 30l9-10 9 10z" fill="currentColor" fillRule="nonzero" />
+              <path d="M7 30L15 22L23 30H7Z" fill="currentColor" fillRule="nonzero" id="stroke" />
+              <path d="M8 30L15 23L22 30H8Z" fill="currentColor" fillRule="nonzero" />
             </S.ArrowItem>
           </S.Arrow>
           {children}

--- a/packages/Popover/src/usePopoverState.ts
+++ b/packages/Popover/src/usePopoverState.ts
@@ -5,19 +5,44 @@ import {
   usePopoverState as useReakitPopoverState,
 } from 'reakit/Popover'
 
-export interface UsePopoverStateOptions {
+export interface UsePopoverStateOptions extends ReakitPopoverInitialState {
   hideTimeout?: number
   showTimeout?: number
   triggerMethod?: 'hover' | 'click'
   withCloseButton?: boolean
+  /**
+   * @deprecated
+   * will be replace by open on ariakit (reakit v2)
+   **/
+  visible?: ReakitPopoverInitialState['visible']
+  /**
+   * Open the popover on load
+   */
+  open?: ReakitPopoverInitialState['visible']
 }
 
 export type UsePopoverStateReturn = ReakitPopoverStateReturn &
-  Pick<UsePopoverStateOptions, 'triggerMethod' | 'withCloseButton'>
+  Pick<UsePopoverStateOptions, 'triggerMethod' | 'withCloseButton'> & {
+    /**
+     * @deprecated
+     * will be replace by open on ariakit (reakit v2)
+     **/
+    visible?: ReakitPopoverStateReturn['visible']
+    /**
+     * Open the popover on load
+     **/
+    open?: ReakitPopoverStateReturn['visible']
+    /**
+     * Custom hide function who call reakit hide after a timeout if is hoverable, or not
+     **/
+    hide: () => void
+    /**
+     * Custom show function who call reakit show after a timeout if is hoverable, or not
+     **/
+    show: () => void
+  }
 
-export type UsePopoverStateProps = ReakitPopoverInitialState & UsePopoverStateOptions
-
-export const usePopoverState: (props?: UsePopoverStateProps) => UsePopoverStateReturn = ({
+export const usePopoverState: (props?: UsePopoverStateOptions) => UsePopoverStateReturn = ({
   animated = 150,
   hideTimeout = 300,
   showTimeout = 500,
@@ -25,7 +50,12 @@ export const usePopoverState: (props?: UsePopoverStateProps) => UsePopoverStateR
   withCloseButton = false,
   ...options
 } = {}) => {
-  const popover = useReakitPopoverState({ animated, ...options })
+  const { open, visible } = options
+  const popover = useReakitPopoverState({
+    animated,
+    visible: visible || open,
+    ...options,
+  })
   const closeCountdownRef = useRef<NodeJS.Timeout>()
   const openCountdownRef = useRef<NodeJS.Timeout>()
   const isHoverable = triggerMethod === 'hover'
@@ -54,6 +84,7 @@ export const usePopoverState: (props?: UsePopoverStateProps) => UsePopoverStateR
 
   return {
     ...popover,
+    open: popover.visible,
     hide,
     show,
     triggerMethod,

--- a/packages/Popover/tests/index.test.tsx
+++ b/packages/Popover/tests/index.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { fireEvent } from '@testing-library/react'
+
+import { render } from '../../../utils/tests'
+import { Popover, usePopoverState } from '../src'
+
+describe('<Popover>', () => {
+  it('should render correctly', () => {
+    const Test = () => {
+      const popoverState = usePopoverState()
+
+      return (
+        <>
+          <Popover.Trigger state={popoverState}>open</Popover.Trigger>
+          <Popover aria-label="popover" state={popoverState}>
+            Popover open
+          </Popover>
+        </>
+      )
+    }
+
+    const { getByText, queryByRole } = render(<Test />)
+    expect(queryByRole('dialog')).toBeNull()
+    fireEvent.click(getByText('open'))
+    expect(queryByRole('dialog')).toHaveTextContent('Popover open')
+  })
+})

--- a/packages/Swiper/tests/index.test.tsx
+++ b/packages/Swiper/tests/index.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/extend-expect'

--- a/packages/Tabs/src/TabList.tsx
+++ b/packages/Tabs/src/TabList.tsx
@@ -1,9 +1,5 @@
 import React, { cloneElement, useRef, useState } from 'react'
-import {
-  TabList as ReakitTabList,
-  TabListOptions as ReakitTabListOptions,
-  TabStateReturn,
-} from 'reakit/Tab'
+import { TabList as ReakitTabList, TabStateReturn } from 'reakit/Tab'
 import flattenChildren from 'react-flatten-children'
 import { useForkRef } from '@welcome-ui/utils'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
@@ -30,32 +26,40 @@ export interface SizeOptions {
   size?: 'sm' | 'md'
 }
 
-export type TabListOptions = Pick<TabStateReturn, 'orientation' | 'selectedId'> &
-  ReakitTabListOptions &
-  SizeOptions
+export type TabListOptions = SizeOptions & {
+  state: Pick<TabStateReturn, 'orientation' | 'selectedId'>
+}
 export type TabListProps = CreateWuiProps<'div', TabListOptions>
 
 /**
  * @name Tabs.TabList
  */
-export const TabList = forwardRef<'div', TabListProps>((props, ref) => {
-  const { as, children, orientation, size = 'md', ...rest } = props
-  const listRef = useRef()
-  const listForkedRef = useForkRef(ref, listRef)
-  const [tabs, activeTab] = useTrackActiveTabs({ selectedId: rest.selectedId }, children)
+export const TabList = forwardRef<'div', TabListProps>(
+  ({ as, children, size = 'md', state = {}, ...rest }, ref) => {
+    const listRef = useRef()
+    const listForkedRef = useForkRef(ref, listRef)
+    const { orientation } = state
+    const [tabs, activeTab] = useTrackActiveTabs({ selectedId: state.selectedId }, children)
 
-  return (
-    <ReakitTabList as={undefined} orientation={orientation} ref={listForkedRef} {...rest}>
-      {tabListProps => (
-        <S.TabList as={as} {...tabListProps} size={size}>
-          {tabs}
-          {tabs.length > 1 && (
-            <ActiveBar activeTab={activeTab} listRef={listRef} orientation={orientation} />
-          )}
-        </S.TabList>
-      )}
-    </ReakitTabList>
-  )
-})
+    return (
+      <ReakitTabList
+        as={undefined}
+        orientation={orientation}
+        ref={listForkedRef}
+        {...state}
+        {...rest}
+      >
+        {tabListProps => (
+          <S.TabList as={as} {...tabListProps} size={size}>
+            {tabs}
+            {tabs.length > 1 && (
+              <ActiveBar activeTab={activeTab} listRef={listRef} orientation={orientation} />
+            )}
+          </S.TabList>
+        )}
+      </ReakitTabList>
+    )
+  }
+)
 
 TabList.displayName = 'TabList'

--- a/packages/Tabs/src/TabPanel.tsx
+++ b/packages/Tabs/src/TabPanel.tsx
@@ -1,31 +1,27 @@
 import React from 'react'
-import {
-  TabPanel as ReakitTabPanel,
-  TabPanelOptions as ReakitTabPanelOptions,
-  TabStateReturn,
-} from 'reakit/Tab'
+import { TabPanel as ReakitTabPanel, TabStateReturn } from 'reakit/Tab'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 
 import * as S from './styles'
 
-export type TabPanelOptions = Pick<TabStateReturn, 'orientation'> & ReakitTabPanelOptions
+export type TabPanelOptions = { state: TabStateReturn }
 export type TabPanelProps = CreateWuiProps<typeof ReakitTabPanel, TabPanelOptions>
 
 /**
  * @name Tabs.TabPanel
  */
-export const TabPanel = forwardRef<'div', TabPanelProps>((props, ref) => {
-  const { as, children, orientation, tabId, ...rest } = props
-
-  return (
-    <ReakitTabPanel as={undefined} ref={ref} tabId={tabId} {...rest}>
-      {tabPanelProps => (
-        <S.TabPanel as={as} orientation={orientation} {...tabPanelProps}>
-          {children}
-        </S.TabPanel>
-      )}
-    </ReakitTabPanel>
-  )
-})
+export const TabPanel = forwardRef<'div', TabPanelProps>(
+  ({ as, children, state, tabId, ...rest }, ref) => {
+    return (
+      <ReakitTabPanel as={undefined} ref={ref} tabId={tabId} {...state} {...rest}>
+        {tabPanelProps => (
+          <S.TabPanel as={as} orientation={state?.orientation} {...tabPanelProps}>
+            {children}
+          </S.TabPanel>
+        )}
+      </ReakitTabPanel>
+    )
+  }
+)
 
 TabPanel.displayName = 'TabPanel'

--- a/packages/Tabs/src/index.tsx
+++ b/packages/Tabs/src/index.tsx
@@ -6,23 +6,25 @@ import { TabList } from './TabList'
 import { TabPanel } from './TabPanel'
 import * as S from './styles'
 
-export type TabOptions = ReakitTabOptions
+export type TabOptions = { state: ReakitTabOptions }
 export type TabProps = CreateWuiProps<'button', TabOptions>
 
 /**
  * @name Tabs
  */
-export const TabComponent = forwardRef<'button', TabProps>(({ as, children, id, ...rest }, ref) => {
-  return (
-    <ReakitTab as={undefined} id={id} ref={ref} {...rest}>
-      {tabProps => (
-        <S.Tab as={as} {...tabProps}>
-          {children}
-        </S.Tab>
-      )}
-    </ReakitTab>
-  )
-})
+export const TabComponent = forwardRef<'button', TabProps>(
+  ({ as, children, id, state, ...rest }, ref) => {
+    return (
+      <ReakitTab as={undefined} id={id} ref={ref} {...state} {...rest}>
+        {tabProps => (
+          <S.Tab as={as} {...tabProps}>
+            {children}
+          </S.Tab>
+        )}
+      </ReakitTab>
+    )
+  }
+)
 
 TabComponent.displayName = 'Tab'
 

--- a/packages/Tabs/tests/index.test.tsx
+++ b/packages/Tabs/tests/index.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 

--- a/packages/Tabs/tests/index.test.tsx
+++ b/packages/Tabs/tests/index.test.tsx
@@ -13,27 +13,27 @@ function getActiveBar({ getByRole }: { getByRole: (id: string) => HTMLElement })
 describe('Tabs', () => {
   it('renders an accessible structure', async () => {
     const Tabs = () => {
-      const tab = useTabState({ selectedId: 'tab1' })
+      const tabState = useTabState({ selectedId: 'tab1' })
       return (
         <>
-          <Tab.List aria-label="Tabs" {...tab}>
-            <Tab data-testid="tab1" id="tab1" {...tab}>
+          <Tab.List aria-label="Tabs" state={tabState}>
+            <Tab data-testid="tab1" id="tab1" state={tabState}>
               Tab 1
             </Tab>
-            <Tab data-testid="tab2" id="tab2" {...tab}>
+            <Tab data-testid="tab2" id="tab2" state={tabState}>
               Tab 2
             </Tab>
-            <Tab data-testid="tab3" disabled id="tab3" {...tab}>
+            <Tab data-testid="tab3" disabled id="tab3" state={tabState}>
               Tab 3
             </Tab>
           </Tab.List>
-          <Tab.Panel data-testid="panel1" tabId="tab1" {...tab}>
+          <Tab.Panel data-testid="panel1" state={tabState} tabId="tab1">
             Panel 1
           </Tab.Panel>
-          <Tab.Panel data-testid="panel2" tabId="tab2" {...tab}>
+          <Tab.Panel data-testid="panel2" state={tabState} tabId="tab2">
             Panel 2
           </Tab.Panel>
-          <Tab.Panel data-testid="panel3" tabId="tab3" {...tab}>
+          <Tab.Panel data-testid="panel3" state={tabState} tabId="tab3">
             Panel 3
           </Tab.Panel>
         </>
@@ -81,15 +81,15 @@ describe('Tabs', () => {
   describe('with one tab', () => {
     it('does not render active bar', () => {
       const Tabs = () => {
-        const tab = useTabState({ selectedId: 'tab1' })
+        const tabState = useTabState({ selectedId: 'tab1' })
         return (
           <>
-            <Tab.List aria-label="Tabs" {...tab}>
-              <Tab id="tab1" {...tab}>
+            <Tab.List aria-label="Tabs" state={tabState}>
+              <Tab id="tab1" state={tabState}>
                 Tab 1
               </Tab>
             </Tab.List>
-            <Tab.Panel tabId="tab1" {...tab}>
+            <Tab.Panel state={tabState} tabId="tab1">
               Panel 1
             </Tab.Panel>
           </>


### PR DESCRIPTION
Fixes #1913 

We need to prepare the migration to [ariakit](https://ariakit.org) (reakit v2), and this migration contains some breaking changes.
We don't want create a version 6 of WUI with the breaking changes when ariakit will be a release candidate (now is on alpha), so we take the lead and anticipate the breaking changes on the V5.

What we changed:
- now the state from a reakit state is not destructured on the component
```jsx
const tabState = useTabState()

<Tab.List state={tabState}>
  <Tab state={tabState}>
    ...
  </Tab>
</Tab.List>
<Tab.Panel state={tabState}>
  ...
</Tab.Panel>
```
- we deprecated the `visible` option, it's replace by the `open` option. _**It will be removed when we add ariakit on WUI**, so please changed now visible property to open if you use it :)_
```jsx
const modalState = useModalState({ open: true })

const { open } = modalState
```


Which components are impacted?
- Accordion
- Drawer
- DropdownMenu
- EmojiPicker
- Modal
- Popover
- Tab 