### PR TITLE
fix: remove quote marks from css value

### DIFF
--- a/lib/src/components/Card/styles.ts
+++ b/lib/src/components/Card/styles.ts
@@ -1,7 +1,7 @@
 import styled, { th } from '@xstyled/styled-components'
 
 export const Card = styled.divBox`
-  overflow: 'hidden';
+  overflow: hidden;
   border-radius: md;
   ${th('cards.default')};
   background-size: cover;


### PR DESCRIPTION
## DESCRIPTION

The `Card` component has a malformed value for `overflow`

Before:
```
  overflow: 'hidden';
```

After:
```
  overflow: hidden;
```

## HOW TO TEST

1. Use card in page
2. Look at css for card

## SCREENSHOTS / SCREEN RECORDINGS

<img width="273" alt="image" src="https://github.com/user-attachments/assets/d344d8a4-b8ed-468e-bb76-ac55658ce436" />

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [x] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
