### PR TITLE
fix: remove & override "as" prop (ariakit)

### DIFF
--- a/packages/DropdownMenu/src/Item.tsx
+++ b/packages/DropdownMenu/src/Item.tsx
@@ -4,7 +4,7 @@ import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 
 import * as S from './Item.styled'
 
-export type ItemProps = CreateWuiProps<'button', Ariakit.MenuItemProps>
+export type ItemProps = CreateWuiProps<'button', Omit<Ariakit.MenuItemProps, 'as'>>
 
 export const Item = forwardRef<'button', ItemProps>(({ as, ...rest }, ref) => {
   return <Ariakit.MenuItem ref={ref} type="button" {...rest} render={<S.Item as={as} />} />

--- a/packages/DropdownMenu/src/index.tsx
+++ b/packages/DropdownMenu/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import * as Ariakit from '@ariakit/react'
-import { As, CreateWuiProps, forwardRef, WuiProps } from '@welcome-ui/system'
+import { CreateWuiProps, forwardRef, WuiProps } from '@welcome-ui/system'
 
 import { Arrow } from './Arrow'
 import { Item } from './Item'
@@ -52,7 +52,8 @@ export function useDropdownMenu(options: UseDropdownMenuProps = {}): UseDropdown
   return dropdownMenu
 }
 
-type TriggerProps = { store: UseDropdownMenu; children: React.ReactNode; as?: As }
+type TriggerOptions = { store: UseDropdownMenu }
+type TriggerProps = CreateWuiProps<'button', TriggerOptions>
 
 export const Trigger = forwardRef<'button', TriggerProps>(({ as, store, ...rest }, ref) => {
   return <Ariakit.MenuButton as={as} ref={ref} store={store} {...rest} />


### PR DESCRIPTION
The `as` prop is deprecated on Ariakit but we want to use the Welcome-UI `as` prop 👀 
<img width="347" alt="image" src="https://github.com/WTTJ/welcome-ui/assets/36373219/93412e20-90e0-4b53-a730-bd597de8ddc0">
