### PR TITLE
fix: rollback modal header a11y

### DIFF
--- a/packages/Modal/src/Header.tsx
+++ b/packages/Modal/src/Header.tsx
@@ -22,13 +22,9 @@ export const Header = forwardRef<'div', HeaderProps>(({ icon, subtitle, title, .
     <S.Header ref={ref} textAlign={icon ? 'center' : null} w="100%" {...rest}>
       <Close isOnHeader />
       {icon}
-      {typeof title === 'string' ? (
-        <Text mb={subtitle ? 'lg' : 0} mt={icon ? 'xl' : 0} variant="h4">
-          {title}
-        </Text>
-      ) : (
-        title
-      )}
+      <Text mb={subtitle ? 'lg' : 0} mt={icon ? 'xl' : 0} variant="h4">
+        {title}
+      </Text>
       {subtitle && <S.HeaderSubtitle>{subtitle}</S.HeaderSubtitle>}
     </S.Header>
   )


### PR DESCRIPTION
rollback this PR https://github.com/WTTJ/welcome-ui/pull/2422

Actually, we have a lot of title like this: `title={<FormattedMessage ... }` in the Modal.Header and I'm not sur we want this BC
<img width="467" alt="image" src="https://github.com/WTTJ/welcome-ui/assets/36373219/8930eb1c-2659-42ee-8f81-4dd0d331c4b6">

So we can rollback this one, and looking for a more suitable solution