### PR TITLE
docs: add v7 website

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /v7.(\d\d|\d).(\d\d|\d)/
+              only: /v8.(\d\d|\d).(\d\d|\d)/
           context:
             - aws
             - welcome-ui
@@ -314,7 +314,7 @@ workflows:
           filters:
             # should add branches here to keep previous doc version of future majors
             branches:
-              only: /v3|v4|v5|v6/
+              only: /v3|v4|v5|v6|v7/
           context:
             - aws
             - welcome-ui

--- a/website/build-app/components/VersionSelector/index.tsx
+++ b/website/build-app/components/VersionSelector/index.tsx
@@ -4,8 +4,11 @@ import lib from '../../../../lib/package.json'
 
 import { Select } from '@/Select'
 
+const VERSION = 'v8'
+
 const versions = [
-  { value: 'v7', label: `v${lib.version}` },
+  { value: VERSION, label: `v${lib.version}` },
+  { value: 'v7', label: 'v7' },
   { value: 'v6', label: 'v6' },
   { value: 'v5', label: 'v5' },
   { value: 'v4', label: 'v4' },
@@ -14,7 +17,7 @@ const versions = [
 
 export const VersionSelector = () => {
   const handleChange = (value: unknown) => {
-    if (value === 'v7') return
+    if (value === VERSION) return
     window.open(`http://welcome-ui.com/${value}`, '_self')
   }
 
@@ -25,7 +28,7 @@ export const VersionSelector = () => {
       onChange={handleChange}
       options={versions}
       size="sm"
-      value="v7"
+      value={VERSION}
     />
   )
 }

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -3,3 +3,5 @@ User-agent: *
 Disallow: /v3
 Disallow: /v4
 Disallow: /v5
+Disallow: /v6
+Disallow: /v7


### PR DESCRIPTION
This pull request includes updates to support version 8 across various parts of the project. The changes primarily focus on updating version references in configuration files and components.

Version updates:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L304-R304): Updated version filters to include `v8` and adjusted tag patterns to match the new version. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L304-R304) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L317-R317)
* [`website/build-app/components/VersionSelector/index.tsx`](diffhunk://#diff-b1730f043736fc685d6208de8a3da9089352f6f2f95a3b4dfeb08f776d5cb7d9R7-R11): Introduced a constant for version `v8` and updated the version selector to use this constant. [[1]](diffhunk://#diff-b1730f043736fc685d6208de8a3da9089352f6f2f95a3b4dfeb08f776d5cb7d9R7-R11) [[2]](diffhunk://#diff-b1730f043736fc685d6208de8a3da9089352f6f2f95a3b4dfeb08f776d5cb7d9L17-R20) [[3]](diffhunk://#diff-b1730f043736fc685d6208de8a3da9089352f6f2f95a3b4dfeb08f776d5cb7d9L28-R31)

Other updates:

* [`website/public/robots.txt`](diffhunk://#diff-684bbefeb31b0ab5993967c2925918f5aed5a7257f5063f02363b1bc929d2db1R6-R7): Added disallow rules for `v6` and `v7` to prevent these versions from being indexed by search engines.