### PR TITLE
chore: add auto github release with changelog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
 
   build:
     <<: *defaults
-    resource_class: large
+    resource_class: xlarge
     steps:
       - attach_workspace:
           at: ~/welcome-ui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    tags:
+      - /v\d.\d.\d/
+
+jobs:
+  publish:
+    name: Create new github release
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: npx extract-changelog-release > Release.txt
+      - name: Test
+        run: cat Release.txt
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: Release.txt


### PR DESCRIPTION
Fixes #1650 

We need to use a github action because `lerna version --create-release` need to have a github secret and this command is done on local, we don't won't other developers to have this token, this action is the solution :) 