### PR TITLE
fix: swiper item width when there is less than x items

### DIFF
--- a/packages/Swiper/src/styles.ts
+++ b/packages/Swiper/src/styles.ts
@@ -116,6 +116,7 @@ export const Container = styled.ulBox<
       list-style-type: none;
       margin-right: ${spaceBetween};
       min-width: ${getSlideWidth(mobile, spaceBetween, theme.toRem)};
+      max-width: ${getSlideWidth(mobile, spaceBetween, theme.toRem)};
       flex: 1;
 
       &:last-child {
@@ -128,6 +129,7 @@ export const Container = styled.ulBox<
       css`
         > * {
           min-width: ${getSlideWidth(mobile, spaceBetween, theme.toRem)};
+          max-width: ${getSlideWidth(mobile, spaceBetween, theme.toRem)};
 
           &:nth-of-type(${mobile}n + 1) {
             scroll-snap-align: start;
@@ -141,6 +143,7 @@ export const Container = styled.ulBox<
       css`
         > * {
           min-width: ${getSlideWidth(tablet, spaceBetween, theme.toRem)};
+          max-width: ${getSlideWidth(tablet, spaceBetween, theme.toRem)};
 
           &:nth-of-type(${tablet}n + 1) {
             scroll-snap-align: start;
@@ -154,6 +157,8 @@ export const Container = styled.ulBox<
       css`
         > * {
           min-width: ${getSlideWidth(desktop, spaceBetween, theme.toRem)};
+          max-width: ${getSlideWidth(desktop, spaceBetween, theme.toRem)};
+
           scroll-snap-align: unset;
 
           &:nth-of-type(${desktop}n + 1) {
@@ -173,6 +178,7 @@ export const Container = styled.ulBox<
       css`
         > * {
           min-width: ${getSlideWidth(desktop + 2, spaceBetween, theme.toRem)};
+          max-width: ${getSlideWidth(desktop + 2, spaceBetween, theme.toRem)};
         }
       `}
     }


### PR DESCRIPTION
What expected:
![Screenshot 2024-09-04 at 10 55 50](https://github.com/user-attachments/assets/ab660133-83e7-409f-932b-e9d83315688c)


Issue:
![Screenshot 2024-09-04 at 10 18 54](https://github.com/user-attachments/assets/ed66fd94-fbf5-495f-b49f-788d2b605b57)
![Screenshot 2024-09-04 at 10 19 02](https://github.com/user-attachments/assets/306ac874-93a4-4cde-83e6-87e6e9c68c81)
