### PR TITLE
Chore: tooltip redesign

### DIFF
--- a/packages/Core/src/theme/tooltips.ts
+++ b/packages/Core/src/theme/tooltips.ts
@@ -3,16 +3,17 @@ import { CSSObject } from '@xstyled/styled-components'
 import { WuiTheme } from './types'
 
 export const getTooltips = (theme: WuiTheme): CSSObject => {
-  const { borderWidths, colors, fontSizes, lineHeights, space, toRem } = theme
+  const { borderWidths, colors, fontSizes, fontWeights, radii, space, toRem } = theme
 
   return {
     maxWidth: toRem(200),
     backgroundColor: colors.black,
     color: colors.white,
     padding: `${space.xs} ${space.sm}`,
-    fontSize: fontSizes.xs,
-    lineHeight: lineHeights.xs,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.medium,
     border: `${borderWidths.sm} solid ${colors['light-400']}`,
+    borderRadius: radii.md,
     boxSizing: 'border-box',
   }
 }

--- a/packages/Tooltip/docs/examples/placement.tsx
+++ b/packages/Tooltip/docs/examples/placement.tsx
@@ -2,79 +2,95 @@ import * as React from 'react'
 import { Tooltip } from '@welcome-ui/tooltip'
 import { Button } from '@welcome-ui/button'
 import { Flex } from '@welcome-ui/flex'
-
+import { Field } from '@welcome-ui/field'
+import { Checkbox } from '@welcome-ui/checkbox'
+import { InputText } from '@welcome-ui/input-text'
 const Example = () => {
+  const [withArrow, setWithArrow] = React.useState(true)
+  const [tooltipContent, setTooltipContent] = React.useState('This is the tooltip content')
+
   return (
-    <>
+    <Flex flexDirection="column" gap="lg">
+      <Field cursor="pointer" label="Enable the arrow property">
+        <Checkbox checked={withArrow} name="arrow" onChange={() => setWithArrow(!withArrow)} />
+      </Field>
+
+      <Field label="Tooltip content">
+        <InputText
+          name="tooltipContent"
+          onChange={e => setTooltipContent(e.target.value)}
+          value={tooltipContent}
+        />
+      </Field>
       <Flex flexWrap="wrap" gap="lg">
-        <Tooltip content="Tooltip" fixed placement="top-start">
+        <Tooltip content={tooltipContent} fixed placement="top-start" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>top-start &#8598; </span>
           </Button>
         </Tooltip>
-        <Tooltip content="Tooltip" fixed placement="top">
+        <Tooltip content={tooltipContent} fixed placement="top" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>top &#8593; </span>
           </Button>
         </Tooltip>
-        <Tooltip content="Tooltip" fixed placement="top-end">
+        <Tooltip content={tooltipContent} fixed placement="top-end" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>top-end &#8599; </span>
           </Button>
         </Tooltip>
       </Flex>
       <Flex flexWrap="wrap" gap="lg">
-        <Tooltip content="Tooltip" fixed placement="bottom-start">
+        <Tooltip content={tooltipContent} fixed placement="bottom-start" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>bottom-start &#8601; </span>
           </Button>
         </Tooltip>
-        <Tooltip content="Tooltip" fixed placement="bottom">
+        <Tooltip content={tooltipContent} fixed placement="bottom" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>bottom &#8595; </span>
           </Button>
         </Tooltip>
-        <Tooltip content="Tooltip" fixed placement="bottom-end">
+        <Tooltip content={tooltipContent} fixed placement="bottom-end" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>bottom-end &#8600; </span>
           </Button>
         </Tooltip>
       </Flex>
       <Flex flexWrap="wrap" gap="lg">
-        <Tooltip content="Tooltip" fixed placement="left-start">
+        <Tooltip content={tooltipContent} fixed placement="left-start" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>left-start &#8598; </span>
           </Button>
         </Tooltip>
-        <Tooltip content="Tooltip" fixed placement="left">
+        <Tooltip content={tooltipContent} fixed placement="left" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>left &#8592; </span>
           </Button>
         </Tooltip>
-        <Tooltip content="Tooltip" fixed placement="left-end">
+        <Tooltip content={tooltipContent} fixed placement="left-end" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>left-end &#8601; </span>
           </Button>
         </Tooltip>
       </Flex>
       <Flex flexWrap="wrap" gap="lg">
-        <Tooltip content="Tooltip" fixed placement="right-start">
+        <Tooltip content={tooltipContent} fixed placement="right-start" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>right-start &#8599; </span>
           </Button>
         </Tooltip>
-        <Tooltip content="Tooltip" fixed placement="right">
+        <Tooltip content={tooltipContent} fixed placement="right" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>right &#8594; </span>
           </Button>
         </Tooltip>
-        <Tooltip content="Tooltip" fixed placement="right-end">
+        <Tooltip content={tooltipContent} fixed placement="right-end" withArrow={withArrow}>
           <Button size="sm" w={120}>
             <span>right-end &#8600; </span>
           </Button>
         </Tooltip>
       </Flex>
-    </>
+    </Flex>
   )
 }
 

