### PR TITLE
Fix <Modal.Footer> type

### DIFF
--- a/packages/Modal/src/Footer.tsx
+++ b/packages/Modal/src/Footer.tsx
@@ -7,8 +7,8 @@ import * as S from './styles'
 
 export interface FooterOptions {
   information?: {
-    title: string
-    subtitle: string
+    title: React.ReactNode
+    subtitle: React.ReactNode
   }
 }
 


### PR DESCRIPTION
There is no reason for them to be string, and we already pass components in some internal projects, so `ReactNode` should be better.