### PR TITLE
fix(Modal): border radius and overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ yarn start
 yarn watch
 ```
 
-4. and go to https://localhost:3020
+4. and go to http://localhost:3020
 
 ## How to release
 

--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
   "ignore": [
     "website"
   ],
-  "version": "5.22.2",
+  "version": "5.22.3-alpha.0",
   "npmClient": "yarn",
   "useNx": false
 }

--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
   "ignore": [
     "website"
   ],
-  "version": "5.22.3-alpha.0",
+  "version": "5.22.4-alpha.0",
   "npmClient": "yarn",
   "useNx": false
 }

--- a/packages/Core/package.json
+++ b/packages/Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@welcome-ui/core",
-  "version": "5.22.2",
+  "version": "5.22.3-alpha.0",
   "description": "welcome-ui: Core utils",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/Core/src/theme/modals.ts
+++ b/packages/Core/src/theme/modals.ts
@@ -28,6 +28,8 @@ export const getModals = (theme: WuiTheme): ThemeModals => {
     },
     header: {
       backgroundColor: colors['light-900'],
+      borderTopLeftRadius: radii.xxl,
+      borderTopRightRadius: radii.xxl,
       paddingTop: space.xxl,
       paddingRight: space['3xl'],
       paddingBottom: space.xxl,
@@ -47,6 +49,8 @@ export const getModals = (theme: WuiTheme): ThemeModals => {
     footer: {
       backgroundColor: colors['light-900'],
       borderTop: `solid ${colors.border}`,
+      borderBottomLeftRadius: radii.xxl,
+      borderBottomRightRadius: radii.xxl,
       children: {
         paddingRight: space.xxl,
         paddingLeft: space.xxl,

--- a/packages/DropdownMenu/package.json
+++ b/packages/DropdownMenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@welcome-ui/dropdown-menu",
-  "version": "5.22.2",
+  "version": "5.22.3-alpha.0",
   "description": "welcome-ui: A DropdownMenu component",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -48,7 +48,7 @@
   "dependencies": {
     "@ariakit/react": "0.4.3",
     "@welcome-ui/box": "^5.20.0",
-    "@welcome-ui/core": "^5.22.2",
+    "@welcome-ui/core": "^5.22.3-alpha.0",
     "@welcome-ui/system": "^5.17.1",
     "@welcome-ui/utils": "^5.22.1"
   },

--- a/packages/Modal/package.json
+++ b/packages/Modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@welcome-ui/modal",
-  "version": "5.22.3-alpha.0",
+  "version": "5.22.4-alpha.0",
   "description": "Modal from Ariakit with a really nice theme 👀",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/Modal/package.json
+++ b/packages/Modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@welcome-ui/modal",
-  "version": "5.22.2",
+  "version": "5.22.3-alpha.0",
   "description": "Modal from Ariakit with a really nice theme 👀",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/Modal/src/styles.ts
+++ b/packages/Modal/src/styles.ts
@@ -48,7 +48,7 @@ export const Dialog = styled.divBox(
     height: 100%;
     max-height: 100%;
     max-width: 100%;
-    overflow: visible;
+    overflow: auto;
     opacity: 0;
     transition:
       opacity 250ms ease-in-out,
@@ -70,9 +70,7 @@ export const Dialog = styled.divBox(
   `
 )
 
-export const Content = styled.divBox`
-  overflow: auto;
-`
+export const Content = styled.divBox``
 
 export const Body = styled.sectionBox`
   ${th('modals.body')};
@@ -96,7 +94,6 @@ export const Footer = styled.footerBox`
   bottom: 0;
   flex-shrink: 0;
   z-index: 1;
-  overflow: hidden;
   ${th('modals.footer')};
 `
 

--- a/packages/Modal/src/styles.ts
+++ b/packages/Modal/src/styles.ts
@@ -48,7 +48,7 @@ export const Dialog = styled.divBox(
     height: 100%;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
+    overflow: visible;
     opacity: 0;
     transition:
       opacity 250ms ease-in-out,
@@ -70,7 +70,9 @@ export const Dialog = styled.divBox(
   `
 )
 
