### PR TITLE
Chore(DatePicker): update datepicker version

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -64,7 +64,7 @@
     "lodash.range": "^3.2.0",
     "lottie-light-react": "^2.4.0",
     "match-sorter": "^8.0.0",
-    "react-datepicker": "^4.16.0",
+    "react-datepicker": "^8.4.0",
     "react-dropzone": "^14.3.5",
     "react-flatten-children": "^1.0.0",
     "react-hot-toast": "^2.4.1"
@@ -78,7 +78,7 @@
     "@types/lodash.debounce": "^4.0.6",
     "@types/lodash.range": "^3.2.9",
     "@types/ramda": "^0.30.2",
-    "@types/react-datepicker": "^4.15.0",
+    "@types/react-datepicker": "^7.0.0",
     "jsdom": "^26.0.0",
     "ramda": "^0.30.1",
     "release-it": "^18.1.2",

--- a/lib/src/components/DatePicker/docs/examples/react-date-picker.tsx
+++ b/lib/src/components/DatePicker/docs/examples/react-date-picker.tsx
@@ -6,7 +6,7 @@ const Example = () => {
       dateFormat="MMM dd yyyy"
       maxDate={new Date()}
       name="welcome"
-      popperProps={{ zIndex: 50 }}
+      popperProps={{ placement: 'top' }}
       value={new Date()}
       yearDropdownItemNumber={30}
     />

--- a/lib/src/components/DatePicker/docs/properties.json
+++ b/lib/src/components/DatePicker/docs/properties.json
@@ -22,6 +22,152 @@
           "name": "number"
         }
       },
+      "excludeDateIntervals": {
+        "defaultValue": null,
+        "description": "",
+        "name": "excludeDateIntervals",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "DateFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "{ start: Date; end: Date; }[]"
+        }
+      },
+      "excludeDates": {
+        "defaultValue": null,
+        "description": "",
+        "name": "excludeDates",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "DateFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "{ date: Date; message?: string; }[] | Date[]",
+          "value": [
+            {
+              "value": "{ date: Date; message?: string; }[]",
+              "description": "",
+              "fullComment": "",
+              "tags": {}
+            },
+            {
+              "value": "Date[]",
+              "description": "",
+              "fullComment": "",
+              "tags": {}
+            }
+          ]
+        }
+      },
+      "excludeTimes": {
+        "defaultValue": null,
+        "description": "",
+        "name": "excludeTimes",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "TimeFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date[]"
+        }
+      },
+      "filterDate": {
+        "defaultValue": null,
+        "description": "",
+        "name": "filterDate",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "DateFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "(date: Date) => boolean"
+        }
+      },
+      "filterTime": {
+        "defaultValue": null,
+        "description": "",
+        "name": "filterTime",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "TimeFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "(time: Date) => boolean"
+        }
+      },
       "icon": {
         "defaultValue": null,
         "description": "",
@@ -36,20 +182,35 @@
             "name": "CustomInputOptions"
           },
           {
-            "fileName": "welcome-ui/node_modules/@types/react-datepicker/index.d.ts",
-            "name": "ReactDatePickerProps"
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/calendar_icon.d.ts",
+            "name": "CalendarIconProps"
           }
         ],
         "required": false,
         "type": {
           "name": "enum",
-          "raw": "Element & (string | ReactElement<any, string | JSXElementConstructor<any>>)",
+          "raw": "Element & ReactNode",
           "value": [
             {
               "value": "Element & string"
             },
             {
+              "value": "Element & number"
+            },
+            {
+              "value": "Element & false"
+            },
+            {
+              "value": "Element & true"
+            },
+            {
               "value": "Element & ReactElement<any, string | JSXElementConstructor<any>>"
+            },
+            {
+              "value": "Element & Iterable<ReactNode>"
+            },
+            {
+              "value": "Element & ReactPortal"
             }
           ]
         }
@@ -84,6 +245,83 @@
           ]
         }
       },
