### PR TITLE
fix: wrong responsiveness on screens

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -102,11 +102,6 @@
       "count": 1
     }
   },
-  "lib/src/theme/colors.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    }
-  },
   "lib/src/utils/hide-focus-rings-root.tsx": {
     "@typescript-eslint/no-unused-expressions": {
       "count": 1

--- a/lib/src/theme/borders.ts
+++ b/lib/src/theme/borders.ts
@@ -1,11 +1,13 @@
+/* eslint-disable perfectionist/sort-objects */
+/* eslint-disable perfectionist/sort-object-types */
 export type ThemeBorderWidths = {
-  lg: string
-  md: string
   sm: string
+  md: string
+  lg: string
 }
 
 export const borderWidths: ThemeBorderWidths = {
-  lg: '3px',
-  md: '2px',
   sm: '1px',
+  md: '2px',
+  lg: '3px',
 }

--- a/lib/src/theme/colors.ts
+++ b/lib/src/theme/colors.ts
@@ -121,13 +121,6 @@ export const getColors = (systemColors: typeof palette) => ({
 })
 
 export const colors = getColors(palette)
-const enum SecondaryColors {
-  'blue',
-  'green',
-  'orange',
-  'pink',
-  'teal',
-  'violet',
-}
 export type ThemeColors = typeof colors
-export type ThemeSecondaryColors = keyof typeof SecondaryColors
+export type ThemeSecondaryColors = SecondaryColors
+type SecondaryColors = 'blue' | 'green' | 'orange' | 'pink' | 'teal' | 'violet'

--- a/lib/src/theme/radii.ts
+++ b/lib/src/theme/radii.ts
@@ -1,24 +1,26 @@
+/* eslint-disable perfectionist/sort-objects */
+/* eslint-disable perfectionist/sort-object-types */
 import type { ThemeValues } from '.'
 
 export type ThemeRadii = {
-  [key: number]: string
-  full: string
-  lg: string
-  md: string
   none: string
   sm: string
+  md: string
+  lg: string
   xl: string
   xxl: string
+  full: string
+  [key: number]: string
 }
 
 export const getRadii = (theme: ThemeValues): ThemeRadii => {
   return {
-    full: '100%',
-    lg: theme.toRem(8),
-    md: theme.toRem(4),
     none: '0',
     sm: theme.toRem(2),
+    md: theme.toRem(4),
+    lg: theme.toRem(8),
     xl: theme.toRem(16),
     xxl: theme.toRem(24),
+    full: '100%',
   }
 }

--- a/lib/src/theme/screens.ts
+++ b/lib/src/theme/screens.ts
@@ -1,5 +1,6 @@
-// we want to keep ThemeScreens in a natural order for documentation
+/* eslint-disable perfectionist/sort-objects */
 /* eslint-disable perfectionist/sort-object-types */
+// we want to keep ThemeScreens in a natural order for documentation
 export type ThemeScreens = {
   xs: number
   sm: number
@@ -12,15 +13,14 @@ export type ThemeScreens = {
   [key: string]: number
   [key: number]: number
 }
-/* eslint-enable perfectionist/sort-object-types */
 
 export const screens: ThemeScreens = {
+  xs: 0,
+  sm: 480,
+  md: 736,
+  lg: 980,
+  xl: 1280,
+  xxl: 1440,
   '3xl': 1620,
   '4xl': 1920,
-  lg: 980,
-  md: 736,
-  sm: 480,
-  xl: 1280,
-  xs: 0,
-  xxl: 1440,
 }

--- a/lib/src/theme/shadows.ts
+++ b/lib/src/theme/shadows.ts
@@ -1,9 +1,11 @@
+/* eslint-disable perfectionist/sort-objects */
+/* eslint-disable perfectionist/sort-object-types */
 export type ThemeShadows = {
-  md: string
   sm: string
+  md: string
 }
 
 export const shadows: ThemeShadows = {
-  md: '3px 4px 10px 0 rgba(0,0,0,0.07)',
   sm: '1px 2px 4px 0 rgba(0,0,0,0.05)',
+  md: '3px 4px 10px 0 rgba(0,0,0,0.07)',
 }

--- a/lib/src/theme/space.ts
+++ b/lib/src/theme/space.ts
@@ -1,7 +1,7 @@
+/* eslint-disable perfectionist/sort-objects */
+/* eslint-disable perfectionist/sort-object-types */
 import type { ThemeValues } from '.'
 
-// we want to keep ThemeSpace in a natural order for documentation
-/* eslint-disable perfectionist/sort-object-types */
 export type ThemeSpace = {
   xxs: string
   xs: string
@@ -18,21 +18,20 @@ export type ThemeSpace = {
   [key: string]: string
   [key: number]: string
 }
-/* eslint-enable perfectionist/sort-object-types */
 
 export const getSpace = (theme: ThemeValues): ThemeSpace => {
   return {
+    xxs: theme.toRem(2),
+    xs: theme.toRem(4),
+    sm: theme.toRem(8),
+    md: theme.toRem(12),
+    lg: theme.toRem(16),
+    xl: theme.toRem(24),
+    xxl: theme.toRem(32),
     '3xl': theme.toRem(48),
     '4xl': theme.toRem(64),
     '5xl': theme.toRem(96),
     '6xl': theme.toRem(128),
     '7xl': theme.toRem(192),
-    lg: theme.toRem(16),
-    md: theme.toRem(12),
-    sm: theme.toRem(8),
-    xl: theme.toRem(24),
-    xs: theme.toRem(4),
-    xxl: theme.toRem(32),
-    xxs: theme.toRem(2),
   }
 }


### PR DESCRIPTION
Fix definitions for screens to avoid wrong import loke:

<img width="318" alt="Capture d’écran 2025-06-12 à 15 22 10" src="https://github.com/user-attachments/assets/7327b0fa-4062-4c70-9a42-332a3926f183" />
