### PR TITLE
fix(tag): add default type to remove button

### DIFF
--- a/packages/Tag/src/index.tsx
+++ b/packages/Tag/src/index.tsx
@@ -77,7 +77,7 @@ export const Tag = forwardRef<'div', TagProps>(
         {content}
         {!!onRemove && (
           <S.ActionIcon size={size}>
-            <S.Button onClick={onRemove} title="Remove">
+            <S.Button onClick={onRemove} title="Remove" type="button">
               <CrossIcon size="xs" title="Remove" />
             </S.Button>
           </S.ActionIcon>


### PR DESCRIPTION
I've added a `type="button"` to the remove button of a Tag, otherwise if this tag is in a form then it submits the form.