### PR TITLE
Fix: rounding of swiper's nextPage calculation

### DIFF
--- a/packages/Swiper/src/index.tsx
+++ b/packages/Swiper/src/index.tsx
@@ -189,9 +189,10 @@ export const Swiper = ({ children, dataTestId, state, ...rest }: SwiperProps) =>
       const childWidth = children?.[0]?.getBoundingClientRect()?.width
 
       const isLastPage = !(scrollWidth - (scrollLeft + offsetWidth) > spaceBetween)
+
       const nextPage = isLastPage
         ? bullets.length - 1
-        : Math.round((scrollLeft / (childWidth + spaceBetween)) * currentSlidesPerView)
+        : Math.round(scrollLeft / ((childWidth + spaceBetween) * currentSlidesPerView))
 
       if (nextPage !== currentPage) {
         setCurrentPage(nextPage)


### PR DESCRIPTION
The recently applied fix: https://github.com/WTTJ/welcome-ui/pull/2052/files passed manual testing on simple configured swipers but it introduced a bug on swipers with multiple slides per view and at least 3 pages. 

Fix: properly round the whole result of nextPage's calculation. 

https://github.com/WTTJ/welcome-ui/assets/85453899/26fdec4c-d117-4569-8db5-d915ef7dbc03

