### PR TITLE
chore: allow shape prop to use object notation with breakpoints as keys

### DIFF
--- a/docs/pages/components/button.mdx
+++ b/docs/pages/components/button.mdx
@@ -28,6 +28,7 @@ Built with [Ariakit](https://ariakit.org/components/button) for a better accessi
 <Button variant="secondary">Secondary</Button>
 <Button variant="tertiary">Tertiary</Button>
 <Button variant="ghost">Ghost</Button>
+<Button shape={{_: 'square', md: 'default', lg: 'circle'}}><WttjIcon /></Button>
 ```
 
 ### States

--- a/packages/Button/package.json
+++ b/packages/Button/package.json
@@ -51,7 +51,8 @@
     "@welcome-ui/box": "^5.16.2",
     "@welcome-ui/loader": "^5.17.0",
     "@welcome-ui/system": "^5.16.2",
-    "@welcome-ui/utils": "^5.16.2"
+    "@welcome-ui/utils": "^5.16.2",
+    "@welcome-ui/core": "^5.16.2"
   },
   "devDependencies": {
     "@welcome-ui/icons": "^5.16.2",

--- a/packages/Button/src/index.tsx
+++ b/packages/Button/src/index.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 import { Box } from '@welcome-ui/box'
 import { Loader } from '@welcome-ui/loader'
+import type { WuiTheme } from '@welcome-ui/core'
 
 import * as S from './styles'
 
-export type Shape = 'circle' | 'square'
+export type ShapeValues = 'circle' | 'square' | 'default'
+export type Shape = ShapeValues | Record<keyof WuiTheme['screens'], ShapeValues>
 export type Size = 'xxs' | 'xs' | 'sm' | 'md' | 'lg'
 export type Variant =
   | 'primary'

--- a/packages/Button/tests/index.test.tsx
+++ b/packages/Button/tests/index.test.tsx
@@ -54,6 +54,39 @@ describe('<Button />', () => {
     expect(button).toHaveStyleRule('height', theme.buttons.sizes.sm.height)
   })
 
+  it('should look like a circle', () => {
+    const theme = createTheme()
+
+    render(
+      <Button dataTestId="button" shape="circle" size="sm">
+        {content}
+      </Button>
+    )
+    const button = screen.getByTestId('button')
+
+    expect(button).toHaveStyleRule('width', theme.buttons.sizes.sm.height)
+    expect(button).toHaveStyleRule('padding', '0')
+    expect(button).toHaveStyleRule('border-radius', theme.buttons.sizes.sm.height)
+  })
+
+  it('should look like the default button', () => {
+    const theme = createTheme()
+
+    render(
+      // Disabling type check since people wui user can be wrong on the value if not using TS
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      <Button dataTestId="button" shape="wrong-value" size="sm">
+        {content}
+      </Button>
+    )
+    const button = screen.getByTestId('button')
+
+    expect(button).toHaveStyleRule('width', 'auto')
+    expect(button).toHaveStyleRule('padding', theme.buttons.sizes.sm.padding)
+    expect(button).toHaveStyleRule('border-radius', theme.buttons.primary.borderRadius)
+  })
+
   it('should have correct size', () => {
     const theme = createTheme()
 
@@ -136,6 +169,96 @@ describe('<Button />', () => {
     expect(button.tagName.toLowerCase()).toBe('a')
     expect(button).toHaveClass('wui-test')
     expect(button).toHaveAttribute('rel', 'noopener noreferrer') // added by target="_blank" on Link
+  })
+
+  it('should render width the shape prop being an object', () => {
+    const theme = createTheme()
+
+    render(
+      <Button dataTestId="button" shape={{ _: 'circle' }} size="sm">
+        {content}
+      </Button>
+    )
+
+    const button = screen.getByTestId('button')
+
+    expect(button).toHaveStyle({
+      height: theme.buttons.sizes.sm.height,
+    })
+  })
+
+  it('should render width the shape prop set as circle for md breakpoint', () => {
+    const theme = createTheme()
+    render(
+      <Button dataTestId="button" shape={{ md: 'circle' }} size="sm">
+        {content}
+      </Button>
+    )
+
+    const button = screen.getByTestId('button')
+
+    expect(button).toHaveStyleRule('width', theme.buttons.sizes.sm.height, {
+      media: `(width >= ${theme.screens.md}px)`,
+    })
+    expect(button).toHaveStyleRule('padding', '0', {
+      media: `(width >= ${theme.screens.md}px)`,
+    })
+    expect(button).toHaveStyleRule('border-radius', theme.buttons.sizes.sm.height, {
+      media: `(width >= ${theme.screens.md}px)`,
+    })
+  })
+
+  it('should render width the shape prop being and object and set as circle (using _)', () => {
+    const theme = createTheme()
+    render(
+      <Button dataTestId="button" shape={{ _: 'circle' }} size="sm">
+        {content}
+      </Button>
+    )
+
+    const button = screen.getByTestId('button')
+
+    expect(button).toHaveStyleRule('width', theme.buttons.sizes.sm.height)
+    expect(button).toHaveStyleRule('padding', '0')
+    expect(button).toHaveStyleRule('border-radius', theme.buttons.sizes.sm.height)
+  })
+
+  it('should render width the shape prop set as circle for _, then default for md and square for lg breakpoints', () => {
+    const theme = createTheme()
+    render(
+      <Button dataTestId="button" shape={{ _: 'circle', md: 'default', lg: 'square' }}>
+        {content}
+      </Button>
+    )
+
+    const button = screen.getByTestId('button')
+
+    // breakpoint '_'
+    expect(button).toHaveStyleRule('width', theme.buttons.sizes.md.height)
+    expect(button).toHaveStyleRule('padding', '0')
+    expect(button).toHaveStyleRule('border-radius', theme.buttons.sizes.md.height)
+
+    // breakpoint 'md'
+    expect(button).toHaveStyleRule('width', 'auto', {
+      media: `(width >= ${theme.screens.md}px)`,
+    })
+    expect(button).toHaveStyleRule('padding', theme.buttons.sizes.md.padding, {
+      media: `(width >= ${theme.screens.md}px)`,
+    })
+    expect(button).toHaveStyleRule('border-radius', '0', {
+      media: `(width >= ${theme.screens.md}px)`,
+    })
+
+    // breakpoint 'lg'
+    expect(button).toHaveStyleRule('width', theme.buttons.sizes.md.height, {
+      media: `(width >= ${theme.screens.lg}px)`,
+    })
+    expect(button).toHaveStyleRule('padding', '0', {
+      media: `(width >= ${theme.screens.lg}px)`,
+    })
+    expect(button).toHaveStyleRule('border-radius', '0', {
+      media: `(width >= ${theme.screens.lg}px)`,
+    })
   })
 
   it('should have correct Icon size with Icon and text', () => {


### PR DESCRIPTION
To avoid Cumulative Layout Shift, we have spotted that we could leverage the usage of the object notation on Button's `shape` prop (like we do on style props)
(more info here 👉 https://www.debugbear.com/project/865/pageLoad/6293/overview?metric=cumulativeLayoutShift focus on the share button)

Until now, button's `shape` attribute had the type `'circle' | square`

It can now be `circle | square | default | Record<BREAKPOINT KEYS HERE, ('circle' | 'square' | 'default')>`

We have an app using `Button` with the `shape` prop being dynamically set with JS to `circle` depending on breakpoints.
Unfortunately, these dynamic styles are not working on SSR so it is better to use css to do so.