### PR TITLE
fix: deactivate swiper scroll animation on first render

### DIFF
--- a/packages/Swiper/src/index.tsx
+++ b/packages/Swiper/src/index.tsx
@@ -136,14 +136,15 @@ export const Swiper = ({
   }, 100)
 
   const goTo = useCallback(
-    (page: number) => {
+    (page: number, isFirstInit = false) => {
       const sliderContainer = ref?.current
       const childWidth = sliderContainer?.children?.[0]?.getBoundingClientRect()?.width
 
       sliderContainer?.scrollTo({
         left: page * (childWidth + spaceBetween) * currentSlidesPerView,
         top: 0,
-        behavior: 'smooth',
+        // We don't want to have a scroll effect when we first render the swiper
+        behavior: !isFirstInit ? 'smooth' : 'auto',
       })
     },
     [currentSlidesPerView, spaceBetween]
@@ -206,7 +207,7 @@ export const Swiper = ({
   }, [getCurrentSlidesPerView, viewportWidth])
 
   useEffect(() => {
-    goTo(firstPageToShow)
+    goTo(firstPageToShow, true)
     getArrowStates()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
Related issue: https://github.com/WTTJ/welcome-ui/issues/1999

https://user-images.githubusercontent.com/19819523/223984497-c24b4cef-295a-4655-8f4d-e5ec54db5dc3.mov

