### PR TITLE
fix: improve scrollbar style after review on front-components

### DIFF
--- a/lib/src/components/Drawer/AssetDrawer/Header.tsx
+++ b/lib/src/components/Drawer/AssetDrawer/Header.tsx
@@ -48,10 +48,9 @@ export const Header: React.FC<HeaderProps> = ({
       gap="xl"
       justifyContent="space-between"
       mb="xl"
-      mt="-md"
+      pb="md"
       position="sticky"
-      py="md"
-      top={0}
+      top="-xxl"
       zIndex={1}
     >
       <Box alignItems="center" display="flex" gap={{ _: 'md', md: 'xl' }}>

--- a/lib/src/components/Drawer/AssetDrawer/Header.tsx
+++ b/lib/src/components/Drawer/AssetDrawer/Header.tsx
@@ -50,7 +50,7 @@ export const Header: React.FC<HeaderProps> = ({
       mb="xl"
       pb="md"
       position="sticky"
-      top="-xxl"
+      top={0}
       zIndex={1}
     >
       <Box alignItems="center" display="flex" gap={{ _: 'md', md: 'xl' }}>

--- a/lib/src/components/Drawer/AssetDrawer/index.tsx
+++ b/lib/src/components/Drawer/AssetDrawer/index.tsx
@@ -58,9 +58,9 @@ export const AssetDrawerComponent = forwardRef<'div', AssetDrawerProps>(
         }}
         withBackdrop
       >
-        <Box h="100%" overflowY="auto" pt="xxl" w="100%">
-          <S.Content maxWidth={maxWidth} mt="-xxl">
-            <Box p={{ _: 'xl md', md: '3xl xl' }}>{children}</Box>
+        <Box h="100%" mt={{ _: 'xl', md: '3xl' }} overflowY="auto" w="100%">
+          <S.Content maxWidth={maxWidth}>
+            <Box p={{ _: '0 md xl', md: '0 xl 3xl' }}>{children}</Box>
           </S.Content>
         </Box>
       </Drawer>

--- a/lib/src/components/Drawer/AssetDrawer/index.tsx
+++ b/lib/src/components/Drawer/AssetDrawer/index.tsx
@@ -48,6 +48,7 @@ export const AssetDrawerComponent = forwardRef<'div', AssetDrawerProps>(
         getPersistentElements={getPersistentElements}
         h={{ _: '100%', md: 'calc(100% - 3rem)' }}
         hideOnInteractOutside={hideOnInteractOutside}
+        overflow="hidden"
         placement="bottom"
         ref={ref}
         store={store}
@@ -57,9 +58,11 @@ export const AssetDrawerComponent = forwardRef<'div', AssetDrawerProps>(
         }}
         withBackdrop
       >
-        <S.Content maxWidth={maxWidth}>
-          <Box p={{ _: 'xl md', md: '3xl xl' }}>{children}</Box>
-        </S.Content>
+        <Box h="100%" overflowY="auto" pt="xxl" w="100%">
+          <S.Content maxWidth={maxWidth} mt="-xxl">
+            <Box p={{ _: 'xl md', md: '3xl xl' }}>{children}</Box>
+          </S.Content>
+        </Box>
       </Drawer>
     )
   }


### PR DESCRIPTION
## DESCRIPTION

<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

We had an issue with the scrollbar overriding the parent drawer for the asset component.

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- Go to http://localhost:3020/components/drawer
- Scroll the doc page to the latest example (AssetDrawer)
- Open it, try to scroll and see the scrollbar is not overriding its parent at the top of the drawer

## SCREENSHOTS / SCREEN RECORDINGS

<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

BEFORE

https://github.com/user-attachments/assets/0c94320f-0dd9-4c29-9993-23cc0a115e8f

AFTER

https://github.com/user-attachments/assets/83d78152-7026-460d-a640-ea85e4c27186

## COMPATIBILITY

- [x] Tested on Safari (desktop)
- [x] Tested on Chrome (desktop)
- [x] Tested on Firefox (desktop)
- [x] Tested on mobile device sizes
- [x] Tested on tablet device sizes
- [x] Tested on IOS Safari (either device or simulator)

## QA

- [x] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases