### PR TITLE
fix: declaration files should be referenced as exportable for typescipt to generate declaration files of libraries using wui

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -17,6 +17,9 @@
       "import": "./dist/utils.mjs",
       "require": "./dist/utils.mjs"
     },
+    "./*.d.ts": {
+      "types": "./*.d.ts"
+    },
     "./*": {
       "types": "./dist/types/components/*/index.d.ts",
       "import": "./dist/*.mjs",


### PR DESCRIPTION

## DESCRIPTION

<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## SCREENSHOTS / SCREEN RECORDINGS

<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
