### PR TITLE
chore(lib): revert types exports change in package.json

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -17,9 +17,6 @@
       "import": "./dist/utils.mjs",
       "require": "./dist/utils.mjs"
     },
-    "./*.d.ts": {
-      "types": "./*.d.ts"
-    },
     "./*": {
       "types": "./dist/types/components/*/index.d.ts",
       "import": "./dist/*.mjs",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@types/node": "22.14.0",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "@typescript-eslint/utils": "^8.31.0",
     "@vitest/eslint-plugin": "^1.1.43",
     "@vusion/webfonts-generator": "^0.8.0",
     "@xstyled/styled-components": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/node": "22.14.0",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
+    "@typescript-eslint/utils": "^8.31.0",
     "@vitest/eslint-plugin": "^1.1.43",
     "@vusion/webfonts-generator": "^0.8.0",
     "@xstyled/styled-components": "^4.0.0",


### PR DESCRIPTION
## DESCRIPTION

<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

We have an issue when importing welcome-ui components, the auto-suggestion to import automatically is broken

Broken since v8.0.3 => https://github.com/WTTJ/welcome-ui/compare/v8.0.2...v8.0.3

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
- Remove an existing import of a WUI component in your project if you have a version higher than 8.0.3
- See when you try to quick fix the issue on the component, you don't have the right component path proposed
- Install the test dev release `0.0.0-dev.1747407678158`
- Do the same process as above, see the path is now correct

## SCREENSHOTS / SCREEN RECORDINGS

<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

<img width="951" alt="Capture d’écran 2025-05-16 à 15 12 04" src="https://github.com/user-attachments/assets/e1213ecb-a6df-401f-9858-dbfce4eb397b" />

## COMPATIBILITY

N/A

## QA

N/A