-export const Content = styled.divBox``
+export const Content = styled.divBox`
+  overflow: auto;
+`
 
 export const Body = styled.sectionBox`
   ${th('modals.body')};
@@ -94,6 +96,7 @@ export const Footer = styled.footerBox`
   bottom: 0;
   flex-shrink: 0;
   z-index: 1;
+  overflow: hidden;
   ${th('modals.footer')};
 `
 

--- a/packages/Themes/Dark/package.json
+++ b/packages/Themes/Dark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@welcome-ui/themes.dark",
-  "version": "5.22.2",
+  "version": "5.22.3-alpha.0",
   "description": "welcome-ui: Dark theme",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -43,7 +43,7 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "@welcome-ui/core": "^5.22.2"
+    "@welcome-ui/core": "^5.22.3-alpha.0"
   },
   "gitHead": "974e7bfd71f8cfe846cbffd678c3860a8952f9e9",
   "sideEffects": false,

--- a/packages/Themes/Welcome/package.json
+++ b/packages/Themes/Welcome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@welcome-ui/themes.welcome",
-  "version": "5.22.2",
+  "version": "5.22.3-alpha.0",
   "description": "welcome-ui: Welcome theme",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -43,7 +43,7 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "@welcome-ui/core": "^5.22.2"
+    "@welcome-ui/core": "^5.22.3-alpha.0"
   },
   "gitHead": "974e7bfd71f8cfe846cbffd678c3860a8952f9e9",
   "sideEffects": false,

--- a/packages/Themes/WelcomeDark/package.json
+++ b/packages/Themes/WelcomeDark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@welcome-ui/themes.welcome-dark",
-  "version": "5.22.2",
+  "version": "5.22.3-alpha.0",
   "description": "welcome-ui: Welcome Dark theme",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -43,8 +43,8 @@
     "url": "https://github.com/WTTJ/welcome-ui/issues"
   },
   "dependencies": {
-    "@welcome-ui/core": "^5.22.2",
-    "@welcome-ui/themes.welcome": "^5.22.2",
+    "@welcome-ui/core": "^5.22.3-alpha.0",
+    "@welcome-ui/themes.welcome": "^5.22.3-alpha.0",
     "ramda": "^0.30.1"
   },
   "gitHead": "6d279e3c89ce7bd16a2e90245aaebaea2bd69462",


### PR DESCRIPTION
When migrating to latest v5 version, we noticed an issue in the Modal style when:
- It contains a select and need to apply an overflow: "visible" property
- It also contains a Header and/or a Footer

Current:
![Capture d’écran 2024-10-28 à 17 13 24 (1)](https://github.com/user-attachments/assets/5907c34a-0789-44f1-ab21-b914b3fc5252)
![Capture d’écran 2024-10-28 à 17 07 01 (1)](https://github.com/user-attachments/assets/2f7856fe-dbd8-446a-8793-4b8a60eae04d)

Expected (tested on welcome-accounts-front)
<img width="1721" alt="Capture d’écran 2024-10-31 à 17 06 34" src="https://github.com/user-attachments/assets/01756e75-691d-443c-ae8a-a7d148a742f1">
<img width="1714" alt="Capture d’écran 2024-10-31 à 17 07 15" src="https://github.com/user-attachments/assets/619a141e-b259-4791-b0f5-f02b2b30cf8d">
<img width="1721" alt="Capture d’écran 2024-10-31 à 17 08 03" src="https://github.com/user-attachments/assets/ae0a2091-ad20-40c0-b5fe-2c8ed528872e">
<img width="1719" alt="Capture d’écran 2024-10-31 à 17 10 30" src="https://github.com/user-attachments/assets/59981678-6e2b-4e7d-b14a-c782e24f0c32">
<img width="1026" alt="Capture d’écran 2024-10-31 à 17 12 38" src="https://github.com/user-attachments/assets/c67a7589-add3-49db-b2e0-373d36152948">
<img width="1040" alt="Capture d’écran 2024-10-31 à 17 13 51" src="https://github.com/user-attachments/assets/faed46fd-896b-43db-9a79-1f580013e5c8">
<img width="1029" alt="Capture d’écran 2024-10-31 à 17 14 13" src="https://github.com/user-attachments/assets/98123baf-d4bd-4481-ae0d-ae5d108785ca">

