### PR TITLE
feat(Text): add wordBreak property

### DIFF
--- a/packages/Text/docs/examples/wordBreak.tsx
+++ b/packages/Text/docs/examples/wordBreak.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { Text } from '@welcome-ui/text'
+
+const Example = () => {
+  return (
+    <>
+      <Text wordBreak="break-all">
+        Honorificabilitudinitatibus califragilisticexpialidocious
+        Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu
+        グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉
+      </Text>
+      <Text wordBreak="break-word">
+        Honorificabilitudinitatibus califragilisticexpialidocious
+        Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu
+        グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉
+      </Text>
+      <Text>This is a text with short words that does not require the word-break attribute</Text>
+    </>
+  )
+}
+
+export default Example

--- a/packages/Text/docs/index.mdx
+++ b/packages/Text/docs/index.mdx
@@ -17,6 +17,12 @@ Set the number of lines you want to display with `lines`. Your text will be disp
 
 <div data-playground="truncation.tsx" data-component="Text"></div>
 
+### wordBreak
+
+Set whether line breaks appear wherever the text would otherwise overflow its content box with the `wordBreak` property.
+
+<div data-playground="wordBreak.tsx" data-component="Text"></div>
+
 ### withDash
 
 With the `withDash` property, a dash is added before the text in headings _(h0 to h6)_.

--- a/packages/Text/docs/properties.json
+++ b/packages/Text/docs/properties.json
@@ -110,6 +110,58 @@
             }
           ]
         }
+      },
+      "wordBreak": {
+        "defaultValue": null,
+        "description": "",
+        "name": "wordBreak",
+        "parent": {
+          "fileName": "Text/src/index.tsx",
+          "name": "TextOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "Text/src/index.tsx",
+            "name": "TextOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "WordBreak",
+          "value": [
+            {
+              "value": "\"inherit\""
+            },
+            {
+              "value": "\"-moz-initial\""
+            },
+            {
+              "value": "\"initial\""
+            },
+            {
+              "value": "\"revert\""
+            },
+            {
+              "value": "\"revert-layer\""
+            },
+            {
+              "value": "\"unset\""
+            },
+            {
+              "value": "\"break-all\""
+            },
+            {
+              "value": "\"break-word\""
+            },
+            {
+              "value": "\"keep-all\""
+            },
+            {
+              "value": "\"normal\""
+            }
+          ]
+        }
       }
     }
   }

--- a/packages/Text/src/index.tsx
+++ b/packages/Text/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type CSSProperties } from 'react'
 import { CreateWuiProps, forwardRef } from '@welcome-ui/system'
 
 import * as S from './styles'
@@ -25,6 +25,7 @@ export interface TextOptions {
   lines?: number
   variant?: Variant
   withDash?: boolean
+  wordBreak?: CSSProperties['wordBreak']
 }
 
 export type TextProps = CreateWuiProps<'p', TextOptions>

--- a/packages/Text/src/styles.ts
+++ b/packages/Text/src/styles.ts
@@ -24,7 +24,7 @@ const getBlockHeight = (lines: number) => css`
   word-break: ${lines === 1 ? 'break-all' : null};
 `
 
-export const Text = styled.p<TextOptions>(({ lines, theme, variant, withDash }) => {
+export const Text = styled.p<TextOptions>(({ lines, theme, variant, withDash, wordBreak }) => {
   const mobileVariant = MOBILE_VARIANTS[variant as keyof typeof MOBILE_VARIANTS]
   const isHeading = variant?.startsWith('h')
   // only add lineHeight fixer styles when these conditions are fulfilled
@@ -36,6 +36,7 @@ export const Text = styled.p<TextOptions>(({ lines, theme, variant, withDash }) 
 
   return css`
     ${th(`texts.${mobileVariant || variant}`)};
+    word-break: ${wordBreak};
 
     /* Start fallback for non-webkit */
     display: block;

--- a/packages/Text/tests/index.test.tsx
+++ b/packages/Text/tests/index.test.tsx
@@ -60,4 +60,15 @@ describe('<Text>', () => {
     expect(text).toHaveStyleRule('overflow', 'hidden')
     expect(text).toHaveStyleRule('-webkit-line-clamp', '3')
   })
+
+  it('should render correctly with wordBreak property', () => {
+    const { getByTestId } = render(
+      <Text dataTestId="text" wordBreak="break-all">
+        {longContent}
+      </Text>
+    )
+    const text = getByTestId('text')
+
+    expect(text).toHaveStyleRule('word-break', 'break-all')
+  })
 })

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -222,6 +222,7 @@ export default {
   "/Text/docs/examples/overwrite.tsx": dynamic(() => import("../../packages/Text/docs/examples/overwrite.tsx").then(mod => mod), { ssr: false }),
   "/Text/docs/examples/truncation.tsx": dynamic(() => import("../../packages/Text/docs/examples/truncation.tsx").then(mod => mod), { ssr: false }),
   "/Text/docs/examples/withDash.tsx": dynamic(() => import("../../packages/Text/docs/examples/withDash.tsx").then(mod => mod), { ssr: false }),
+  "/Text/docs/examples/wordBreak.tsx": dynamic(() => import("../../packages/Text/docs/examples/wordBreak.tsx").then(mod => mod), { ssr: false }),
   "/Textarea/docs/examples/field.tsx": dynamic(() => import("../../packages/Textarea/docs/examples/field.tsx").then(mod => mod), { ssr: false }),
   "/Textarea/docs/examples/overview.tsx": dynamic(() => import("../../packages/Textarea/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/TimePicker/docs/examples/icon.tsx": dynamic(() => import("../../packages/TimePicker/docs/examples/icon.tsx").then(mod => mod), { ssr: false }),


### PR DESCRIPTION
# DESCRIPTION

We want to implement the wordBreak property on the Text component to avoid breaking the display of this component in our apps.


## LINEAR TICKET

https://linear.app/wttj/issue/WUI-70/components-do-not-support-word-break-or-word-wrap-properties


# HOW TO TEST

- You need to run `yarn start` on your project locally
- Then go to `http://localhost:3020/components/text`
- See you now have a `wordBreak` example in the doc, with long words that need to be broken

# SCREENSHOTS / SCREEN RECORDINGS

<img width="848" alt="Capture d’écran 2025-01-07 à 12 05 57" src="https://github.com/user-attachments/assets/a51431df-79d2-4a65-baae-d5316771b1eb" />
