### PR TITLE
fix: forward ref warnings

### DIFF
--- a/packages/Breadcrumb/src/Item.tsx
+++ b/packages/Breadcrumb/src/Item.tsx
@@ -16,7 +16,7 @@ export type ItemProps = CreateWuiProps<'a', ItemOptions>
  * @name Breadcrumb.Item
  */
 export const Item = forwardRef<'a', ItemProps>(
-  ({ children, dataTestId, isActive, separator, ...rest }) => {
+  ({ children, dataTestId, isActive, separator, ...rest }, ref) => {
     return (
       <Box
         aria-label="breadcrumb"
@@ -26,7 +26,12 @@ export const Item = forwardRef<'a', ItemProps>(
         flex="0 0 auto"
       >
         {separator && <S.Separator role="presentation">{separator}</S.Separator>}
-        <S.Item aria-current={isActive ? 'page' : undefined} isActive={isActive} {...rest}>
+        <S.Item
+          aria-current={isActive ? 'page' : undefined}
+          isActive={isActive}
+          {...rest}
+          ref={ref}
+        >
           {children}
         </S.Item>
       </Box>

--- a/packages/Slider/src/Range.tsx
+++ b/packages/Slider/src/Range.tsx
@@ -39,21 +39,24 @@ const ensureMax = (value: number, toCompare: number, step: number) =>
  * @name Slider.Range
  */
 export const Range = forwardRef<'div', RangeProps>(
-  ({
-    borderSelectorColor = 'light-900',
-    disabled,
-    hint,
-    label,
-    max,
-    min,
-    onChange,
-    step = 1,
-    tooltip,
-    type,
-    value,
-    values,
-    ...restProps
-  }) => {
+  (
+    {
+      borderSelectorColor = 'light-900',
+      disabled,
+      hint,
+      label,
+      max,
+      min,
+      onChange,
+      step = 1,
+      tooltip,
+      type,
+      value,
+      values,
+      ...restProps
+    },
+    ref
+  ) => {
     const [minValue, setMinValue] = useState(min)
     const [maxValue, setMaxValue] = useState(max)
     const [inputMinValue, setInputMinValue] = useState<number>(max)
@@ -183,7 +186,7 @@ export const Range = forwardRef<'div', RangeProps>(
     }, [value])
 
     return (
-      <Box position="relative" w="100%">
+      <Box position="relative" ref={ref} w="100%">
         {label && (
           <Text as="label" variant="sm">
             {label}

--- a/packages/Slider/src/index.tsx
+++ b/packages/Slider/src/index.tsx
@@ -38,21 +38,24 @@ export const ensureMinMax = (value: number, min: number, max: number, step: numb
 }
 
 export const SliderComponent = forwardRef<'div', SliderProps>(
-  ({
-    borderSelectorColor = 'light-900',
-    disabled,
-    hint,
-    label,
-    max,
-    min,
-    onChange,
-    step = 1,
-    tooltip,
-    type,
-    value,
-    values,
-    ...rest
-  }) => {
+  (
+    {
+      borderSelectorColor = 'light-900',
+      disabled,
+      hint,
+      label,
+      max,
+      min,
+      onChange,
+      step = 1,
+      tooltip,
+      type,
+      value,
+      values,
+      ...rest
+    },
+    ref
+  ) => {
     const range = useRef<HTMLInputElement>(null)
     const tooltipRef = useRef<HTMLOutputElement>(null)
     const [tooltipVisible, setTooltipVisible] = useState<boolean>(false)
@@ -127,7 +130,7 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
     }, [value])
 
     return (
-      <Box display="flex" flexDirection="column" position="relative">
+      <Box display="flex" flexDirection="column" position="relative" ref={ref}>
         {label && (
           <Text as="label" variant="sm">
             {label}


### PR DESCRIPTION
fix this warning in the browser console
`Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?`