### PR TITLE
feat(datepicker): add option to prevent virtual keyboard from opening

### DIFF
--- a/packages/DatePicker/src/index.tsx
+++ b/packages/DatePicker/src/index.tsx
@@ -20,6 +20,7 @@ export interface DatePickerOptions {
   onFocus?: CustomInputOptions['handleFocus']
   useWeekdaysShort?: boolean
   placeholder?: ReactDatePickerProps['placeholderText']
+  preventVirtualKeyboard?: boolean
   value: string | Date
   transparent?: boolean
 }
@@ -49,6 +50,7 @@ export const DatePicker = forwardRef<'input', DatePickerProps>(
       onChange,
       onFocus,
       placeholder,
+      preventVirtualKeyboard = false,
       popperProps,
       size = 'md',
       startYear = 1900,
@@ -135,6 +137,7 @@ export const DatePicker = forwardRef<'input', DatePickerProps>(
             handleFocus={e => handleFocus(e)}
             icon={icon}
             iconPlacement={iconPlacement}
+            inputMode={preventVirtualKeyboard ? 'none' : 'text'}
             onReset={handleReset}
             ref={instance => {
               // for internal use only


### PR DESCRIPTION
Add an option to prevent the virtual keyboard from opening (useful on mobile).

## Without `preventVirtualKeyboard`:
<img src="https://github.com/WTTJ/welcome-ui/assets/1446004/22b51ad2-b2c9-4248-b2ba-2f3fbe8d3129" height="800px" />

## With : `preventVirtualKeyboard`:
<img src="https://github.com/WTTJ/welcome-ui/assets/1446004/5dd81f79-18d8-4870-8fdf-bfc4e73bcd3c" height="800px" />