+      "includeDateIntervals": {
+        "defaultValue": null,
+        "description": "",
+        "name": "includeDateIntervals",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "DateFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "{ start: Date; end: Date; }[]"
+        }
+      },
+      "includeDates": {
+        "defaultValue": null,
+        "description": "",
+        "name": "includeDates",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "DateFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date[]"
+        }
+      },
+      "includeTimes": {
+        "defaultValue": null,
+        "description": "",
+        "name": "includeTimes",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "TimeFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date[]"
+        }
+      },
       "locale": {
         "defaultValue": null,
         "description": "",
@@ -101,6 +339,114 @@
         "required": false,
         "type": {
           "name": "Locale"
+        }
+      },
+      "maxDate": {
+        "defaultValue": null,
+        "description": "",
+        "name": "maxDate",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+          "name": "MonthYearDropdownOptionsProps"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+            "name": "MonthYearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date"
+        }
+      },
+      "maxTime": {
+        "defaultValue": null,
+        "description": "",
+        "name": "maxTime",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "TimeFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date"
+        }
+      },
+      "minDate": {
+        "defaultValue": null,
+        "description": "",
+        "name": "minDate",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+          "name": "MonthYearDropdownOptionsProps"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+            "name": "MonthYearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date"
+        }
+      },
+      "minTime": {
+        "defaultValue": null,
+        "description": "",
+        "name": "minTime",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "TimeFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date"
         }
       },
       "onBlur": {
@@ -193,6 +539,70 @@
           {
             "fileName": "welcome-ui/lib/src/components/DatePicker/index.tsx",
             "name": "DatePickerOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "scrollableMonthYearDropdown": {
+        "defaultValue": null,
+        "description": "",
+        "name": "scrollableMonthYearDropdown",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+          "name": "MonthYearDropdownOptionsProps"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+            "name": "MonthYearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+            "name": "MonthYearDropdownOptionsProps"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "scrollableYearDropdown": {
+        "defaultValue": null,
+        "description": "",
+        "name": "scrollableYearDropdown",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+          "name": "YearDropdownOptionsProps"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
           }
         ],
         "required": false,
@@ -355,6 +765,29 @@
               "tags": {}
             }
           ]
+        }
+      },
+      "yearDropdownItemNumber": {
+        "defaultValue": null,
+        "description": "",
+        "name": "yearDropdownItemNumber",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+          "name": "YearDropdownOptionsProps"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "number"
         }
       }
     }

