### PR TITLE
Allow falsy children in <ButtonGroup>, fixes #1705

### DIFF
--- a/packages/ButtonGroup/src/index.tsx
+++ b/packages/ButtonGroup/src/index.tsx
@@ -4,7 +4,8 @@ import { Button, ButtonProps, Size, Variant } from '@welcome-ui/button'
 
 import * as S from './styles'
 
-type ChildrenProps = React.ReactElement<typeof Button> | React.ReactElement<typeof Button>[]
+type ChildType = React.ReactElement<typeof Button> | null | undefined | boolean
+type ChildrenProps = ChildType | ChildType[]
 
 export interface ButtonGroupOptions {
   children: ChildrenProps

--- a/packages/ButtonGroup/tests/index.test.tsx
+++ b/packages/ButtonGroup/tests/index.test.tsx
@@ -9,8 +9,11 @@ describe('<ButtonGroup>', () => {
     const { getByTestId } = render(
       <ButtonGroup dataTestId="group">
         <Button>One</Button>
+        {null}
         <Button>Two</Button>
+        {false}
         <Button>Tree</Button>
+        {undefined}
       </ButtonGroup>
     )
     const group = getByTestId('group')


### PR DESCRIPTION
The goal of this PR is to allow us to write something like this:

```jsx
<ButtonGroup>
  <Button>Foo</Button>
  {hasBar && <Button>Bar</Button>}
</ButtonGroup>
```

instead of:

```jsx
{hasBar && (
  <ButtonGroup>
    <Button>Foo</Button>
    <Button>Bar</Button>
  </ButtonGroup>
)}
{!hasBar && (
  <Button>Foo</Button>
)}
```

We already filter falsy values out here: https://github.com/WTTJ/welcome-ui/blob/master/packages/ButtonGroup/src/index.tsx#L23