### PR TITLE
fix(Tag): use ternary for conditional prop

### DIFF
--- a/packages/Tag/src/index.tsx
+++ b/packages/Tag/src/index.tsx
@@ -52,10 +52,9 @@ export const Tag = forwardRef<'div', TagProps>(
   ) => {
     const content = wrapChildren(children as JSX.Element)
     // get size children for int and string
-    const childrenLength =
-      !!(children || children === 0) &&
-      ['number', 'string'].includes(typeof children) &&
-      children.toString().length
+    const hasIntOrStringChildren =
+      !!(children || children === 0) && ['number', 'string'].includes(typeof children)
+    const childrenLength = hasIntOrStringChildren ? children.toString().length : undefined
     const hasLink = !!href || !!to
 
     return (


### PR DESCRIPTION
PR to clean up a warning recurring in test files. I used a ternary rather than the `&&` notation to check for the childrenLength.

<img width="999" alt="Screenshot 2024-08-02 at 15 11 34" src="https://github.com/user-attachments/assets/e718d8f3-529a-45b6-895e-39d9bfde9314">
