### PR TITLE
fix: missing system on shape

### DIFF
--- a/packages/Shape/src/styles.ts
+++ b/packages/Shape/src/styles.ts
@@ -17,7 +17,6 @@ export const Shape = styled(Box)<ShapeOptions>(
     display: flex;
     align-items: center;
     justify-content: center;
-    ${shape && shapeStyles(w as string, h as string, shape)}
 
     img {
       object-fit: cover;
@@ -27,5 +26,8 @@ export const Shape = styled(Box)<ShapeOptions>(
     }
 
     ${system};
+
+    /* we must override shapeStyles (let this line under ${system}) */
+    ${shape && shapeStyles(w as string, h as string, shape)}
   `
 )

--- a/packages/Shape/src/styles.ts
+++ b/packages/Shape/src/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css } from '@xstyled/styled-components'
+import styled, { css, system } from '@xstyled/styled-components'
 import { getMax } from '@welcome-ui/utils'
 import { Box } from '@welcome-ui/box'
 
@@ -25,5 +25,7 @@ export const Shape = styled(Box)<ShapeOptions>(
       width: 100%;
       height: 100%;
     }
+
+    ${system};
   `
 )


### PR DESCRIPTION
`<Shape position="absolute" />` doesn't work without `system` inside the styled component.