### PR TITLE
fix: hide unwanted aria messages for date/time pickers

### DIFF
--- a/packages/DateTimePickerCommon/src/CustomPopper.tsx
+++ b/packages/DateTimePickerCommon/src/CustomPopper.tsx
@@ -3,6 +3,7 @@ import styled, { css, CSSObject, th } from '@xstyled/styled-components'
 import { cardStyles } from '@welcome-ui/utils'
 
 import { datePickerStyles } from './datePickerStyles'
+import { fixAriaMessageStyle } from './styles'
 
 export const CustomPopper = ({
   children,
@@ -21,6 +22,7 @@ export const CustomPopper = ({
 const StyledCustomPopper = styled.div(
   ({ popperStyles }: { popperStyles: CSSObject }) => css`
     ${datePickerStyles};
+    ${fixAriaMessageStyle};
     .react-datepicker-popper {
       ${popperStyles};
     }

--- a/packages/DateTimePickerCommon/src/index.tsx
+++ b/packages/DateTimePickerCommon/src/index.tsx
@@ -4,4 +4,4 @@ export * from './CustomInput'
 export * from './utils'
 
 // no export * as S here because of crash on gatsby
-export { StyledDatePicker, StyledTimePicker } from './styles'
+export { fixAriaMessageStyle, StyledDatePicker, StyledTimePicker } from './styles'

--- a/packages/DateTimePickerCommon/src/styles.ts
+++ b/packages/DateTimePickerCommon/src/styles.ts
@@ -74,3 +74,17 @@ export const Selects = styled.div`
     margin-right: sm;
   }
 `
+
+export const fixAriaMessageStyle = css`
+  .react-datepicker__aria-live {
+    position: absolute;
+    clip-path: circle(0);
+    border: 0;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    width: 1px;
+    white-space: nowrap;
+  }
+`

--- a/packages/TimePicker/src/index.tsx
+++ b/packages/TimePicker/src/index.tsx
@@ -11,6 +11,8 @@ import {
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 import { ReactDatePickerProps } from 'react-datepicker'
 
+import * as S from './styles'
+
 export interface TimePickerOptions {
   onChange?: (date?: Date) => void
   onBlur?: CustomInputOptions['handleBlur']
@@ -97,38 +99,40 @@ export const TimePicker = forwardRef<'input', TimePickerProps>(
     }
 
     return (
-      <StyledTimePicker
-        calendarClassName="time-picker-popper"
-        customInput={
-          <CustomInput
-            className="time-picker"
-            data-testid={dataTestId}
-            focused={focused}
-            handleBlur={handleBlur}
-            handleFocus={handleFocus}
-            icon={icon}
-            iconPlacement={iconPlacement}
-            onReset={handleReset}
-            ref={ref}
-            size={size}
-          />
-        }
-        dateFormat={dateFormat}
-        disabled={disabled}
-        iconPlacement={!!icon && iconPlacement}
-        onChange={handleChange}
-        placeholderText={placeholderText}
-        popperContainer={CustomPopper}
-        popperProps={popperProps}
-        selected={date}
-        showTimeSelect
-        showTimeSelectOnly
-        size={size}
-        timeIntervals={timeIntervals}
-        transparent={transparent}
-        {...rest}
-        isClearable={false}
-      />
+      <S.Wrapper>
+        <StyledTimePicker
+          calendarClassName="time-picker-popper"
+          customInput={
+            <CustomInput
+              className="time-picker"
+              data-testid={dataTestId}
+              focused={focused}
+              handleBlur={handleBlur}
+              handleFocus={handleFocus}
+              icon={icon}
+              iconPlacement={iconPlacement}
+              onReset={handleReset}
+              ref={ref}
+              size={size}
+            />
+          }
+          dateFormat={dateFormat}
+          disabled={disabled}
+          iconPlacement={!!icon && iconPlacement}
+          onChange={handleChange}
+          placeholderText={placeholderText}
+          popperContainer={CustomPopper}
+          popperProps={popperProps}
+          selected={date}
+          showTimeSelect
+          showTimeSelectOnly
+          size={size}
+          timeIntervals={timeIntervals}
+          transparent={transparent}
+          {...rest}
+          isClearable={false}
+        />
+      </S.Wrapper>
     )
   }
 )

--- a/packages/TimePicker/src/styles.ts
+++ b/packages/TimePicker/src/styles.ts
@@ -1,0 +1,7 @@
+import styled from '@xstyled/styled-components'
+import { fixAriaMessageStyle } from '@welcome-ui/date-time-picker-common'
+
+export const Wrapper = styled.div`
+  position: relative;
+  ${fixAriaMessageStyle}
+`


### PR DESCRIPTION
Fixes #2305 

Hide unwanted aria message for DatePicker and TimePicker

![screenshot_2023-11-06_at_10 47 01](https://github.com/WTTJ/welcome-ui/assets/1446004/fbd8e77f-901f-4ad9-bf20-515d20f462ba)

![Screenshot 2023-11-07 at 14 21 13](https://github.com/WTTJ/welcome-ui/assets/1446004/43049595-06d6-4d26-96e8-b5ba56a886ee)
