### PR TITLE
Chore(Select): use pointer cursor when hovering select options [WUI-50]

### DIFF
--- a/packages/Select/docs/examples/creatable-custom.tsx
+++ b/packages/Select/docs/examples/creatable-custom.tsx
@@ -27,8 +27,8 @@ const Example = () => {
       renderCreateItem={value => {
         return (
           <Box alignItems="center" display="flex">
-            <AddIcon mr="sm" />
-            <Text m={0}>
+            <AddIcon mr="sm" size="sm" />
+            <Text as="span" variant="sm">
               Add <b>{value.toString()}</b> as a new option
             </Text>
           </Box>

--- a/packages/Select/src/styles.ts
+++ b/packages/Select/src/styles.ts
@@ -93,6 +93,10 @@ export const Menu = styled.ul`
   transition: medium;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+
+  &:hover > * {
+    cursor: pointer;
+  }
 `
 
 export const Item = styled.li(
@@ -120,10 +124,6 @@ export const Item = styled.li(
     text-decoration: none;
     font-size: sm;
     transition: background ${th.transition('medium')};
-
-    &:hover {
-      cursor: pointer;
-    }
   `
 )
 

--- a/packages/Select/src/styles.ts
+++ b/packages/Select/src/styles.ts
@@ -46,7 +46,7 @@ export const Input = styled('div').withConfig({ shouldForwardProp })<{
       iconPlacement,
     })};
     ${overflowEllipsis};
-    cursor: default;
+    cursor: pointer;
     ${system}
     line-height: 1em;
 

--- a/packages/Select/src/styles.ts
+++ b/packages/Select/src/styles.ts
@@ -120,6 +120,10 @@ export const Item = styled.li(
     text-decoration: none;
     font-size: sm;
     transition: background ${th.transition('medium')};
+
+    &:hover {
+      cursor: pointer;
+    }
   `
 )
 


### PR DESCRIPTION
[WUI-50: Add a pointer cursor to Select dropdown](https://linear.app/wttj/issue/WUI-50/add-a-pointer-cursor-to-select-dropdown)

<img width="767" alt="select pointer cursor after" src="https://github.com/user-attachments/assets/fba82441-c3ec-4860-a61b-e77f7ae801e3">
