### PR TITLE
fix: slider when useReset is used in WuiProvider

### DIFF
--- a/packages/Slider/src/Range.tsx
+++ b/packages/Slider/src/Range.tsx
@@ -220,7 +220,7 @@ export const Range = forwardRef<'div', RangeProps>(
               <Box>{min}</Box>
             ))}
 
-          <Box position="relative" w="100%">
+          <Box flexGrow="1" position="relative">
             {tooltip && (
               <>
                 <S.Output isVisible={tooltipMinVisible} ref={tooltipMinRef}>

--- a/packages/Slider/src/index.tsx
+++ b/packages/Slider/src/index.tsx
@@ -150,23 +150,20 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
               <Box>{min}</Box>
             ))}
 
-          <Box display="flex" h={20} position="relative" w="100%">
+          <Box display="flex" flexGrow="1" h={20} position="relative">
             <S.Slider
               borderSelectorColor={borderSelectorColor}
               disabled={disabled}
               list="tickmarks"
               max={max}
               min={min}
-              onChange={
-                (e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = parseInt(e.target.value, 10)
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                const value = parseInt(e.target.value, 10)
 
-                  // No use of the OnChange here to avoid calls at each value update
-                  _setLocalValue(value)
-                  setInputValue(value)
-                }
-                // eslint-disable-next-line prettier/prettier
-                }      
+                // No use of the OnChange here to avoid calls at each value update
+                _setLocalValue(value)
+                setInputValue(value)
+              }}
               onKeyDown={handleKeyDown}
               onMouseDown={() => {
                 tooltip && tooltipVisible === false && setTooltipVisible(true)


### PR DESCRIPTION
This PR fixes a bug when the `<Slider>` component is used with `useReset` on `<WuiProvider>`.

Before:
![image](https://github.com/WTTJ/welcome-ui/assets/243189/a2d3f597-8803-44dc-8323-4697b0da7b8a)

After:
![image](https://github.com/WTTJ/welcome-ui/assets/243189/d48451ee-a4c4-4776-9d2f-b16a0c7a723b)
