### PR TITLE
Fix: use proper colors when the select is disabled

### DIFF
--- a/packages/Select/src/index.tsx
+++ b/packages/Select/src/index.tsx
@@ -14,7 +14,6 @@ import {
   DefaultFieldStylesProps,
   FIELD_ICON_SIZE,
 } from '@welcome-ui/utils'
-import { IconWrapper } from '@welcome-ui/field'
 
 import {
   getInputValue,
@@ -303,7 +302,7 @@ export const Select = forwardRef<'input', SelectProps>(
                 onClick: () => setIsOpen(!isOpen),
               })}
             >
-              <DownIcon color="dark-900" size="sm" />
+              <DownIcon size="sm" />
             </S.DropDownIndicator>
           )
 
@@ -339,7 +338,7 @@ export const Select = forwardRef<'input', SelectProps>(
           const iconSize = FIELD_ICON_SIZE[size]
 
           return (
-            <S.Wrapper {...rootProps}>
+            <S.Wrapper {...rootProps} disabled={disabled}>
               <S.InputWrapper>
                 {isSearchable ? (
                   <S.Input as="input" type="text" {...inputProps} />
@@ -347,9 +346,9 @@ export const Select = forwardRef<'input', SelectProps>(
                   <S.Input {...inputProps}>{inputContent}</S.Input>
                 )}
                 {icon && (
-                  <IconWrapper iconPlacement="left" size={iconSize}>
+                  <S.IconWrapper iconPlacement="left" size={iconSize}>
                     {React.cloneElement(icon, { ...icon.props, size: iconSize })}
-                  </IconWrapper>
+                  </S.IconWrapper>
                 )}
                 <S.Indicators size={size}>
                   {isShowDeleteIcon && DeleteIcon}

--- a/packages/Select/src/styles.ts
+++ b/packages/Select/src/styles.ts
@@ -9,13 +9,21 @@ import {
   overflowEllipsis,
   Size,
 } from '@welcome-ui/utils'
+import { IconWrapper as WUIIconWrapper } from '@welcome-ui/field'
 
 import { SelectOptions } from './index'
 
-export const Wrapper = styled('div').withConfig({ shouldForwardProp })`
-  position: relative;
-  ${system}
-`
+export const Wrapper = styled('div').withConfig({ shouldForwardProp })<{ disabled: boolean }>(
+  ({ disabled }) => css`
+    position: relative;
+    ${system}
+    ${IconWrapper} {
+      color: ${disabled ? th('defaultFields.select.disabled.color') : 'initial'};
+    }
+  `
+)
+
+export const IconWrapper = styled(WUIIconWrapper)``
 
 export const InputWrapper = styled.div`
   position: relative;
@@ -63,7 +71,7 @@ export const Input = styled('div').withConfig({ shouldForwardProp })<{
         left: 0;
         ${overflowEllipsis};
         padding: inherit;
-        opacity: 0.5;
+        ${th('defaultFields.placeholder')}
       }
       &::before {
         height: auto;
@@ -146,6 +154,10 @@ export const DropDownIndicator = styled.button.withConfig({ shouldForwardProp })
 
     &:not(:last-child) {
       width: auto;
+    }
+
+    &:disabled {
+      color: ${th('defaultFields.select.disabled.color')};
     }
   `
 )


### PR DESCRIPTION
Issue raised for the showcase editor by Jade :
- The icons and the dropdown arrow on the right should have the same color as the text when the select is in a disabled state, according to [the select design specs](https://www.figma.com/file/l9klusKgMYIp90BkLBE3K7/Forms?type=design&node-id=2310-2800&mode=design&t=lqcGfKRG02slaj3g-0)