### PR TITLE
Fix(AssetDrawer): remove persistent elements boolean assertion

### DIFF
--- a/lib/src/components/Drawer/AssetDrawer/index.tsx
+++ b/lib/src/components/Drawer/AssetDrawer/index.tsx
@@ -39,15 +39,13 @@ export const AssetDrawerComponent = forwardRef<'div', AssetDrawerProps>(
       return !isTargetWithinPersistentElements
     }
 
-    const hideOnInteractOutside = Boolean(parentGetPersistentElements) || hideOnInteractOutsideFn
-
     return (
       <Drawer
         {...rest}
         autoFocusOnShow={false}
         getPersistentElements={getPersistentElements}
         h={{ _: '100%', md: 'calc(100% - 3rem)' }}
-        hideOnInteractOutside={hideOnInteractOutside}
+        hideOnInteractOutside={hideOnInteractOutsideFn}
         overflow="hidden"
         placement="bottom"
         ref={ref}


### PR DESCRIPTION
## DESCRIPTION
The Asset Drawer's props `hideOnInteractOutside` is define as is: 

```typescript
const hideOnInteractOutside = Boolean(parentGetPersistentElements) || hideOnInteractOutsideFn
```
But `parentGetPersistentElements` allows interaction with elements displayed on top of the asset drawer.
However, `Boolean(parentGetPersistentElements)` always returns true when we pass elements. 
So the drawer closes on interaction.

This PR removes the Boolean assertion/cast/thing
Behavior is preserved because we still iterate over the passed elements in the function `hideOnInteractOutsideFn`

## SCREENSHOTS / SCREEN RECORDINGS
the issue: 

https://github.com/user-attachments/assets/557e15a3-9e51-4419-a89a-72899314617f

After the fix: 

https://github.com/user-attachments/assets/9d9787fb-9fce-44ce-81ab-c7c6c0adc31b



## QA
- [X] Thoroughly tested in local environment with a dev release
