### PR TITLE
fix: computation of slides per view when swiper is full width

### DIFF
--- a/packages/Swiper/src/index.tsx
+++ b/packages/Swiper/src/index.tsx
@@ -80,12 +80,12 @@ export const useSwiper = (options: UseSwiperProps = {}) => {
       return slidesPerView.mobile
     } else if (viewportWidth <= screens.lg) {
       return slidesPerView.tablet
-    } else if (viewportWidth <= screens['4xl']) {
-      return slidesPerView.desktop
-    } else {
+    } else if (viewportWidth >= screens['4xl'] && fullWidth) {
       return slidesPerView.desktop + 2
+    } else {
+      return slidesPerView.desktop
     }
-  }, [viewportWidth, screens, slidesPerView])
+  }, [fullWidth, viewportWidth, screens, slidesPerView])
 
   return {
     centeredSlides,

--- a/packages/Swiper/src/index.tsx
+++ b/packages/Swiper/src/index.tsx
@@ -80,10 +80,12 @@ export const useSwiper = (options: UseSwiperProps = {}) => {
       return slidesPerView.mobile
     } else if (viewportWidth <= screens.lg) {
       return slidesPerView.tablet
-    } else {
+    } else if (viewportWidth <= screens['4xl']) {
       return slidesPerView.desktop
+    } else {
+      return slidesPerView.desktop + 2
     }
-  }, [slidesPerView, screens.md, screens.lg, viewportWidth])
+  }, [viewportWidth, screens, slidesPerView])
 
   return {
     centeredSlides,

--- a/packages/Swiper/src/styles.ts
+++ b/packages/Swiper/src/styles.ts
@@ -166,7 +166,7 @@ export const Container = styled.ul<Pick<UseSwiper, 'slidesPerView' | 'spaceBetwe
         `}
       }
 
-      @media (min-width: 1920px) {
+      @media (min-width: 4xl) {
         ${desktop &&
         fullWidth &&
         css`


### PR DESCRIPTION
When swiper has "fullWidth" prop to true, [we display 2 additional items](https://github.com/WTTJ/welcome-ui/blob/81ec13a464e0469b5bc0719255ae12d3ae63e1e5/packages/Swiper/src/styles.ts#L174) on resolutions >1920px.  

But these 2 additional items displayed had the 'aria-hidden' property set to true, which prevented us from interacting with these items (such as clicking on a link).