### PR TITLE
Chore(Accordion): increase arrow btn size and title gap [WUI-108]

### DIFF
--- a/lib/src/components/Accordion/styles.ts
+++ b/lib/src/components/Accordion/styles.ts
@@ -20,7 +20,7 @@ export const Icon = styled.divBox`
   height: 32;
   color: inherit;
   display: flex;
-  border-radius: 12;
+  border-radius: 16;
 
   & *:first-child {
     margin: auto;

--- a/lib/src/components/Accordion/styles.ts
+++ b/lib/src/components/Accordion/styles.ts
@@ -16,8 +16,8 @@ export const Icon = styled.divBox`
   ${th('accordions.icon')};
   transform: rotate3d(0);
   transition: medium;
-  width: 24;
-  height: 24;
+  width: 32;
+  height: 32;
   color: inherit;
   display: flex;
   border-radius: 12;
@@ -36,7 +36,7 @@ export const Disclosure = styled(Ariakit.Disclosure)`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: xxl;
+  gap: lg;
 
   &[aria-expanded='true'] {
     ${Icon} {


### PR DESCRIPTION
### DESCRIPTION
**Sizing and spacing adjustements**
- Title's`gap` decreased from `xxl` to `lg`
- Arrow button size increased from `24px` to `32px`
- Arrow button border radius increased to `16px` to keep roundeness
This PR changes are required have been requested and approuved by the designers for a wttj-front component. 

### HOW TO TEST
To test the gap value, you can create a accordion with a very long title. 
To test the arrow button, hover the title. 

### SCREENSHOTS / SCREEN RECORDINGS 
<img width="858" alt="Capture d’écran 2025-02-13 à 09 10 43" src="https://github.com/user-attachments/assets/a85cd2d1-c1ff-4d3a-8bd8-3372c01afc49" />