### PR TITLE
chore: allow color in welcome loader

### DIFF
--- a/lib/src/components/WelcomeLoader/docs/examples/color.tsx
+++ b/lib/src/components/WelcomeLoader/docs/examples/color.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react'
+
+import { WelcomeLoader } from '@/WelcomeLoader'
+
+const Example = () => {
+  return <WelcomeLoader color="neutral-90" />
+}
+
+export default Example

--- a/lib/src/components/WelcomeLoader/docs/index.mdx
+++ b/lib/src/components/WelcomeLoader/docs/index.mdx
@@ -11,3 +11,9 @@ peerDependencies: 'lottie-light-react'
 You can resize or add some properties like margin etc.
 
 <div data-playground="resize.tsx" data-component="WelcomeLoader"></div>
+
+### Change color
+
+You can change the color by passing in a valid theme color (e.g. neutral-90).
+
+<div data-playground="color.tsx" data-component="WelcomeLoader"></div>

--- a/lib/src/components/WelcomeLoader/index.tsx
+++ b/lib/src/components/WelcomeLoader/index.tsx
@@ -1,18 +1,29 @@
 import React from 'react'
 import { useLottie } from 'lottie-light-react'
+import { useTheme } from 'styled-components'
 
 import loader from './loader.json'
+import { convertHexToVectorColor } from './utils'
 
 import { forwardRef } from '@/System'
 import { Box, BoxProps } from '@/Box'
 
