### PR TITLE
Fix(AlertTitle): the close button goes over title [TAL-119]

### DIFF
--- a/lib/src/components/Alert/styles.ts
+++ b/lib/src/components/Alert/styles.ts
@@ -61,6 +61,7 @@ export const Title = styled(Text)<AlertTitleProps>(({ variant }) => {
     font-weight: medium;
     ${th('alerts.title.default')};
     ${th(`alerts.title.sizes.${variant}`)};
+    margin-right: xl;
     ${system};
   `
 })


### PR DESCRIPTION
## DESCRIPTION
The close button overlaps with the title when the content is too long. 
This PR adds a margin-right of 24px


## SCREENSHOTS / SCREEN RECORDINGS
<img width="905" alt="Capture d’écran 2025-06-09 à 16 08 35" src="https://github.com/user-attachments/assets/ba80ec10-8bfe-43e3-846f-382d0d3a0ee1" />


## QA
- [X] Thoroughly tested in local environment
