### PR TITLE
chore: upgrade-packages-next script

### DIFF
--- a/scripts/upgrade-packages-next.js
+++ b/scripts/upgrade-packages-next.js
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+// This script will help you to upgrade Welcome-UI packages still in prerelease
+// node ./scripts/upgrade-packages-next.js "../your-project/package.json"
+const { execSync } = require('child_process')
+const path = require('path')
+const fs = require('fs')
+
+const [packageJsonPath = ''] = process.argv.slice(2)
+const packageJsonPathResolved = path.resolve(packageJsonPath)
+
+const packageJson = require(packageJsonPathResolved)
+const { dependencies } = packageJson
+
+const wuiDeps = Object.keys(dependencies).filter(dep => dep.startsWith('@welcome-ui'))
+
+wuiDeps.forEach(package => {
+  const currentVersion = dependencies[package]
+  const { data } = JSON.parse(execSync(`yarn info ${package}@next --json`).toString())
+
+  const nextVersion = data['dist-tags'].next
+  dependencies[package] = nextVersion || currentVersion
+})
+
+fs.writeFileSync(packageJsonPathResolved, JSON.stringify(packageJson, 0, 2))

--- a/scripts/upgrade-v5.js
+++ b/scripts/upgrade-v5.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // This script will help you to migrate from Welcome-UI v4 to Welcome-UI v5
-// node ./scripts/upgrade-v5.js "../your-projets/src/**/**.**(ts|tsx)"
+// node ./scripts/upgrade-v5.js "../your-project/src/**/**.**(ts|tsx)"
 const fs = require('fs/promises')
 
 const glob = require('glob')


### PR DESCRIPTION
Unfortunately, `yarn upgrade-interactive --latest` does not work with the prerelease versions...
It is very boring to upgrade welcome-ui v5 (still in alpha), this script should help 🤗 

After the script:
<img width="1242" alt="image" src="https://user-images.githubusercontent.com/36373219/225583907-e998165c-25fe-4870-b9b7-26fdbb5bbb62.png">

(don't forget to run a `yarn install` after running this script)