### PR TITLE
fix(avatar): getInitials break words with accent

### DIFF
--- a/packages/Avatar/src/utils.ts
+++ b/packages/Avatar/src/utils.ts
@@ -8,9 +8,8 @@ export function getSeededColor(colors: Theme['colors'], seed = ''): string {
   return colors[colorsIndex]
 }
 
-export function getInitials(name: string): string {
-  const formattedName = name && name.replace(/\W+/gm, ' ')
-  const [firstWord, lastWord] = formattedName.split(' ')
+export function getInitials(name = ''): string {
+  const [firstWord, lastWord] = name.split(' ')
 
   if (firstWord && lastWord) {
     return `${firstWord.charAt(0).toUpperCase()}${lastWord.charAt(0).toUpperCase()}`

--- a/packages/Avatar/tests/index.test.tsx
+++ b/packages/Avatar/tests/index.test.tsx
@@ -22,4 +22,10 @@ describe('<Avatar>', () => {
     expect(container).toHaveTextContent('WE')
     expect(container).not.toHaveTextContent('WJ')
   })
+
+  it('should render without image and 2 words with accent', () => {
+    const { container } = render(<Avatar name="welcème jungle" />)
+
+    expect(container).toHaveTextContent('WJ')
+  })
 })


### PR DESCRIPTION
Current behavior:

```jsx
<Avatar name="Welcème Jungle" src={null} />
// initials "WM"
```

Desired behavior:
```jsx
<Avatar name="Welcème Jungle" src={null} />
// initials "WJ"
```