### PR TITLE
fix: swiper aria-hidden slide on last page

### DIFF
--- a/docs/pages/components/swiper.mdx
+++ b/docs/pages/components/swiper.mdx
@@ -208,7 +208,11 @@ Use dark (black) colors for the pagination and arrows in case of slides too brig
 
 ```jsx
 function() {
-  const swiper = useSwiper({ withPagination: { mobile: true, desktop: true }, withDarkUI: true })
+  const swiper = useSwiper({
+    slidesPerView: { mobile: 1, tablet: 2, desktop: 4 },
+    withPagination: { mobile: true, desktop: true },
+    withDarkUI: true 
+  })
 
   return (
     <Swiper store={swiper} h={350}>

--- a/packages/Swiper/src/index.tsx
+++ b/packages/Swiper/src/index.tsx
@@ -145,24 +145,31 @@ export const Swiper = ({ children, dataTestId, store, ...rest }: SwiperProps) =>
     withPagination,
   } = store
 
-  const slides = Children.map(children, (child, i) => {
-    const key = `${id}-${i}`
-    return cloneElement(child, {
-      ...child.props,
-      id: key,
-      key,
-      'aria-hidden': Math.ceil((i + 1) / currentSlidesPerView) - 1 !== currentPage,
-      'aria-roledescription': 'slide',
-      'aria-label': `${i + 1} of ${Children.toArray(children).length}`,
-    })
-  })
-
-  const slidesLength = slides.length
+  const slidesLength = Children.toArray(children).length
   const numberOfPage = Math.ceil(slidesLength / currentSlidesPerView)
   const bullets = Array.from(Array(numberOfPage).keys())
 
   const isFirstPage = currentPage === 0
   const isLastPage = currentPage === bullets.length - 1
+
+  const slides = Children.map(children, (child, i) => {
+    const key = `${id}-${i}`
+    const currentSlide = i + 1
+    const pageForThisSlide = Math.ceil(currentSlide / currentSlidesPerView) - 1
+    // item can be visible on the last page even if it isn't on the current page due to the automatic filling of the last page
+    const isHidden = isLastPage
+      ? slidesLength - currentSlide >= currentSlidesPerView
+      : pageForThisSlide !== currentPage
+
+    return cloneElement(child, {
+      ...child.props,
+      id: key,
+      key,
+      'aria-hidden': isHidden,
+      'aria-roledescription': 'slide',
+      'aria-label': `${currentSlide} of ${slidesLength}`,
+    })
+  })
 
   const firstPageToShow = centeredSlides
     ? // if centeredSlides is true, we calculate which number is the middle page


### PR DESCRIPTION
Items with `aria-hidden=true` have a `backgroundColor: tomato` 💅🏻 
 
before:

https://github.com/WTTJ/welcome-ui/assets/36373219/07e72cef-4640-464e-bc95-28ab723d4bd1

after:


https://github.com/WTTJ/welcome-ui/assets/36373219/47b828a6-46c0-42dd-862c-a34113658035


