### PR TITLE
fix(field): add missing & selector in Label css

### DIFF
--- a/lib/src/components/Label/styles.ts
+++ b/lib/src/components/Label/styles.ts
@@ -20,7 +20,7 @@ export const Label = styled.labelBox.withConfig({ shouldForwardProp })<{
         margin-right: sm;
       }
 
-      :last-child {
+      &:last-child {
         ${required && requiredStyles};
       }
     }


### PR DESCRIPTION
## DESCRIPTION

<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

The asterisk associated with required field is missing, due to a missing css selector

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- start your project locally
- Go to http://localhost:3020/components/field
- Scroll til the required example
- See you now have the asterisk next to the field label

## SCREENSHOTS / SCREEN RECORDINGS

<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

BEFORE
![Capture d’écran 2025-03-31 à 12 07 40](https://github.com/user-attachments/assets/53a539fc-253f-49c4-8dfe-5ae168d6abce)

AFTER
![Capture d’écran 2025-03-31 à 12 07 16](https://github.com/user-attachments/assets/b70497f1-c744-4aaa-af61-cc4d651dc685)

## COMPATIBILITY

- [x] Tested on Safari (desktop)
- [x] Tested on Chrome (desktop)
- [x] Tested on Firefox (desktop)
- [x] Tested on mobile device sizes
- [x] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [x] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
