### PR TITLE
fix: tooltip children without wrapper

### DIFF
--- a/docs/pages/components/tooltip.mdx
+++ b/docs/pages/components/tooltip.mdx
@@ -46,6 +46,18 @@ Set a `max-width` for long text
 </Tooltip>
 ```
 
+## With a disabled button
+
+You should wrap the disabled button with an element.
+
+```jsx
+<Tooltip placement="bottom-start" content="Tooltip">
+  <div>
+    <Button disabled>Disabled Button</Button>
+  </div>
+</Tooltip>
+```
+
 ## With a fixed position
 
 Using the `fixed` prop in combination with `placement` will enable a translate animation on your tooltip. The direction works with these values for `placement`.

--- a/docs/pages/components/tooltip.mdx
+++ b/docs/pages/components/tooltip.mdx
@@ -48,13 +48,11 @@ Set a `max-width` for long text
 
 ## With a disabled button
 
-You should wrap the disabled button with an element.
+We're adding a wrapper around the button when it's disabled otherwise the tooltip does not trigger.
 
 ```jsx
 <Tooltip placement="bottom-start" content="Tooltip">
-  <div>
-    <Button disabled>Disabled Button</Button>
-  </div>
+  <Button disabled>Disabled Button</Button>
 </Tooltip>
 ```
 

--- a/docs/pages/upgrade.mdx
+++ b/docs/pages/upgrade.mdx
@@ -168,6 +168,10 @@ We renamed some icons:
 - `<DuplicateIcon>` become `<CopyIcon>`
 - `<TagsIcon>` become `<TagIcon>`
 
+### Tooltip
+
+We added a div around the Children of the tooltip when the children has a disabled prop otherwise the tooltip does not trigger.
+
 ### Swiper
 
 We rework the swiper component:

--- a/docs/pages/upgrade.mdx
+++ b/docs/pages/upgrade.mdx
@@ -168,10 +168,6 @@ We renamed some icons:
 - `<DuplicateIcon>` become `<CopyIcon>`
 - `<TagsIcon>` become `<TagIcon>`
 
-### Tooltip
-
-We added a div around the Children of the tooltip to prevent the following behavior : the tooltip would not be triggered if the Children was a disabled button.
-
 ### Swiper
 
 We rework the swiper component:

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -37,6 +37,7 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
+    "@welcome-ui/box": "^5.0.0-alpha.21",
     "@welcome-ui/system": "^5.0.0-alpha.21",
     "popper.js": "^1.16.1",
     "reakit": "^1.3.11"

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -37,7 +37,6 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "@welcome-ui/box": "^5.0.0-alpha.21",
     "@welcome-ui/system": "^5.0.0-alpha.21",
     "popper.js": "^1.16.1",
     "reakit": "^1.3.11"

--- a/packages/Tooltip/src/index.tsx
+++ b/packages/Tooltip/src/index.tsx
@@ -10,6 +10,7 @@ import Popper, { Placement } from 'popper.js'
 import { TooltipReference, useTooltipState } from 'reakit/Tooltip'
 import { useDialogState } from 'reakit/Dialog'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
+import { Box } from '@welcome-ui/box'
 
 import * as S from './styles'
 
@@ -138,10 +139,14 @@ export const Tooltip = forwardRef<'div', TooltipProps>((props, ref): React.React
     return children as React.ReactElement
   }
 
+  const child = (children as JSX.Element)?.props?.disabled
+    ? React.Children.only(<Box display="inline-block">{children}</Box>)
+    : children
+
   return (
     <>
       <TooltipReference as={undefined} {...tooltip}>
-        {referenceProps => cloneElement(children as JSX.Element, referenceProps)}
+        {referenceProps => cloneElement(child as JSX.Element, referenceProps)}
       </TooltipReference>
 
       <S.Tooltip ref={ref} {...tooltip} {...rest}>

--- a/packages/Tooltip/src/index.tsx
+++ b/packages/Tooltip/src/index.tsx
@@ -10,7 +10,6 @@ import Popper, { Placement } from 'popper.js'
 import { TooltipReference, useTooltipState } from 'reakit/Tooltip'
 import { useDialogState } from 'reakit/Dialog'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
-import { Box } from '@welcome-ui/box'
 
 import * as S from './styles'
 
@@ -139,14 +138,10 @@ export const Tooltip = forwardRef<'div', TooltipProps>((props, ref): React.React
     return children as React.ReactElement
   }
 
-  const child = React.Children.only(
-    <Box display="inline-block">{children}</Box>
-  ) as React.ReactElement
-
   return (
     <>
       <TooltipReference as={undefined} {...tooltip}>
-        {referenceProps => cloneElement(child, referenceProps)}
+        {referenceProps => cloneElement(children as JSX.Element, referenceProps)}
       </TooltipReference>
 
       <S.Tooltip ref={ref} {...tooltip} {...rest}>


### PR DESCRIPTION
Here, the `tabIndex` is injected into the wrapper of the child instead of the child. We must remove this wrapper.

Before:
<img width="646" alt="Capture d’écran 2023-03-02 à 11 31 20" src="https://user-images.githubusercontent.com/36373219/222403316-693e29e7-2504-4282-aab9-cdf80cc44fc1.png">

After:

<img width="646" alt="Capture d’écran 2023-03-02 à 11 33 00" src="https://user-images.githubusercontent.com/36373219/222403696-d5219542-e219-4105-843e-0611ea293127.png">

cf [reakit doc](https://reakit.io/docs/tooltip/#abstracting)

We added a div around the Children of the tooltip when the children has a disabled prop otherwise the tooltip does not trigger.