--- a/packages/Tooltip/docs/examples/withArrow.tsx
+++ b/packages/Tooltip/docs/examples/withArrow.tsx
@@ -5,7 +5,7 @@ import { Button } from '@welcome-ui/button'
 const Example = () => {
   return (
     <Tooltip content="Tooltip" fixed withArrow>
-      <Button>Fixed tooltip with an arrow ⬇️</Button>
+      <Button>With an arrow ⬇️</Button>
     </Tooltip>
   )
 }

--- a/packages/Tooltip/docs/examples/withArrow.tsx
+++ b/packages/Tooltip/docs/examples/withArrow.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+import { Tooltip } from '@welcome-ui/tooltip'
+import { Button } from '@welcome-ui/button'
+
+const Example = () => {
+  return (
+    <Tooltip content="Tooltip" fixed withArrow>
+      <Button>Fixed tooltip with an arrow ⬇️</Button>
+    </Tooltip>
+  )
+}
+
+export default Example

--- a/packages/Tooltip/docs/index.mdx
+++ b/packages/Tooltip/docs/index.mdx
@@ -12,6 +12,14 @@ Maybe you don't want the tooltip to follow the cursor set by `fixed` property
 
 <div data-playground="fixed.tsx" data-component="Tooltip"></div>
 
+## With an arrow
+
+You can use the `withArrow` property to display an arrow pointing towards your trigger
+
+It will only display with the `fixed` property set to `true`
+
+<div data-playground="withArrow.tsx" data-component="Tooltip"></div>
+
 ### With a long text and a custom placement
 
 Set a `max-width` for long text

--- a/packages/Tooltip/docs/index.mdx
+++ b/packages/Tooltip/docs/index.mdx
@@ -12,7 +12,7 @@ Maybe you don't want the tooltip to follow the cursor set by `fixed` property
 
 <div data-playground="fixed.tsx" data-component="Tooltip"></div>
 
-## With an arrow
+### With an arrow
 
 You can use the `withArrow` property to display an arrow pointing towards your trigger
 

--- a/packages/Tooltip/src/index.tsx
+++ b/packages/Tooltip/src/index.tsx
@@ -8,7 +8,7 @@ import * as S from './styles'
 export type TooltipOptions = {
   children: React.ReactNode
   content: string | JSX.Element
-  arrow?: boolean
+  withArrow?: boolean
   fixed?: boolean
 } & Pick<Ariakit.TooltipStoreProps, 'placement'> &
   Pick<Ariakit.TooltipOptions, 'gutter'>
@@ -23,7 +23,7 @@ export const Tooltip = forwardRef<'div', TooltipProps>(
       fixed = false,
       placement = fixed ? 'top' : 'bottom',
       gutter = 8,
-      arrow,
+      withArrow,
       ...rest
     },
     ref
