### PR TITLE
Fix(slider): connect input and slider position, disabled input, values style

### DIFF
--- a/packages/Slider/src/Range.tsx
+++ b/packages/Slider/src/Range.tsx
@@ -26,14 +26,40 @@ export type RangeProps = CreateWuiProps<'div', RangeOptions>
 /**
  * Ensure mininum of a given value against a value `toCompare` based on a step
  */
-const ensureMin = (value: number, toCompare: number, step: number) =>
-  round(Math.min(value, toCompare - 1 * step), step)
+const ensureMin = ({
+  min,
+  step,
+  toCompare,
+  value,
+}: {
+  value: number
+  toCompare: number
+  step: number
+  min: number
+}) => {
+  let cleanValue = Math.min(value, toCompare - 1 * step)
+  cleanValue = Math.max(cleanValue, min)
+  return round(cleanValue, step)
+}
 
 /**
  * Ensure maximum of a given value against a value `toCompare` based on a step
  */
-const ensureMax = (value: number, toCompare: number, step: number) =>
-  round(Math.max(value, toCompare + 1 * step), step)
+const ensureMax = ({
+  max,
+  step,
+  toCompare,
+  value,
+}: {
+  value: number
+  toCompare: number
+  step: number
+  max: number
+}) => {
+  let cleanValue = Math.max(value, toCompare + 1 * step)
+  cleanValue = Math.min(cleanValue, max)
+  return round(cleanValue, step)
+}
 
 /**
  * @name Slider.Range
@@ -70,16 +96,26 @@ export const Range = forwardRef<'div', RangeProps>(
     const [tooltipMaxVisible, setTooltipMaxVisible] = useState<boolean>(false)
 
     const handleMinValue = (e: ChangeEvent<HTMLInputElement>) => {
-      // Prevents the min value from being above the max
-      const value = ensureMin(parseInt(e.target.value, 10), maxValue, step)
+      // Prevents the min value from being above the max value and under the min
+      const value = ensureMin({
+        value: parseInt(e.target.value, 10),
+        toCompare: maxValue,
+        step,
+        min,
+      })
       setInputMinValue(value)
       setMinValue(value)
       e.target.value = value.toString()
     }
 
     const handleMaxValue = (e: ChangeEvent<HTMLInputElement>) => {
-      // Prevents the max from being below the min
-      const value = ensureMax(parseInt(e.target.value, 10), minValue, step)
+      // Prevents the max value from being below the min value and above the max
+      const value = ensureMax({
+        value: parseInt(e.target.value, 10),
+        toCompare: minValue,
+        step,
+        max,
+      })
       setInputMaxValue(value)
       setMaxValue(value)
       e.target.value = value.toString()
@@ -92,10 +128,10 @@ export const Range = forwardRef<'div', RangeProps>(
         let value = minValue
 
         if (e.key === 'ArrowRight') {
-          value = ensureMin(value + step, maxValue, step)
+          value = ensureMin({ value: value + step, toCompare: maxValue, step, min })
         }
         if (e.key === 'ArrowLeft') {
-          value = ensureMin(value - step, maxValue, step)
+          value = ensureMin({ value: value - step, toCompare: maxValue, step, min })
         }
 
         setInputMinValue(value)
@@ -107,10 +143,10 @@ export const Range = forwardRef<'div', RangeProps>(
         let value = maxValue
 
         if (e.key === 'ArrowRight') {
-          value = ensureMax(value + step, minValue, step)
+          value = ensureMax({ value: value + step, toCompare: minValue, step, max })
         }
         if (e.key === 'ArrowLeft') {
-          value = ensureMax(value - step, minValue, step)
+          value = ensureMax({ value: value - step, toCompare: minValue, step, max })
         }
 
         setInputMaxValue(value)
@@ -172,12 +208,12 @@ export const Range = forwardRef<'div', RangeProps>(
     useEffect(() => {
       if (value) {
         if (!isNaN(value.min) && value.min !== minValue) {
-          const validValue = ensureMin(value.min || min, maxValue, step)
+          const validValue = ensureMin({ value: value.min || min, toCompare: maxValue, step, min })
           setMinValue(validValue)
           setInputMinValue(validValue)
         }
         if (!isNaN(value.max) && value.max !== maxValue) {
-          const validValue = ensureMax(value.max || max, minValue, step)
+          const validValue = ensureMax({ value: value.max || max, toCompare: minValue, step, max })
           setMaxValue(validValue)
           setInputMaxValue(validValue)
         }
@@ -197,8 +233,20 @@ export const Range = forwardRef<'div', RangeProps>(
           {(type === 'inline' || type === 'fields') &&
             (type === 'fields' ? (
               <InputText
+                disabled={disabled}
                 max={maxValue}
                 min={min}
+                onBlur={() => {
+                  const value = ensureMin({
+                    value: inputMinValue,
+                    toCompare: maxValue,
+                    step,
+                    min,
+                  })
+                  setInputMinValue(value)
+                  setMinValue(value)
+                  onChange({ min: value, max: maxValue })
+                }}
                 onChange={e => {
                   let value = parseInt(e.target.value, 10)
                   if (isNaN(value)) {
@@ -208,7 +256,12 @@ export const Range = forwardRef<'div', RangeProps>(
                 }}
                 onKeyDown={e => {
                   if (e.key === 'Enter') {
-                    const value = ensureMin(inputMinValue, maxValue, step)
+                    const value = ensureMin({
+                      value: inputMinValue,
+                      toCompare: maxValue,
+                      step,
+                      min,
+                    })
                     setInputMinValue(value)
                     setMinValue(value)
                     onChange({ min: value, max: maxValue })
@@ -300,8 +353,20 @@ export const Range = forwardRef<'div', RangeProps>(
           {(type === 'inline' || type === 'fields') &&
             (type === 'fields' ? (
               <InputText
+                disabled={disabled}
                 max={max}
                 min={minValue + 1}
+                onBlur={() => {
+                  const value = ensureMax({
+                    value: inputMaxValue,
+                    toCompare: minValue,
+                    step,
+                    max,
+                  })
+                  setInputMaxValue(value)
+                  setMaxValue(value)
+                  onChange({ min: minValue, max: value })
+                }}
                 onChange={e => {
                   let value = parseInt(e.target.value, 10)
                   if (isNaN(value)) {
@@ -311,7 +376,12 @@ export const Range = forwardRef<'div', RangeProps>(
                 }}
                 onKeyDown={e => {
                   if (e.key === 'Enter') {
-                    const value = ensureMax(inputMaxValue, minValue, step)
+                    const value = ensureMax({
+                      value: inputMaxValue,
+                      toCompare: minValue,
+                      step,
+                      max,
+                    })
                     setInputMaxValue(value)
                     setMaxValue(value)
                     onChange({ min: minValue, max: value })
@@ -336,5 +406,3 @@ export const Range = forwardRef<'div', RangeProps>(
     )
   }
 )
-
-Range.displayName = 'Range'

--- a/packages/Slider/src/Range.tsx
+++ b/packages/Slider/src/Range.tsx
@@ -24,7 +24,7 @@ export interface RangeOptions extends Omit<SliderOptions, 'type' | 'value' | 'on
 export type RangeProps = CreateWuiProps<'div', RangeOptions>
 
 /**
- * Ensure mininum of a given value against a value `toCompare` based on a step
+ * Ensure minimum of a given value against a value `toCompare` based on a step
  */
 const ensureMin = ({
   min,
@@ -158,7 +158,9 @@ export const Range = forwardRef<'div', RangeProps>(
     const getPercent = useCallback(
       (value: number) => {
         const percent = Math.round(((value - min) / (max - min)) * 100)
-        return percent > max ? max : percent < min ? min : percent
+        if (percent < 0) return 0
+        if (percent > 100) return 100
+        return percent
       },
       [min, max]
     )

--- a/packages/Slider/src/Range.tsx
+++ b/packages/Slider/src/Range.tsx
@@ -37,9 +37,9 @@ const ensureMin = ({
   step: number
   min: number
 }) => {
-  let cleanValue = Math.min(value, toCompare - 1 * step)
-  cleanValue = Math.max(cleanValue, min)
-  return round(cleanValue, step)
+  let ensuredValue = Math.min(value, toCompare - 1 * step)
+  ensuredValue = Math.max(ensuredValue, min)
+  return round(ensuredValue, step)
 }
 
 /**
@@ -56,9 +56,9 @@ const ensureMax = ({
   step: number
   max: number
 }) => {
-  let cleanValue = Math.max(value, toCompare + 1 * step)
-  cleanValue = Math.min(cleanValue, max)
-  return round(cleanValue, step)
+  let ensuredValue = Math.max(value, toCompare + 1 * step)
+  ensuredValue = Math.min(ensuredValue, max)
+  return round(ensuredValue, step)
 }
 
 /**

--- a/packages/Slider/src/index.tsx
+++ b/packages/Slider/src/index.tsx
@@ -75,10 +75,10 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
       let value = localValue
 
       if (e.key === 'ArrowRight') {
-        value = value + step
+        value = ensureMinMax(value + step, min, max, step)
       }
       if (e.key === 'ArrowLeft') {
-        value = value - step
+        value = ensureMinMax(value - step, min, max, step)
       }
       setLocalValue(value)
       setInputValue(value)
@@ -100,6 +100,13 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
         setLocalValue(value)
         onChange(value)
       }
+    }
+
+    const handleBlur = () => {
+      const value = ensureMinMax(inputValue, min, max, step)
+      setInputValue(value)
+      setLocalValue(value)
+      onChange(value)
     }
 
     const getPercent = useCallback(
@@ -140,8 +147,10 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
           {(type === 'inline' || type === 'left-field') &&
             (type === 'left-field' ? (
               <InputText
+                disabled={disabled}
                 max={max}
                 min={min}
+                onBlur={handleBlur}
                 onChange={handleInputChange}
                 onKeyDown={handleInput}
                 size="sm"
@@ -153,7 +162,7 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
               <Box>{min}</Box>
             ))}
 
-          <Box display="flex" flexGrow="1" h={20} position="relative">
+          <Box display="flex" flexDirection="column" flexGrow="1" h={20} position="relative">
             <S.Slider
               borderSelectorColor={borderSelectorColor}
               disabled={disabled}
@@ -187,7 +196,7 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
               </S.Output>
             )}
             {values && (
-              <Box h={24} ml={10} mr={10} position="relative">
+              <Box h={24} ml={10} mr={10} mt={5} position="relative">
                 {values
                   .reduce((prev, acc) => (prev.includes(acc) ? prev : [...prev, acc]), [])
                   .filter(v => v >= min && v <= max)
@@ -204,8 +213,10 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
           {(type === 'inline' || type === 'right-field') &&
             (type === 'right-field' ? (
               <InputText
+                disabled={disabled}
                 max={max}
                 min={min}
+                onBlur={handleBlur}
                 onChange={handleInputChange}
                 onKeyDown={handleInput}
                 size="sm"

--- a/packages/Slider/src/index.tsx
+++ b/packages/Slider/src/index.tsx
@@ -70,7 +70,7 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
     }
 
     // Handle enter key
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const handleSliderKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
       e.preventDefault()
       let value = localValue
 
@@ -93,20 +93,17 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
       setInputValue(value)
     }
 
-    const handleInput = (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
-        const value = ensureMinMax(inputValue, min, max, step)
-        setInputValue(value)
-        setLocalValue(value)
-        onChange(value)
-      }
-    }
-
-    const handleBlur = () => {
+    const handleInput = () => {
       const value = ensureMinMax(inputValue, min, max, step)
       setInputValue(value)
       setLocalValue(value)
       onChange(value)
+    }
+
+    const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        handleInput()
+      }
     }
 
     const getPercent = useCallback(
@@ -150,9 +147,9 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
                 disabled={disabled}
                 max={max}
                 min={min}
-                onBlur={handleBlur}
+                onBlur={handleInput}
                 onChange={handleInputChange}
-                onKeyDown={handleInput}
+                onKeyDown={handleInputKeyDown}
                 size="sm"
                 type="number"
                 value={inputValue.toString()}
@@ -176,7 +173,7 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
                 _setLocalValue(value)
                 setInputValue(value)
               }}
-              onKeyDown={handleKeyDown}
+              onKeyDown={handleSliderKeyDown}
               onMouseDown={() => {
                 tooltip && tooltipVisible === false && setTooltipVisible(true)
               }}
@@ -216,9 +213,9 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
                 disabled={disabled}
                 max={max}
                 min={min}
-                onBlur={handleBlur}
+                onBlur={handleInput}
                 onChange={handleInputChange}
-                onKeyDown={handleInput}
+                onKeyDown={handleInputKeyDown}
                 size="sm"
                 type="number"
                 value={inputValue.toString()}

--- a/packages/Slider/tests/index.test.tsx
+++ b/packages/Slider/tests/index.test.tsx
@@ -116,6 +116,54 @@ describe('<Slider> test', () => {
 
     expect(slider).toMatchObject({ value: '60' })
   })
+
+  test('Slider and left field should be disabled', () => {
+    const handleChange = jest.fn()
+    const value = 30
+    const { container } = render(
+      <Slider
+        disabled
+        max={100}
+        min={0}
+        onChange={handleChange}
+        type="left-field"
+        value={value}
+        w={100}
+      />
+    )
+
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    const slider = container.querySelector<HTMLInputElement>('input[type="range"]')!
+    const numberInput = container.querySelector<HTMLInputElement>('input[type="number"]')!
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+
+    expect(slider).toBeDisabled()
+    expect(numberInput).toBeDisabled()
+  })
+
+  test('Slider and right field should be disabled', () => {
+    const handleChange = jest.fn()
+    const value = 30
+    const { container } = render(
+      <Slider
+        disabled
+        max={100}
+        min={0}
+        onChange={handleChange}
+        type="right-field"
+        value={value}
+        w={100}
+      />
+    )
+
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    const slider = container.querySelector<HTMLInputElement>('input[type="range"]')!
+    const numberInput = container.querySelector<HTMLInputElement>('input[type="number"]')!
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+
+    expect(slider).toBeDisabled()
+    expect(numberInput).toBeDisabled()
+  })
 })
 
 describe('<Slider.Range> test', () => {
@@ -279,5 +327,28 @@ describe('<Slider.Range> test', () => {
 
     expect(handleChange.mock.calls.length).toBe(2)
     expect(handleChange.mock.calls[1][0]).toMatchObject({ min: 20, max: 30 })
+  })
+
+  test('Slider.Range and fields should be disabled', () => {
+    const handleChange = jest.fn()
+    const { container } = render(
+      <Slider.Range
+        disabled
+        max={100}
+        min={0}
+        onChange={handleChange}
+        step={10}
+        type="fields"
+        value={{ min: 20, max: 50 }}
+      />
+    )
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    const inputSlider = container.querySelector<HTMLInputElement>('input[type="number"]')!
+    const fields = container.querySelectorAll<HTMLInputElement>('input[type="number"]')!
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+
+    expect(inputSlider).toBeDisabled()
+    expect(fields[0]).toBeDisabled()
+    expect(fields[1]).toBeDisabled()
   })
 })


### PR DESCRIPTION
**FIX :**
- `disabled` props should disable the number inputs too
- onBlur after changing the number input value should update the slider position
- fix `values` labels position in Slider component
- ensure the respect of `min` and `max` when user update value using arrow keys
- fix yellow range position and length in Slider.Range when `min` and `max` are set and different from 0 and 100


fixes https://github.com/WTTJ/welcome-ui/issues/2168

### Before

https://github.com/WTTJ/welcome-ui/assets/33298885/5e43f576-60b5-4b9d-8b4a-fc5f3af3650f

### After


https://github.com/WTTJ/welcome-ui/assets/33298885/4272b61d-68cc-4be8-85b1-b0fc98721d06

