### PR TITLE
fix: don't set translation if no element

### DIFF
--- a/packages/Breadcrumb/src/index.tsx
+++ b/packages/Breadcrumb/src/index.tsx
@@ -63,6 +63,7 @@ export const BreadcrumbComponent = forwardRef<'div', BreadcrumbProps>(
     })
 
     function translate(element: HTMLElement, value: number) {
+      if (!element) return
       element.style.transform = `scale3d(${value}, 1, 1)`
     }
 


### PR DESCRIPTION
An error in sentry has shown that `style` could be called on `undefined` here 👉 https://github.com/WTTJ/welcome-ui/blob/main/packages/Breadcrumb/src/index.tsx#L66

(the sentry error for those who have access 👉  https://wttj.sentry.io/issues/5458739338/?environment=production&project=1222380&query=is:unresolved+issue.priority:%5Bhigh,+medium%5D&statsPeriod=1h&stream_index=0)

This is just about fixing the error when no element.