### PR TITLE
fix: dropdown-menu item type

### DIFF
--- a/packages/DropdownMenu/src/Item.tsx
+++ b/packages/DropdownMenu/src/Item.tsx
@@ -6,10 +6,10 @@ import * as S from './Item.styled'
 
 import { DropdownMenuOptions } from '.'
 
-export type ItemProps = CreateWuiProps<
-  'button',
-  MenuItemProps & { state: DropdownMenuOptions['state'] }
->
+type ItemOptions = Pick<DropdownMenuOptions, 'state'> &
+  Omit<MenuItemProps, keyof DropdownMenuOptions['state']>
+
+export type ItemProps = CreateWuiProps<'button', ItemOptions>
 
 export const Item = forwardRef<'button', ItemProps>(({ as, children, state, ...rest }, ref) => {
   return (


### PR DESCRIPTION
After upgrading to 5.0.0-alpha.22, we need to pass the props `state` and `{...state}`

```tsx
<DropdownMenu.Item {...menu} state={menu} />
```

We must remove `{...state}` on declaration