### PR TITLE
feat: allow to display custom file name in the preview of a FileDrop

### DIFF
--- a/packages/FileDrop/docs/examples/custom-filename.tsx
+++ b/packages/FileDrop/docs/examples/custom-filename.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import { FileDrop } from '@welcome-ui/file-drop'
+
+const Example = () => {
+  const handleChange = () => {
+    // your code
+  }
+
+  return (
+    <FileDrop
+      fileName="My custom filename"
+      handleAddFile={handleChange}
+      handleRemoveFile={handleChange}
+      name="file2"
+      value="https://test-documents-file/filename-too-complicated-to-display-1234.docx?v=63731713698"
+    />
+  )
+}
+
+export default Example

--- a/packages/FileDrop/docs/index.mdx
+++ b/packages/FileDrop/docs/index.mdx
@@ -51,6 +51,12 @@ Sometime in the url we don't have the type of the file, you can override with `f
 
 <div data-playground="no-type.tsx" data-component="FileDrop"></div>
 
+### With a custom filename
+
+By default, the filename is retrieved from the url. If you want to display a custom filename, you can use the `fileName` prop.
+
+<div data-playground="custom-filename.tsx" data-component="FileDrop"></div>
+
 ### Disabled
 
 <div data-playground="disabled.tsx" data-component="FileDrop"></div>

--- a/packages/FileDrop/docs/properties.json
+++ b/packages/FileDrop/docs/properties.json
@@ -26,6 +26,25 @@
           "name": "Accept"
         }
       },
+      "fileName": {
+        "defaultValue": null,
+        "description": "",
+        "name": "fileName",
+        "parent": {
+          "fileName": "FileDrop/src/index.tsx",
+          "name": "FileDropOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "FileDrop/src/index.tsx",
+            "name": "FileDropOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
       "forceFileType": {
         "defaultValue": null,
         "description": "",

--- a/packages/FileDrop/src/FilePreview.tsx
+++ b/packages/FileDrop/src/FilePreview.tsx
@@ -8,18 +8,20 @@ import { FileType, WordingsType } from './index'
 
 export interface MessageProps {
   file: FileType
+  fileName?: string
   forceFileType?: ForceFileType
 }
 
 export const FilePreview: React.FC<MessageProps & WordingsType> = ({
   file,
+  fileName,
   forceFileType,
   previewButtonText = 'Preview',
 }) => {
   const isUrl = typeof file === 'string'
   const Icon = getFileIcon(file, forceFileType)
   const size = file instanceof File ? getFileSize(file) : null
-  const name = getFileName(file)
+  const name = isUrl && fileName ? fileName : getFileName(file)
 
   return (
     <>

--- a/packages/FileDrop/src/Preview.tsx
+++ b/packages/FileDrop/src/Preview.tsx
@@ -11,6 +11,7 @@ export const Preview: React.FC<ChildrenType> = ({
   disabled,
   error,
   file,
+  fileName,
   fileUrl,
   forceFileType,
   isAnImage,
@@ -29,7 +30,9 @@ export const Preview: React.FC<ChildrenType> = ({
     if (isAnImage) {
       return <ImagePreview src={fileUrl as string} />
     } else {
-      return <FilePreview file={file} forceFileType={forceFileType} {...wordings} />
+      return (
+        <FilePreview file={file} fileName={fileName} forceFileType={forceFileType} {...wordings} />
+      )
     }
   }
   return <Message disabled={disabled} openFile={openFile} {...wordings} />

--- a/packages/FileDrop/src/index.tsx
+++ b/packages/FileDrop/src/index.tsx
@@ -45,6 +45,7 @@ export type ChildrenType = {
   disabled?: boolean
   error?: string
   file?: FileType
+  fileName?: string
   fileUrl?: FileUrlType
   forceFileType?: ForceFileType
   isAnImage?: boolean
@@ -58,6 +59,7 @@ export interface FileDropOptions {
   /** Pass a comma-separated string of file types e.g. "image/png" or "image/png,image/jpeg" */
   accept?: Accept
   children?: (state: ChildrenType) => JSX.Element
+  fileName?: string
   isClearable?: boolean
   isEditable?: boolean
   forceFileType?: ForceFileType
@@ -83,6 +85,7 @@ export const FileDrop = forwardRef<'div', FileDropProps>(
       children = Preview,
       dataTestId,
       disabled,
+      fileName,
       forceFileType,
       handleAddFile,
       handleRemoveFile,
@@ -199,6 +202,7 @@ export const FileDrop = forwardRef<'div', FileDropProps>(
             disabled,
             error,
             file,
+            fileName,
             fileUrl: file && getPreviewUrl(file),
             forceFileType,
             isAnImage: forceFileType === 'image' || isAnImage(file),

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -84,6 +84,7 @@ export default {
   "/Field/docs/examples/refs.tsx": dynamic(() => import("../../packages/Field/docs/examples/refs.tsx").then(mod => mod), { ssr: false }),
   "/Field/docs/examples/required.tsx": dynamic(() => import("../../packages/Field/docs/examples/required.tsx").then(mod => mod), { ssr: false }),
   "/Field/docs/examples/variants.tsx": dynamic(() => import("../../packages/Field/docs/examples/variants.tsx").then(mod => mod), { ssr: false }),
+  "/FileDrop/docs/examples/custom-filename.tsx": dynamic(() => import("../../packages/FileDrop/docs/examples/custom-filename.tsx").then(mod => mod), { ssr: false }),
   "/FileDrop/docs/examples/disabled.tsx": dynamic(() => import("../../packages/FileDrop/docs/examples/disabled.tsx").then(mod => mod), { ssr: false }),
   "/FileDrop/docs/examples/image.tsx": dynamic(() => import("../../packages/FileDrop/docs/examples/image.tsx").then(mod => mod), { ssr: false }),
   "/FileDrop/docs/examples/no-type.tsx": dynamic(() => import("../../packages/FileDrop/docs/examples/no-type.tsx").then(mod => mod), { ssr: false }),


### PR DESCRIPTION
Add a new `fileName` prop to the `FileDrop` component, allowing users to display a custom file name in the preview instead of the default name extracted from the URL.  
This is useful when the actual file name is too complex or not representative of the file's content.