-export const WelcomeLoader = forwardRef<'div', BoxProps>(({ w = 150, ...props }, ref) => {
-  const options = {
-    animationData: loader,
-    loop: true,
+const currentColorRegex = new RegExp('1,0.803921568627,0,1', 'g')
+
+export const WelcomeLoader = forwardRef<'div', BoxProps>(({ color, w = 150, ...props }, ref) => {
+  const theme = useTheme()
+  let animationData = loader
+
+  if (color) {
+    const hex = theme.colors[color as keyof typeof theme.colors]
+    const newColor = convertHexToVectorColor(hex)
+    if (newColor) {
+      const updated = JSON.stringify(loader, null, 0).replace(currentColorRegex, newColor)
+      animationData = JSON.parse(updated)
+    }
   }
 
-  const { View } = useLottie(options)
+  const { View } = useLottie({ animationData, loop: true })
 
   return (
     <Box ref={ref} w={w} {...props}>

--- a/lib/src/components/WelcomeLoader/utils.test.ts
+++ b/lib/src/components/WelcomeLoader/utils.test.ts
@@ -1,11 +1,11 @@
 import { convertHexToVectorColor } from './utils'
 
 const colors = [
-  { hex: '#0000FF', vector: '0,0,1,1' },
-  { hex: '#00FF00', vector: '0,1,0,1' },
-  { hex: '#800080', vector: '0.5,0,0.5,1' },
-  { hex: '#FFFFFF', vector: '1,1,1,1' },
-  { hex: '#000000', vector: '0,0,0,1' },
+  { hex: '#0000FF', vector: '0,0,1' },
+  { hex: '#00FF00', vector: '0,1,0' },
+  { hex: '#800080', vector: '0.5019607843137255,0,0.5019607843137255' },
+  { hex: '#FFFFFF', vector: '1,1,1' },
+  { hex: '#000000', vector: '0,0,0' },
 ]
 
 describe('convertHexToVectorColor', () => {
@@ -22,12 +22,12 @@ describe('convertHexToVectorColor', () => {
   })
 
   it('should handle hex colors without # prefix', () => {
-    expect(convertHexToVectorColor('0000FF')).toBe('0,0,1,1')
-    expect(convertHexToVectorColor('00FF00')).toBe('0,1,0,1')
+    expect(convertHexToVectorColor('0000FF')).toBe('0,0,1')
+    expect(convertHexToVectorColor('00FF00')).toBe('0,1,0')
   })
 
   it('should handle short hex format (#RGB)', () => {
-    expect(convertHexToVectorColor('#00F')).toBe('0,0,1,1')
-    expect(convertHexToVectorColor('#0F0')).toBe('0,1,0,1')
+    expect(convertHexToVectorColor('#00F')).toBe('0,0,1')
+    expect(convertHexToVectorColor('#0F0')).toBe('0,1,0')
   })
 })

--- a/lib/src/components/WelcomeLoader/utils.test.ts
+++ b/lib/src/components/WelcomeLoader/utils.test.ts
@@ -1,0 +1,33 @@
+import { convertHexToVectorColor } from './utils'
+
+const colors = [
+  { hex: '#0000FF', vector: '0,0,1,1' },
+  { hex: '#00FF00', vector: '0,1,0,1' },
+  { hex: '#800080', vector: '0.5,0,0.5,1' },
+  { hex: '#FFFFFF', vector: '1,1,1,1' },
+  { hex: '#000000', vector: '0,0,0,1' },
+]
+
+describe('convertHexToVectorColor', () => {
+  it('should convert hex colors to vector colors correctly', () => {
+    colors.forEach(({ hex, vector }) => {
+      expect(convertHexToVectorColor(hex)).toBe(vector)
+    })
+  })
+
+  it('should return undefined for invalid hex colors', () => {
+    expect(convertHexToVectorColor('invalid')).toBeUndefined()
+    expect(convertHexToVectorColor('#XYZ')).toBeUndefined()
+    expect(convertHexToVectorColor('')).toBeUndefined()
+  })
+
+  it('should handle hex colors without # prefix', () => {
+    expect(convertHexToVectorColor('0000FF')).toBe('0,0,1,1')
+    expect(convertHexToVectorColor('00FF00')).toBe('0,1,0,1')
+  })
+
+  it('should handle short hex format (#RGB)', () => {
+    expect(convertHexToVectorColor('#00F')).toBe('0,0,1,1')
+    expect(convertHexToVectorColor('#0F0')).toBe('0,1,0,1')
+  })
+})

--- a/lib/src/components/WelcomeLoader/utils.ts
+++ b/lib/src/components/WelcomeLoader/utils.ts
@@ -1,0 +1,14 @@
+import { hexToRGBA } from '@/utils'
+
+export const convertHexToVectorColor = (hex: string) => {
+  try {
+    const newColor = hexToRGBA(hex)
+      .split(',')
+      .map(c => parseFloat(c) / 255)
+      .join(',')
+
+    return newColor
+  } catch (error) {
+    return undefined
+  }
+}

--- a/lib/src/components/WelcomeLoader/utils.ts
+++ b/lib/src/components/WelcomeLoader/utils.ts
@@ -1,13 +1,17 @@
-import { hexToRGBA } from '@/utils'
+import { hexToRGB } from '@/utils'
 
 export const convertHexToVectorColor = (hex: string) => {
   try {
-    const newColor = hexToRGBA(hex)
+    const rgb = hexToRGB(hex)
+
+    if (!rgb) {
+      return undefined
+    }
+
+    return rgb
       .split(',')
       .map(c => parseFloat(c) / 255)
       .join(',')
-
-    return newColor
   } catch (error) {
     return undefined
   }

--- a/lib/src/utils/hex-to-rgb.test.ts
+++ b/lib/src/utils/hex-to-rgb.test.ts
@@ -1,0 +1,45 @@
+import { hexToRGB } from './hex-to-rgb'
+
+describe('hexToRGB', () => {
+  const testCases = [
+    { input: '#000000', expected: '0, 0, 0' },
+    { input: '#FFFFFF', expected: '255, 255, 255' },
+    { input: '#FF0000', expected: '255, 0, 0' },
+    { input: '#00FF00', expected: '0, 255, 0' },
+    { input: '#0000FF', expected: '0, 0, 255' },
+    { input: '#FFCD00', expected: '255, 205, 0' },
+  ]
+
+  it('should convert 6-digit hex colors to RGB values', () => {
+    testCases.forEach(({ expected, input }) => {
+      expect(hexToRGB(input)).toBe(expected)
+    })
+  })
+
+  it('should handle 3-digit hex colors', () => {
+    expect(hexToRGB('#000')).toBe('0, 0, 0')
+    expect(hexToRGB('#FFF')).toBe('255, 255, 255')
+    expect(hexToRGB('#F00')).toBe('255, 0, 0')
+  })
+
+  it('should handle lowercase hex colors', () => {
+    expect(hexToRGB('#ffffff')).toBe('255, 255, 255')
+    expect(hexToRGB('#ff0000')).toBe('255, 0, 0')
+    expect(hexToRGB('#fff')).toBe('255, 255, 255')
+  })
+
+  it('should handle hex colors without hash', () => {
+    expect(hexToRGB('FFFFFF')).toBe('255, 255, 255')
+    expect(hexToRGB('000000')).toBe('0, 0, 0')
+    expect(hexToRGB('FFF')).toBe('255, 255, 255')
+  })
+
+  it('should return undefined for invalid inputs', () => {
+    expect(hexToRGB('')).toBeUndefined()
+    expect(hexToRGB(undefined)).toBeUndefined()
+    expect(hexToRGB('#GGG')).toBeUndefined()
+    expect(hexToRGB('#GGGGGG')).toBeUndefined()
+    expect(hexToRGB('#FF')).toBeUndefined()
+    expect(hexToRGB('#FFFF')).toBeUndefined()
+  })
+})

--- a/lib/src/utils/hex-to-rgba.test.ts
+++ b/lib/src/utils/hex-to-rgba.test.ts
@@ -1,0 +1,32 @@
+import { hexToRGBA } from './hex-to-rgba'
+
+describe('hexToRGBA', () => {
+  it('should convert hex colors to RGBA with default transparency', () => {
+    expect(hexToRGBA('#000000')).toBe('rgba(0, 0, 0, 1)')
+    expect(hexToRGBA('#FFFFFF')).toBe('rgba(255, 255, 255, 1)')
+    expect(hexToRGBA('#FF0000')).toBe('rgba(255, 0, 0, 1)')
+  })
+
+  it('should handle custom transparency values', () => {
+    expect(hexToRGBA('#000000', 0.5)).toBe('rgba(0, 0, 0, 0.5)')
+    expect(hexToRGBA('#FFFFFF', 0)).toBe('rgba(255, 255, 255, 0)')
+    expect(hexToRGBA('#FF0000', 0.75)).toBe('rgba(255, 0, 0, 0.75)')
+  })
+
+  it('should handle 3-digit hex colors', () => {
+    expect(hexToRGBA('#000')).toBe('rgba(0, 0, 0, 1)')
+    expect(hexToRGBA('#FFF', 0.5)).toBe('rgba(255, 255, 255, 0.5)')
+  })
+
+  it('should handle lowercase hex colors', () => {
+    expect(hexToRGBA('#ffffff')).toBe('rgba(255, 255, 255, 1)')
+    expect(hexToRGBA('#ff0000', 0.5)).toBe('rgba(255, 0, 0, 0.5)')
+  })
+
+  it('should return undefined for invalid inputs', () => {
+    expect(hexToRGBA('')).toBeUndefined()
+    expect(hexToRGBA(undefined)).toBeUndefined()
+    expect(hexToRGBA('#GGG')).toBeUndefined()
+    expect(hexToRGBA('#GGGGGG')).toBeUndefined()
+  })
+})

--- a/lib/src/utils/hex-to-rgba.ts
+++ b/lib/src/utils/hex-to-rgba.ts
@@ -1,11 +1,7 @@
 import { hexToRGB } from './hex-to-rgb'
 
 export const hexToRGBA = (hex: string, transparency = 1): string => {
-  if (!hex) return
-
-  if (!hex.startsWith('#')) return hex
-
   const toRgb = hexToRGB(hex)
 
-  return `rgba(${toRgb}, ${transparency})`
+  return toRgb ? `rgba(${toRgb}, ${transparency})` : undefined
 }

--- a/lib/src/utils/index.ts
+++ b/lib/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './format-bytes'
 export * from './hex-to-rgba'
+export * from './hex-to-rgb'
 export * from './field-styles'
 export * from './overflow-ellipsis'
 export * from './throttle'

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -249,6 +249,7 @@ export default {
   "/VariantIcon/docs/examples/icon.tsx": dynamic(() => import("../../lib/src/components/VariantIcon/docs/examples/icon.tsx").then(mod => mod), { ssr: false }),
   "/VariantIcon/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/VariantIcon/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/VariantIcon/docs/examples/sizes.tsx": dynamic(() => import("../../lib/src/components/VariantIcon/docs/examples/sizes.tsx").then(mod => mod), { ssr: false }),
+  "/WelcomeLoader/docs/examples/color.tsx": dynamic(() => import("../../lib/src/components/WelcomeLoader/docs/examples/color.tsx").then(mod => mod), { ssr: false }),
   "/WelcomeLoader/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/WelcomeLoader/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/WelcomeLoader/docs/examples/resize.tsx": dynamic(() => import("../../lib/src/components/WelcomeLoader/docs/examples/resize.tsx").then(mod => mod), { ssr: false })
 };


### PR DESCRIPTION
## DESCRIPTION

Can now pass a valid theme color (e.g. `neutral-90`) to the WelcomeLoader to change the loader color

## HOW TO TEST

View the docs : https://welcome-ui.com/components/welcome-loader#change-color

## SCREENSHOTS / SCREEN RECORDINGS

<img width="882" alt="image" src="https://github.com/user-attachments/assets/399d86a9-b9a8-4c78-a1eb-c6f83baaedcc" />

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [x] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [x] Thoroughly tested in local environment
- [x] Added tests for all new features
- [x] Added tests that considered edge cases