@@ -79,11 +79,11 @@ export const Tooltip = forwardRef<'div', TooltipProps>(
           updatePosition={!fixed ? updatePosition : undefined}
         >
           <S.FadeIn
-            arrow={arrow}
             fixed={fixed}
             onTransitionEnd={stopAnimation}
             placement={currentPlacement}
             popoverHeight={popoverElement?.getBoundingClientRect().height}
+            withArrow={withArrow}
           >
             {content}
           </S.FadeIn>

--- a/packages/Tooltip/src/styles.ts
+++ b/packages/Tooltip/src/styles.ts
@@ -35,10 +35,34 @@ const fadeInStyle = css`
 type FadeIn = {
   placement?: TooltipProps['placement']
   fixed?: boolean
+  arrow?: boolean
+  popoverHeight: number
+}
+
+const arrowSize = 12
+const arrowSpacer = arrowSize * 1.5
+
+const getXPosition = (placement: string) => {
+  if (placement.includes('start')) return arrowSpacer
+  if (placement.includes('end')) return `calc(100% - ${arrowSpacer + 'px'})`
+  return '50%'
+}
+
+const getYPosition = (placement: string, popoverHeight: number) => {
+  //To avoid offsetting the arrow outside its parent, we check that the sizer is not bigger than the tooltip size
+  const isPopoverSmall = popoverHeight - arrowSpacer < arrowSize
+
+  if (placement.includes('end')) {
+    return isPopoverSmall ? `${arrowSize}px` : `calc(100% - ${arrowSpacer}px)`
+  }
+  if (placement.includes('start')) {
+    return isPopoverSmall ? `${arrowSize}px` : `${arrowSpacer}px`
+  }
+  return '50%'
 }
 
 export const FadeIn = styled.div<FadeIn>(
-  ({ fixed, placement }) => css`
+  ({ arrow, fixed, placement, popoverHeight }) => css`
     ${th('tooltips')};
     ${system};
     transition: opacity ${th.transition('medium')}, transform ${th.transition('medium')},
@@ -46,6 +70,56 @@ export const FadeIn = styled.div<FadeIn>(
     visibility: hidden;
     opacity: 0;
     transform-origin: top center;
+    z-index: 10;
+
+    ${fixed &&
+    arrow &&
+    css`
+      &::after {
+        content: '';
+        position: absolute;
+        background-color: inherit;
+        width: ${arrowSize};
+        height: ${arrowSize};
+        border-width: inherit;
+        border-style: solid;
+        border-color: transparent light-400 light-400 transparent;
+        border-bottom-right-radius: inherit;
+        clip-path: polygon(0% 100%, 0% 100%, 100% 100%, 100% 0%);
+        z-index: 0;
+        translate: -50% -50%;
+
+        ${placement.includes('top') &&
+        css`
+          top: 100%;
+          left: ${getXPosition(placement)};
+          rotate: 45deg;
+        `}
+
+        ${placement.includes('bottom') &&
+        css`
+          bottom: 100%;
+          left: ${getXPosition(placement)};
+          translate: -50% 50%;
+          rotate: 225deg;
+        `}
+        
+        ${placement.includes('left') &&
+        css`
+          top: ${getYPosition(placement, popoverHeight)};
+          left: 100%;
+          rotate: -45deg;
+        `}
+        
+        ${placement.includes('right') &&
+        css`
+          top: ${getYPosition(placement, popoverHeight)};
+          left: 0%;
+          rotate: 135deg;
+        `}
+      }
+    `}
+
     ${fixed &&
     css`
       transform: ${getFadeInDirection(placement)};

--- a/packages/Tooltip/src/styles.ts
+++ b/packages/Tooltip/src/styles.ts
@@ -35,7 +35,7 @@ const fadeInStyle = css`
 type FadeIn = {
   placement?: TooltipProps['placement']
   fixed?: boolean
-  arrow?: boolean
+  withArrow?: boolean
   popoverHeight: number
 }
 
@@ -62,7 +62,7 @@ const getYPosition = (placement: string, popoverHeight: number) => {
 }
 
 export const FadeIn = styled.div<FadeIn>(
-  ({ arrow, fixed, placement, popoverHeight }) => css`
+  ({ fixed, placement, popoverHeight, withArrow }) => css`
     ${th('tooltips')};
     ${system};
     transition: opacity ${th.transition('medium')}, transform ${th.transition('medium')},
@@ -73,7 +73,7 @@ export const FadeIn = styled.div<FadeIn>(
     z-index: 10;
 
     ${fixed &&
-    arrow &&
+    withArrow &&
     css`
       &::after {
         content: '';

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -239,5 +239,6 @@ export default {
   "/Tooltip/docs/examples/fixed.tsx": dynamic(() => import("../../packages/Tooltip/docs/examples/fixed.tsx").then(mod => mod), { ssr: false }),
   "/Tooltip/docs/examples/long-text.tsx": dynamic(() => import("../../packages/Tooltip/docs/examples/long-text.tsx").then(mod => mod), { ssr: false }),
   "/Tooltip/docs/examples/overview.tsx": dynamic(() => import("../../packages/Tooltip/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
-  "/Tooltip/docs/examples/placement.tsx": dynamic(() => import("../../packages/Tooltip/docs/examples/placement.tsx").then(mod => mod), { ssr: false })
+  "/Tooltip/docs/examples/placement.tsx": dynamic(() => import("../../packages/Tooltip/docs/examples/placement.tsx").then(mod => mod), { ssr: false }),
+  "/Tooltip/docs/examples/withArrow.tsx": dynamic(() => import("../../packages/Tooltip/docs/examples/withArrow.tsx").then(mod => mod), { ssr: false })
 };


### PR DESCRIPTION
[new Tooltip figma](https://www.figma.com/design/TC5aahnPVDU1hhBcff037e/Feedback?node-id=2-890&t=U5KECT8ulj9zSnFz-0)
The arrow's position is based on the tooltip placement recovered from the store, and not the user prop. 
This garanties that the arrow's position is coherent with the tooltip's if it doesn't have enough space. 

https://github.com/WTTJ/welcome-ui/assets/85453899/ea58e3fa-7f8c-401f-b16b-830be38acf7c
https://github.com/WTTJ/welcome-ui/assets/85453899/f46bb833-510a-4334-8cdf-fa2097c22266

