### PR TITLE
fix: avoid having js error because of NaN on tabs activebar

### DIFF
--- a/packages/Tabs/src/ActiveBar.tsx
+++ b/packages/Tabs/src/ActiveBar.tsx
@@ -42,8 +42,8 @@ function useActiveBar(
       const width = activeTabRect.width / scale
 
       setState({
-        size: width,
-        offset: left,
+        size: isNaN(width) ? 0 : width,
+        offset: isNaN(left) ? 0 : left,
         orientation,
       })
     }


### PR DESCRIPTION
When bouding rect values are all 0 we have a divison of 0 / 0 which equals NaN.
To avoid this, I check for NaN