### PR TITLE
fix: zIndex on modal Header and Footer

### DIFF
--- a/packages/Modal/src/styles.ts
+++ b/packages/Modal/src/styles.ts
@@ -77,6 +77,7 @@ export const Header = styled.headerBox`
   position: sticky;
   top: 0;
   flex-shrink: 0;
+  z-index: 1;
   ${th('modals.header')};
 `
 
@@ -89,6 +90,7 @@ export const Footer = styled.footerBox`
   position: sticky;
   bottom: 0;
   flex-shrink: 0;
+  z-index: 1;
   ${th('modals.footer')};
 `
 


### PR DESCRIPTION
We need to add zIndex to avoid wrong zIndex from modal content