--- a/lib/src/components/DatePicker/index.tsx
+++ b/lib/src/components/DatePicker/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import type { ReactDatePickerProps } from 'react-datepicker'
+import type { DatePickerProps as ReactDatePickerProps } from 'react-datepicker'
 
 import type { CustomHeaderProps, CustomInputOptions, Focused } from '@/DateTimePickerCommon'
 import {

--- a/lib/src/components/DateTimePicker/docs/properties.json
+++ b/lib/src/components/DateTimePicker/docs/properties.json
@@ -1,41 +1,6 @@
 {
   "DateTimePicker": {
     "props": {
-      "locale": {
-        "defaultValue": null,
-        "description": "",
-        "name": "locale",
-        "parent": {
-          "fileName": "welcome-ui/lib/src/components/DateTimePickerCommon/CustomHeader.tsx",
-          "name": "CustomHeaderOptions"
-        },
-        "declarations": [
-          {
-            "fileName": "welcome-ui/lib/src/components/DateTimePickerCommon/CustomHeader.tsx",
-            "name": "CustomHeaderOptions"
-          },
-          {
-            "fileName": "welcome-ui/node_modules/@types/react-datepicker/index.d.ts",
-            "name": "ReactDatePickerProps"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "enum",
-          "raw": "Locale | (Locale & string)",
-          "value": [
-            {
-              "value": "Locale",
-              "description": "",
-              "fullComment": "",
-              "tags": {}
-            },
-            {
-              "value": "Locale & string"
-            }
-          ]
-        }
-      },
       "onChange": {
         "defaultValue": null,
         "description": "",

--- a/lib/src/components/DateTimePicker/index.tsx
+++ b/lib/src/components/DateTimePicker/index.tsx
@@ -1,4 +1,5 @@
-import React, { Children, cloneElement, useEffect, useState } from 'react'
+import * as locales from 'date-fns/locale'
+import React, { Children, cloneElement, useEffect, useMemo, useState } from 'react'
 
 import type { DatePickerProps } from '@/DatePicker'
 import { DatePicker } from '@/DatePicker'
@@ -12,9 +13,26 @@ import * as S from './styles'
 
 export type DateTimePickerProps = CreateWuiProps<
   'input',
-  Pick<DatePickerProps, 'disabled' | 'locale' | 'onChange' | 'size' | 'transparent' | 'value'> &
-    Pick<TimePickerProps, 'disabled' | 'locale' | 'onChange' | 'size' | 'transparent' | 'value'>
+  Pick<DatePickerProps, 'onChange' | 'size' | 'transparent' | 'value'> &
+    Pick<TimePickerProps, 'onChange' | 'size' | 'transparent' | 'value'> & {
+      locale?: LocalesKeys
+    }
 >
+
+type LocalesKeys = keyof typeof locales
+const isValidLocale = (locale?: string): locale is LocalesKeys => locale && locale in locales
+
+const getLocale = (locale?: LocalesKeys) => {
+  const browserLocale = navigator.language.split('-')[0]
+
+  if (isValidLocale(locale)) {
+    return locales[locale]
+  }
+  if (isValidLocale(browserLocale)) {
+    return locales[browserLocale]
+  }
+  return locales['enUS']
+}
 
 export const DateTimePicker = forwardRef<'input', DateTimePickerProps>(
   (
@@ -65,6 +83,8 @@ export const DateTimePicker = forwardRef<'input', DateTimePickerProps>(
       //eslint-disable-next-line
     }, [value])
 
+    const localeObject = useMemo(() => getLocale(locale), [locale])
+
     return (
       <S.DateTimePicker data-testid={dataTestId}>
         {children
@@ -86,7 +106,7 @@ export const DateTimePicker = forwardRef<'input', DateTimePickerProps>(
             <DatePicker
               dataTestId={`${dataTestId}-datePicker`}
               disabled={disabled}
-              locale={locale}
+              locale={localeObject}
               onChange={handleChange}
               ref={ref}
               size={size}
@@ -96,7 +116,7 @@ export const DateTimePicker = forwardRef<'input', DateTimePickerProps>(
             <TimePicker
               dataTestId={`${dataTestId}-timePicker`}
               disabled={disabled}
-              locale={locale}
+              locale={localeObject}
               onChange={handleChange}
               size={size}
               transparent={transparent}

--- a/lib/src/components/DateTimePicker/index.tsx
+++ b/lib/src/components/DateTimePicker/index.tsx
@@ -1,4 +1,3 @@
-import * as locales from 'date-fns/locale'
 import React, { Children, cloneElement, useEffect, useMemo, useState } from 'react'
 
 import type { DatePickerProps } from '@/DatePicker'
@@ -10,29 +9,15 @@ import type { TimePickerProps } from '@/TimePicker'
 import { TimePicker } from '@/TimePicker'
 
 import * as S from './styles'
+import { getLocale, type LocalesKey } from './utils'
 
 export type DateTimePickerProps = CreateWuiProps<
   'input',
   Pick<DatePickerProps, 'onChange' | 'size' | 'transparent' | 'value'> &
     Pick<TimePickerProps, 'onChange' | 'size' | 'transparent' | 'value'> & {
-      locale?: LocalesKeys
+      locale?: LocalesKey
     }
 >
-
-type LocalesKeys = keyof typeof locales
-const isValidLocale = (locale?: string): locale is LocalesKeys => locale && locale in locales
-
-const getLocale = (locale?: LocalesKeys) => {
-  const browserLocale = navigator.language.split('-')[0]
-
-  if (isValidLocale(locale)) {
-    return locales[locale]
-  }
-  if (isValidLocale(browserLocale)) {
-    return locales[browserLocale]
-  }
-  return locales['enUS']
-}
 
 export const DateTimePicker = forwardRef<'input', DateTimePickerProps>(
   (

--- a/lib/src/components/DateTimePicker/tests/index.test.tsx
+++ b/lib/src/components/DateTimePicker/tests/index.test.tsx
@@ -4,6 +4,8 @@ import { DateTimePicker } from '../'
 import { render } from '../../../../tests'
 import { DatePicker } from '../../DatePicker'
 import { TimePicker } from '../../TimePicker'
+import type { LocalesKey } from '../utils'
+import { getLocale } from '../utils'
 
 describe('<DateTimePicker />', () => {
   it('<DateTimePicker> renders correctly', () => {
@@ -200,5 +202,22 @@ describe('<DateTimePicker />', () => {
 
     expect(datePicker).toHaveValue('')
     expect(clearButton).not.toBeInTheDocument()
+  })
+})
+
+describe('getLocale', () => {
+  it('returns the correct locale for a valid locale code', () => {
+    const locale = getLocale('fr')
+    expect(locale.code).toBe('fr')
+  })
+
+  it('returns the browser locale if the provided locale is invalid', () => {
+    const locale = getLocale('invalid-locale' as LocalesKey)
+    expect(locale.code).toBe(navigator.language)
+  })
+
+  it('returns the default locale if no valid locale is provided', () => {
+    const locale = getLocale()
+    expect(locale.code).toBe('en-US')
   })
 })

--- a/lib/src/components/DateTimePicker/tests/index.test.tsx
+++ b/lib/src/components/DateTimePicker/tests/index.test.tsx
@@ -72,7 +72,6 @@ describe('<DateTimePicker />', () => {
     await user.click(datePicker)
 
     const [monthSelect, yearSelect] = screen.getAllByRole('combobox')
-
     expect(monthSelect).toHaveTextContent('September')
     expect(yearSelect).toHaveTextContent('2001')
   })
@@ -88,8 +87,8 @@ describe('<DateTimePicker />', () => {
 
     const decreaseMonth = screen.getByTitle('Previous month')
     const increaseMonth = screen.getByTitle('Next month')
-    const [monthSelect, yearSelect] = screen.getAllByRole('combobox')
 
+    const [monthSelect, yearSelect] = screen.getAllByRole('combobox')
     expect(monthSelect).toHaveTextContent('September')
     expect(yearSelect).toHaveTextContent('2001')
 
@@ -136,7 +135,6 @@ describe('<DateTimePicker />', () => {
     await user.click(datePicker)
 
     const [monthSelect, yearSelect] = screen.getAllByRole('combobox')
-
     expect(monthSelect).toHaveTextContent('June')
     expect(yearSelect).toHaveTextContent('2018')
   })

--- a/lib/src/components/DateTimePicker/utils.ts
+++ b/lib/src/components/DateTimePicker/utils.ts
@@ -1,0 +1,16 @@
+import * as locales from 'date-fns/locale'
+
+export type LocalesKey = keyof typeof locales
+const isValidLocale = (locale?: string): locale is LocalesKey => locale && locale in locales
+
+export const getLocale = (locale?: LocalesKey) => {
+  const browserLocale = navigator.language.split('-')[0]
+
+  if (isValidLocale(locale)) {
+    return locales[locale]
+  }
+  if (isValidLocale(browserLocale)) {
+    return locales[browserLocale]
+  }
+  return locales['enUS']
+}

--- a/lib/src/components/DateTimePickerCommon/CustomInput.tsx
+++ b/lib/src/components/DateTimePickerCommon/CustomInput.tsx
@@ -34,7 +34,7 @@ export const CustomInput = forwardRef<HTMLInputElement, CustomInputProps>(
     const iconSize = FIELD_ICON_SIZE[size]
 
     return (
-      <S.CustomInput focused={focused} onBlur={handleBlur} onFocus={handleFocus}>
+      <S.CustomInput $focused={focused} onBlur={handleBlur} onFocus={handleFocus}>
         <input value={value} {...rest} ref={ref} />
         {icon && iconPlacement !== 'right' ? (
           <IconWrapper iconPlacement={iconPlacement} size={iconSize}>

--- a/lib/src/components/DateTimePickerCommon/styles.ts
+++ b/lib/src/components/DateTimePickerCommon/styles.ts
@@ -1,5 +1,5 @@
 import styled, { css, system } from '@xstyled/styled-components'
-import type { ReactDatePickerProps } from 'react-datepicker'
+import type { DatePickerProps as ReactDatePickerProps } from 'react-datepicker'
 import ReactDatePicker from 'react-datepicker'
 
 import { StyledButton } from '@/Button'
@@ -37,16 +37,16 @@ export const StyledTimePicker = styled(
   `
 )
 
-export const CustomInput = styled.div<{ focused: Focused }>(
-  ({ focused }) => css`
+export const CustomInput = styled.div<{ $focused: Focused }>(
+  ({ $focused }) => css`
     position: relative;
 
     ${IconGroupWrapper} {
-      z-index: ${focused ? 1 : null};
+      z-index: ${$focused ? 1 : null};
     }
 
     ${IconWrapper} {
-      z-index: ${focused ? 1 : null};
+      z-index: ${$focused ? 1 : null};
     }
   `
 )

--- a/lib/src/components/DateTimePickerCommon/utils.ts
+++ b/lib/src/components/DateTimePickerCommon/utils.ts
@@ -1,9 +1,12 @@
-import type { Locale } from 'date-fns'
+import type { Locale, Month } from 'date-fns'
 import range from 'lodash.range'
 
 import type { SelectOption, SelectOptions } from '@/Select'
 
-const MONTHS = [
+const MONTHS: {
+  label: string
+  value: Month
+}[] = [
   { label: 'January', value: 0 },
   { label: 'February', value: 1 },
   { label: 'March', value: 2 },
@@ -42,9 +45,9 @@ export const getMonths = (locale: Locale): SelectOptions['options'] => {
     return MONTHS
   }
 
-  return MONTHS.map((item, index) => ({
-    ...item,
-    label: locale.localize.month(index),
+  return MONTHS.map(({ value }) => ({
+    label: locale.localize.month(value),
+    value,
   }))
 }
 

--- a/lib/src/components/TimePicker/docs/examples/react-date-picker.tsx
+++ b/lib/src/components/TimePicker/docs/examples/react-date-picker.tsx
@@ -1,9 +1,7 @@
 import { TimePicker } from '@/TimePicker'
 
 const Example = () => {
-  return (
-    <TimePicker name="welcome" popperProps={{ zIndex: 50 }} timeIntervals={30} value={new Date()} />
-  )
+  return <TimePicker name="welcome" timeIntervals={30} value={new Date()} />
 }
 
 export default Example

--- a/lib/src/components/TimePicker/docs/properties.json
+++ b/lib/src/components/TimePicker/docs/properties.json
@@ -1,18 +1,164 @@
 {
   "TimePicker": {
     "props": {
+      "excludeDateIntervals": {
+        "defaultValue": null,
+        "description": "",
+        "name": "excludeDateIntervals",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "DateFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "{ start: Date; end: Date; }[]"
+        }
+      },
+      "excludeDates": {
+        "defaultValue": null,
+        "description": "",
+        "name": "excludeDates",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "DateFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "{ date: Date; message?: string; }[] | Date[]",
+          "value": [
+            {
+              "value": "{ date: Date; message?: string; }[]",
+              "description": "",
+              "fullComment": "",
+              "tags": {}
+            },
+            {
+              "value": "Date[]",
+              "description": "",
+              "fullComment": "",
+              "tags": {}
+            }
+          ]
+        }
+      },
+      "excludeTimes": {
+        "defaultValue": null,
+        "description": "",
+        "name": "excludeTimes",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "TimeFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date[]"
+        }
+      },
+      "filterDate": {
+        "defaultValue": null,
+        "description": "",
+        "name": "filterDate",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "DateFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "(date: Date) => boolean"
+        }
+      },
+      "filterTime": {
+        "defaultValue": null,
+        "description": "",
+        "name": "filterTime",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "TimeFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "(time: Date) => boolean"
+        }
+      },
       "icon": {
         "defaultValue": null,
         "description": "",
         "name": "icon",
         "parent": {
-          "fileName": "welcome-ui/node_modules/@types/react-datepicker/index.d.ts",
-          "name": "ReactDatePickerProps"
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/calendar_icon.d.ts",
+          "name": "CalendarIconProps"
         },
         "declarations": [
           {
-            "fileName": "welcome-ui/node_modules/@types/react-datepicker/index.d.ts",
-            "name": "ReactDatePickerProps"
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/calendar_icon.d.ts",
+            "name": "CalendarIconProps"
           },
           {
             "fileName": "welcome-ui/lib/src/components/DateTimePickerCommon/CustomInput.tsx",
@@ -22,13 +168,28 @@
         "required": false,
         "type": {
           "name": "enum",
-          "raw": "(string | ReactElement<any, string | JSXElementConstructor<any>>) & Element",
+          "raw": "ReactNode & Element",
           "value": [
             {
               "value": "string & Element"
             },
             {
+              "value": "number & Element"
+            },
+            {
+              "value": "false & Element"
+            },
+            {
+              "value": "true & Element"
+            },
+            {
               "value": "ReactElement<any, string | JSXElementConstructor<any>> & Element"
+            },
+            {
+              "value": "Iterable<ReactNode> & Element"
+            },
+            {
+              "value": "ReactPortal & Element"
             }
           ]
         }
@@ -61,6 +222,191 @@
               "value": "\"left\""
             }
           ]
+        }
+      },
+      "includeDateIntervals": {
+        "defaultValue": null,
+        "description": "",
+        "name": "includeDateIntervals",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "DateFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "{ start: Date; end: Date; }[]"
+        }
+      },
+      "includeDates": {
+        "defaultValue": null,
+        "description": "",
+        "name": "includeDates",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "DateFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date[]"
+        }
+      },
+      "includeTimes": {
+        "defaultValue": null,
+        "description": "",
+        "name": "includeTimes",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "TimeFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date[]"
+        }
+      },
+      "maxDate": {
+        "defaultValue": null,
+        "description": "",
+        "name": "maxDate",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+          "name": "MonthYearDropdownOptionsProps"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+            "name": "MonthYearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date"
+        }
+      },
+      "maxTime": {
+        "defaultValue": null,
+        "description": "",
+        "name": "maxTime",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "TimeFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date"
+        }
+      },
+      "minDate": {
+        "defaultValue": null,
+        "description": "",
+        "name": "minDate",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+          "name": "MonthYearDropdownOptionsProps"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+            "name": "MonthYearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "DateFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date"
+        }
+      },
+      "minTime": {
+        "defaultValue": null,
+        "description": "",
+        "name": "minTime",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+          "name": "TimeFilterOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/date_utils.d.ts",
+            "name": "TimeFilterOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Date"
         }
       },
       "onBlur": {
@@ -137,6 +483,70 @@
         "required": false,
         "type": {
           "name": "string"
+        }
+      },
+      "scrollableMonthYearDropdown": {
+        "defaultValue": null,
+        "description": "",
+        "name": "scrollableMonthYearDropdown",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+          "name": "MonthYearDropdownOptionsProps"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+            "name": "MonthYearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/month_year_dropdown_options.d.ts",
+            "name": "MonthYearDropdownOptionsProps"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "scrollableYearDropdown": {
+        "defaultValue": null,
+        "description": "",
+        "name": "scrollableYearDropdown",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+          "name": "YearDropdownOptionsProps"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
         }
       },
       "size": {
@@ -234,6 +644,29 @@
               "tags": {}
             }
           ]
+        }
+      },
+      "yearDropdownItemNumber": {
+        "defaultValue": null,
+        "description": "",
+        "name": "yearDropdownItemNumber",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+          "name": "YearDropdownOptionsProps"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          },
+          {
+            "fileName": "welcome-ui/node_modules/react-datepicker/dist/year_dropdown_options.d.ts",
+            "name": "YearDropdownOptionsProps"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "number"
         }
       }
     }

--- a/lib/src/components/TimePicker/index.tsx
+++ b/lib/src/components/TimePicker/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import type { ReactDatePickerProps } from 'react-datepicker'
+import type { DatePickerProps as ReactDatePickerProps } from 'react-datepicker'
 
 import type { CustomInputOptions, Focused } from '@/DateTimePickerCommon'
 import {

--- a/lib/tests/setup.ts
+++ b/lib/tests/setup.ts
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom/vitest'
+import { vi } from 'vitest'
+
+// Mock ResizeObserver globally
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  disconnect: vi.fn(),
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+}))

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,7 +213,7 @@
   dependencies:
     "@babel/types" "^7.26.10"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.8":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.23.8":
   version "7.26.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.10.tgz#a07b4d8fa27af131a633d7b3524db803eb4764c2"
   integrity sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==
@@ -697,6 +697,27 @@
   integrity sha512-VKmvHVatWnewmGGy+7Mdy4cTJX71Pli6v/Wjb5RQBuq5wjUYx+Ef+kRThi8qggZqDgD8CogCpqhRoVp3+yQk+g==
   dependencies:
     "@floating-ui/core" "^1.3.1"
+
+"@floating-ui/react-dom@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.3.tgz#1dea32e59514a67d182f0c89c8975ff959774b61"
+  integrity sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
+"@floating-ui/react@^0.27.3":
+  version "0.27.12"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.27.12.tgz#f1ddb43f50aa354a54de621272c44fff51444b51"
+  integrity sha512-kKlWNrpIQxF1B/a2MZvE0/uyKby4960yjO91W7nVyNKmmfNi62xU9HCjL1M1eWzx/LFj/VPSwJVbwQk9Pq/68A==
+  dependencies:
+    "@floating-ui/react-dom" "^2.1.3"
+    "@floating-ui/utils" "^0.2.9"
+    tabbable "^6.0.0"
+
+"@floating-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
+  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -1273,11 +1294,6 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
-"@popperjs/core@^2.11.8", "@popperjs/core@^2.9.2":
-  version "2.11.8"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
-  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
-
 "@rollup/pluginutils@^5.1.4":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.4.tgz#bb94f1f9eaaac944da237767cdfee6c5b2262d4a"
@@ -1654,15 +1670,12 @@
   dependencies:
     types-ramda "^0.30.1"
 
-"@types/react-datepicker@^4.15.0":
-  version "4.19.3"
-  resolved "https://registry.yarnpkg.com/@types/react-datepicker/-/react-datepicker-4.19.3.tgz#0a58e42d820adf12337617bd72289766643775db"
-  integrity sha512-85F9eKWu9fGiD9r4KVVMPYAdkJJswR3Wci9PvqplmB6T+D+VbUqPeKtifg96NZ4nEhufjehW+SX4JLrEWVplWw==
+"@types/react-datepicker@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-datepicker/-/react-datepicker-7.0.0.tgz#1d36553a92546246f1e10d862b3cfa7d295dff01"
+  integrity sha512-4tWwOUq589tozyQPBVEqGNng5DaZkomx5IVNuur868yYdgjH6RaL373/HKiVt1IDoNNXYiTGspm1F7kjrarM8Q==
   dependencies:
-    "@popperjs/core" "^2.9.2"
-    "@types/react" "*"
-    date-fns "^2.0.1"
-    react-popper "^2.2.5"
+    react-datepicker "*"
 
 "@types/react-dom@18.3.1":
   version "18.3.1"
@@ -2717,11 +2730,6 @@ ci-info@^4.1.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.1.0.tgz#92319d2fa29d2620180ea5afed31f589bc98cf83"
   integrity sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==
 
-classnames@^2.2.6:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
-  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
-
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -2772,7 +2780,7 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-clsx@^2.0.0:
+clsx@^2.0.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -3293,13 +3301,6 @@ data-view-byte-offset@^1.0.1:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
-
-date-fns@^2.0.1, date-fns@^2.30.0:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
 
 date-fns@^4.1.0:
   version "4.1.0"
@@ -5979,7 +5980,7 @@ longest-streak@^3.0.0:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
   integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7590,17 +7591,14 @@ rc@1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-datepicker@^4.16.0:
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-4.21.0.tgz#09b2ba3e53654a8563b22c9f649835716c8456d3"
-  integrity sha512-z0DtuRrKMz9i7dcTusW29VacbM9pn08g1yw0cG+Y5GpodJDxSWv7zUMxl3IwKN9Ap/AMphiepvmT5P+iNCgEiA==
+react-datepicker@*, react-datepicker@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-8.4.0.tgz#8db0beac6282ef72d12494bd49cc5e61362a3a42"
+  integrity sha512-6nPDnj8vektWCIOy9ArS3avus9Ndsyz5XgFCJ7nBxXASSpBdSL6lG9jzNNmViPOAOPh6T5oJyGaXuMirBLECag==
   dependencies:
-    "@popperjs/core" "^2.11.8"
-    classnames "^2.2.6"
-    date-fns "^2.30.0"
-    prop-types "^15.7.2"
-    react-onclickoutside "^6.13.0"
-    react-popper "^2.3.0"
+    "@floating-ui/react" "^0.27.3"
+    clsx "^2.1.1"
+    date-fns "^4.1.0"
 
 react-docgen-typescript@^2.2.2:
   version "2.2.2"
@@ -7623,11 +7621,6 @@ react-dropzone@^14.3.5:
     attr-accept "^2.2.4"
     file-selector "^2.1.0"
     prop-types "^15.8.1"
-
-react-fast-compare@^3.0.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
-  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
 react-flatten-children@^1.0.0:
   version "1.1.2"
@@ -7666,19 +7659,6 @@ react-markdown@9.0.1:
     unified "^11.0.0"
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
-
-react-onclickoutside@^6.13.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz#e165ea4e5157f3da94f4376a3ab3e22a565f4ffc"
-  integrity sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==
-
-react-popper@^2.2.5, react-popper@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
-  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
-  dependencies:
-    react-fast-compare "^3.0.1"
-    warning "^4.0.2"
 
 react-router-dom@7.5.2:
   version "7.5.2"
@@ -8955,6 +8935,11 @@ synckit@^0.11.0:
     "@pkgr/core" "^0.2.3"
     tslib "^2.8.1"
 
+tabbable@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
+  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
+
 table@^6.9.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.9.0.tgz#50040afa6264141c7566b3b81d4d82c47a8668f5"
@@ -9659,13 +9644,6 @@ w3c-xmlserializer@^5.0.0:
   integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
   dependencies:
     xml-name-validator "^5.0.0"
-
-warning@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
 
 web-namespaces@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## DESCRIPTION
This Pr updates the datepicker to its last version. 
Only breaking potential breaking changes I could find was: 
- on [v5.0.0] (https://github.com/Hacker0x01/react-datepicker/releases/tag/v5.0.0) -> Migrate from Popper.js to Floating-UI
- on [v6.6.0] (https://github.com/Hacker0x01/react-datepicker/releases/tag/v6.6.0) -> feat: Replaced classnames with clsx 
I observed no change in behavior for the datepicker 

## HOW TO TEST
- Mess round with the datepicker components 
- Install a dev release to your project and run your tests suites 


## QA
- [X] Thoroughly tested in local environment
- [ ] Dev release 
