### PR TITLE
Fix: prevent currentPage from being a float

### DIFF
--- a/packages/Swiper/src/index.tsx
+++ b/packages/Swiper/src/index.tsx
@@ -191,7 +191,7 @@ export const Swiper = ({ children, dataTestId, state, ...rest }: SwiperProps) =>
       const isLastPage = !(scrollWidth - (scrollLeft + offsetWidth) > spaceBetween)
       const nextPage = isLastPage
         ? bullets.length - 1
-        : scrollLeft / Math.round((childWidth + spaceBetween) * currentSlidesPerView)
+        : Math.round((scrollLeft / (childWidth + spaceBetween)) * currentSlidesPerView)
 
       if (nextPage !== currentPage) {
         setCurrentPage(nextPage)


### PR DESCRIPTION
Moved `Math.round` to round the operation result instead of only the divisor. 
Could break the loop if currentPage is not an integer on the last slide. 

For exemple : 
- I have 6 slides 
- currentPage = the scrolled amount of pixel divided by the amount of slide
- On the last slide, the 6th, currentPage could be equal to 5,9999
- As currentPage < 6, the swiper believes there is still a slide
- Next button is still displayed, but doesn't do anything as there is nowhere to scroll 
- If loop is true, loop won't work either