### PR TITLE
fix Breadcrumb: remove  vertical scroll

### DIFF
--- a/packages/Breadcrumb/src/Item.tsx
+++ b/packages/Breadcrumb/src/Item.tsx
@@ -24,6 +24,7 @@ export const Item = forwardRef<'a', ItemProps>(
         data-testid={dataTestId}
         display="inline-flex"
         flex="0 0 auto"
+        lineHeight="normal"
       >
         {separator && <S.Separator role="presentation">{separator}</S.Separator>}
         <S.Item

--- a/packages/Breadcrumb/src/styles.ts
+++ b/packages/Breadcrumb/src/styles.ts
@@ -45,7 +45,6 @@ export const List = styled.ol`
   max-width: 100%;
   height: 100%;
   overflow-x: auto;
-  overflow-y: hidden;
   margin: 0;
   padding: 0;
   list-style: none;

--- a/packages/Breadcrumb/src/styles.ts
+++ b/packages/Breadcrumb/src/styles.ts
@@ -45,6 +45,7 @@ export const List = styled.ol`
   max-width: 100%;
   height: 100%;
   overflow-x: auto;
+  overflow-y: hidden;
   margin: 0;
   padding: 0;
   list-style: none;


### PR DESCRIPTION
<img width="354" alt="Capture d’écran 2023-06-20 à 16 17 40" src="https://github.com/WTTJ/welcome-ui/assets/33298885/b7319ff7-9764-4355-b619-978e09ab27dc">

https://github.com/WTTJ/welcome-ui/assets/33298885/619a4e60-fd7c-4b78-8382-4d729a065496

