### PR TITLE
fix: ensure that toast can be identify as a persistent element

### DIFF
--- a/lib/src/components/Toast/index.tsx
+++ b/lib/src/components/Toast/index.tsx
@@ -33,7 +33,7 @@ export const Notifications: React.FC<NotificationsProps> = ({ pauseOnHover = tru
     <ThemeProvider theme={themeContext}>
       {toasts.length > 0 &&
         createPortal(
-          <div onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+          <div data-wui-persistent onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
             {toasts.map(toast => (
               <ToastWrapper
                 calculateOffset={calculateOffset}


### PR DESCRIPTION
As discussed [here](https://wttj.slack.com/archives/C017KMZ4FBJ/p1736172619738689), I made the change to add a generic identifier in order to retrieve all the toast that must be persistent after opening a modal.

I choose this approach to ensure a clear separation between styling and functionality, avoids potential class name conflicts, and makes the selection of persistent toasts more reliable and maintainable. Also `data-wui-persistent` can be used in any other component that need to be persistent.