### PR TITLE
fix(modal): not visible while updating state on open

### DIFF
--- a/packages/Modal/src/index.tsx
+++ b/packages/Modal/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import * as Ariakit from '@ariakit/react'
 import { BoxProps } from '@welcome-ui/box'
 import { As, CreateWuiProps, forwardRef } from '@welcome-ui/system'
@@ -30,23 +30,20 @@ export type UseModalProps = Ariakit.DialogStoreProps & {
 export type UseModalState = Ariakit.DialogStoreState
 
 export function useModal(options?: UseModalProps): UseModal {
-  const { onClose, ...storeOptions } = options || {}
+  const { onClose, setOpen, ...storeOptions } = options || {}
 
   const dialog = Ariakit.useDialogStore({
     animated: true,
+    setOpen: open => {
+      if (!open && onClose) {
+        onClose()
+      }
+      setOpen?.(open)
+    },
     ...storeOptions,
   })
 
-  return useMemo(
-    () => ({
-      ...dialog,
-      hide: () => {
-        dialog.hide()
-        onClose?.()
-      },
-    }),
-    [onClose, dialog]
-  )
+  return dialog
 }
 
 const ModalComponent = forwardRef<'div', ModalProps>(

--- a/packages/Modal/src/index.tsx
+++ b/packages/Modal/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import * as Ariakit from '@ariakit/react'
 import { BoxProps } from '@welcome-ui/box'
 import { As, CreateWuiProps, forwardRef } from '@welcome-ui/system'
@@ -37,13 +37,16 @@ export function useModal(options?: UseModalProps): UseModal {
     ...storeOptions,
   })
 
-  return {
-    ...dialog,
-    hide: () => {
-      dialog.hide()
-      onClose?.()
-    },
-  }
+  return useMemo(
+    () => ({
+      ...dialog,
+      hide: () => {
+        dialog.hide()
+        onClose?.()
+      },
+    }),
+    [onClose, dialog]
+  )
 }
 
 const ModalComponent = forwardRef<'div', ModalProps>(

--- a/packages/Modal/tests/index.test.tsx
+++ b/packages/Modal/tests/index.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { fireEvent } from '@testing-library/react'
 
 import { render } from '../../../utils/tests'
-import { Modal, useModal } from '../src'
+import { Modal, UseModal, useModal } from '../src'
 
 describe('<Modal>', () => {
   it('should render correctly', () => {
@@ -47,5 +47,47 @@ describe('<Modal>', () => {
     const { getByText, queryByRole } = render(<ModalTest />)
     fireEvent.click(getByText('open'))
     expect(queryByRole('dialog')).not.toHaveTextContent('Modal.Body exist?')
+  })
+
+  it('should render with data-enter attribute', async () => {
+    const Test = () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [count, setCount] = useState(1)
+      const modal = useModal()
+
+      return (
+        <>
+          <Modal.Trigger store={modal}>open</Modal.Trigger>
+          <TestModal modal={modal} setCount={setCount} />
+        </>
+      )
+    }
+    const TestModal = ({
+      modal,
+      setCount,
+    }: {
+      modal: UseModal
+      setCount: React.Dispatch<React.SetStateAction<number>>
+    }) => {
+      useEffect(() => {
+        setCount(c => c + 1)
+      }, [setCount])
+
+      return (
+        <Modal ariaLabel="modal" store={modal}>
+          <div>Modal open</div>
+        </Modal>
+      )
+    }
+
+    const { getByText, queryByRole } = render(<Test />)
+    expect(queryByRole('dialog')).toBeNull()
+    fireEvent.click(getByText('open'))
+    expect(queryByRole('dialog')).toHaveTextContent('Modal open')
+    expect(queryByRole('dialog')).toHaveAttribute('data-dialog')
+
+    // wait until ariakit set "data-enter" attribute
+    await await new Promise(r => setTimeout(r, 100))
+    expect(queryByRole('dialog')).toHaveAttribute('data-enter')
   })
 })

--- a/packages/Modal/tests/index.test.tsx
+++ b/packages/Modal/tests/index.test.tsx
@@ -87,7 +87,7 @@ describe('<Modal>', () => {
     expect(queryByRole('dialog')).toHaveAttribute('data-dialog')
 
     // wait until ariakit set "data-enter" attribute
-    await await new Promise(r => setTimeout(r, 100))
+    await new Promise(r => setTimeout(r, 100))
     expect(queryByRole('dialog')).toHaveAttribute('data-enter')
   })
 })


### PR DESCRIPTION
Fix https://github.com/WTTJ/welcome-ui/issues/2341

The first option is to remove the `onClose` prop from the `useModal` and render the same hook as the drawer:
```tsx
export function useModal(options?: UseModalProps): UseModal {
  return Ariakit.useDialogStore({ animated: true, ..options })
}
```

The second option is to wrap the render of the hook with a `useMemo`, I decided to choose this one for prevent breaking changes, but I'm open to discussing it.

(I prefer the first option, but I don't know if the `onClose` prop is used by someone?)