### PR TITLE
feat(breadcrumb): items without link must be disabled

### DIFF
--- a/docs/pages/components/breadcrumb.mdx
+++ b/docs/pages/components/breadcrumb.mdx
@@ -67,15 +67,15 @@ By default we removed clickable the last child. You can change this by set to fa
 </Breadcrumb>
 ```
 
-## Item disable
+## Items without link will be disable
 
-You can disable an item.
+We are looking for "href" prop. (or "to" prop for react-router)
 
 ```jsx
 <Breadcrumb>
-  <Breadcrumb.Item disabled>Introduction</Breadcrumb.Item>
-  <Breadcrumb.Item href="/">Components</Breadcrumb.Item>
-  <Breadcrumb.Item href="/">Breadcrumb</Breadcrumb.Item>
+  <Breadcrumb.Item href="/">Introduction</Breadcrumb.Item>
+  <Breadcrumb.Item>Disabled</Breadcrumb.Item>
+  <Breadcrumb.Item>Breadcrumb</Breadcrumb.Item>
 </Breadcrumb>
 ```
 

--- a/docs/pages/components/breadcrumb.mdx
+++ b/docs/pages/components/breadcrumb.mdx
@@ -67,6 +67,18 @@ By default we removed clickable the last child. You can change this by set to fa
 </Breadcrumb>
 ```
 
+## Item disable
+
+You can disable an item.
+
+```jsx
+<Breadcrumb>
+  <Breadcrumb.Item disabled>Introduction</Breadcrumb.Item>
+  <Breadcrumb.Item href="/">Components</Breadcrumb.Item>
+  <Breadcrumb.Item href="/">Breadcrumb</Breadcrumb.Item>
+</Breadcrumb>
+```
+
 ## Properties
 
 ### Breadcrumb

--- a/packages/Breadcrumb/src/Item.styles.ts
+++ b/packages/Breadcrumb/src/Item.styles.ts
@@ -1,35 +1,24 @@
-import styled, { css, th } from '@xstyled/styled-components'
-import { shouldForwardProp } from '@welcome-ui/system'
+import styled, { th } from '@xstyled/styled-components'
 
-interface ItemProps {
-  isActive: boolean
-}
+export const Item = styled.aBox`
+  ${th('breadcrumbs.item.default')};
+  align-items: center;
+  transition: medium;
+  direction: initial;
 
-export const Item = styled.aBox.withConfig({ shouldForwardProp })<ItemProps>(
-  ({ isActive }) => css`
-    ${th('breadcrumbs.item.default')};
-    align-items: center;
-    transition: medium;
-    direction: initial;
+  &:hover {
+    ${th('breadcrumbs.item.hover')};
+  }
 
-    ${!isActive &&
-    css`
-      &:hover {
-        ${th('breadcrumbs.item.hover')};
-      }
-    `};
+  &[aria-current='page'] {
+    ${th('breadcrumbs.item.active')};
+  }
 
-    &[aria-disabled='true'] {
-      pointer-events: none;
-      cursor: default;
-    }
-
-    ${isActive &&
-    css`
-      ${th('breadcrumbs.item.active')};
-    `}
-  `
-)
+  &[aria-disabled='true'] {
+    pointer-events: none;
+    cursor: default;
+  }
+`
 
 export const Separator = styled.span`
   ${th('breadcrumbs.separator')};

--- a/packages/Breadcrumb/src/Item.styles.ts
+++ b/packages/Breadcrumb/src/Item.styles.ts
@@ -19,6 +19,11 @@ export const Item = styled.aBox.withConfig({ shouldForwardProp })<ItemProps>(
       }
     `};
 
+    &[aria-disabled='true'] {
+      pointer-events: none;
+      cursor: default;
+    }
+
     ${isActive &&
     css`
       ${th('breadcrumbs.item.active')};

--- a/packages/Breadcrumb/src/Item.tsx
+++ b/packages/Breadcrumb/src/Item.tsx
@@ -6,9 +6,10 @@ import * as S from './Item.styles'
 
 export interface ItemOptions {
   children: React.ReactNode
-  disabled?: boolean
   separator?: string | React.ReactNode
   isActive?: boolean
+  /* useful for react-router */
+  to?: string
 }
 
 export type ItemProps = CreateWuiProps<'a', ItemOptions>
@@ -17,7 +18,9 @@ export type ItemProps = CreateWuiProps<'a', ItemOptions>
  * @name Breadcrumb.Item
  */
 export const Item = forwardRef<'a', ItemProps>(
-  ({ children, dataTestId, disabled, isActive, separator, ...rest }, ref) => {
+  ({ children, dataTestId, isActive, separator, ...rest }, ref) => {
+    const isClickable = rest.href || rest.to
+
     return (
       <Box
         aria-label="breadcrumb"
@@ -30,8 +33,7 @@ export const Item = forwardRef<'a', ItemProps>(
         {separator && <S.Separator role="presentation">{separator}</S.Separator>}
         <S.Item
           aria-current={isActive ? 'page' : undefined}
-          aria-disabled={disabled}
-          isActive={isActive}
+          aria-disabled={!isClickable}
           {...rest}
           ref={ref}
         >

--- a/packages/Breadcrumb/src/Item.tsx
+++ b/packages/Breadcrumb/src/Item.tsx
@@ -6,6 +6,7 @@ import * as S from './Item.styles'
 
 export interface ItemOptions {
   children: React.ReactNode
+  disabled?: boolean
   separator?: string | React.ReactNode
   isActive?: boolean
 }
@@ -16,7 +17,7 @@ export type ItemProps = CreateWuiProps<'a', ItemOptions>
  * @name Breadcrumb.Item
  */
 export const Item = forwardRef<'a', ItemProps>(
-  ({ children, dataTestId, isActive, separator, ...rest }, ref) => {
+  ({ children, dataTestId, disabled, isActive, separator, ...rest }, ref) => {
     return (
       <Box
         aria-label="breadcrumb"
@@ -29,6 +30,7 @@ export const Item = forwardRef<'a', ItemProps>(
         {separator && <S.Separator role="presentation">{separator}</S.Separator>}
         <S.Item
           aria-current={isActive ? 'page' : undefined}
+          aria-disabled={disabled}
           isActive={isActive}
           {...rest}
           ref={ref}

--- a/packages/Breadcrumb/src/index.tsx
+++ b/packages/Breadcrumb/src/index.tsx
@@ -58,7 +58,6 @@ export const BreadcrumbComponent = forwardRef<'div', BreadcrumbProps>(
         key: `breadcrumb-${index}`,
         separator: isLastChild ? undefined : separator,
         isActive,
-        as: !!isActive && 'span',
         ...child.props,
       })
     })

--- a/packages/Core/src/theme/breadcrumbs.ts
+++ b/packages/Core/src/theme/breadcrumbs.ts
@@ -29,7 +29,7 @@ export const getBreadcrumbs = (theme: WuiTheme): ThemeBreadcrumbs => {
         color: colors['dark-700'],
       },
       active: {
-        color: colors['dark-900'],
+        color: colors['dark-700'],
       },
     },
     separator: {


### PR DESCRIPTION
Following our design:
- Item without link must not have "hover" style
- Active item should have color to `dark-700` instead of `dark-900`



https://github.com/WTTJ/welcome-ui/assets/36373219/cc7e7144-7701-43e0-9d24-9457b549d9e0

