### PR TITLE
Fix(Tags): do not use shape styles when onRemove is truthy

### DIFF
--- a/lib/src/components/Tag/styles.ts
+++ b/lib/src/components/Tag/styles.ts
@@ -51,6 +51,7 @@ export const Tag = styled.div.withConfig({
       }
     `}
     ${length === 1 &&
+    !hasRemoveAction &&
     css`
       justify-content: center;
       ${shapeStyles(size, w as string, h as string)};


### PR DESCRIPTION
## DESCRIPTION
[WUI-116: Tags: missing padding when they are one character long](https://linear.app/wttj/issue/WUI-116/tags-selected-values-are-missing-padding-when-they-are-short)

Tags are not dispalyed properly when these two conditions are met:
- Content is one character -> the Tag uses Shape styles
- Tag has a onRemove handler -> adds padding to the tag's content 

This PR checks for onRemove before enabling the Shape styles

## HOW TO TEST
- Create a Tag with one character and an onRemove handler

## SCREENSHOTS / SCREEN RECORDINGS
<img width="1169" alt="Capture d’écran 2025-04-15 à 18 01 22" src="https://github.com/user-attachments/assets/a4a9720a-a938-49fd-aea4-7c2d5636c5a6" />

## QA
- [X] Thoroughly tested in local environment
