### PR TITLE
Fix: use a contrast compliant color for texts

### DIFF
--- a/lib/src/components/Breadcrumb/theme.ts
+++ b/lib/src/components/Breadcrumb/theme.ts
@@ -21,7 +21,7 @@ export const getBreadcrumbs = (theme: ThemeValues): ThemeBreadcrumbs => {
         color: colors['neutral-70'],
       },
       default: {
-        color: colors['neutral-50'],
+        color: colors['neutral-60'],
         textDecoration: 'none',
       },
       hover: {

--- a/lib/src/components/Link/theme.ts
+++ b/lib/src/components/Link/theme.ts
@@ -27,7 +27,7 @@ export const getLinks = (theme: ThemeValues): ThemeLinks => {
     },
     disabled: {
       backgroundImage: `linear-gradient(0deg, ${colors['neutral-30']}, ${colors['neutral-30']} 100%)`,
-      color: colors['neutral-50'],
+      color: colors['neutral-60'],
     },
     primary: {
       default: {},

--- a/lib/src/components/Slider/Range.tsx
+++ b/lib/src/components/Slider/Range.tsx
@@ -401,11 +401,7 @@ export const Range = forwardRef<'div', RangeProps>(
             ))}
         </Box>
 
-        {hint ? (
-          <Hint color="neutral-50" mt={0}>
-            {hint}
-          </Hint>
-        ) : null}
+        {hint ? <Hint mt={0}>{hint}</Hint> : null}
       </Box>
     )
   }

--- a/lib/src/components/Slider/index.tsx
+++ b/lib/src/components/Slider/index.tsx
@@ -228,11 +228,7 @@ export const SliderComponent = forwardRef<'div', SliderProps>(
             ))}
         </Box>
 
-        {hint ? (
-          <Hint color="neutral-50" mt={0}>
-            {hint}
-          </Hint>
-        ) : null}
+        {hint ? <Hint mt={0}>{hint}</Hint> : null}
       </Box>
     )
   }

--- a/lib/src/components/Slider/styles.ts
+++ b/lib/src/components/Slider/styles.ts
@@ -205,7 +205,6 @@ export const Thick = styled(Box)(
 export const ThickLabel = styled(Hint)(
   () => css`
     position: absolute;
-    color: neutral-50;
     top: 0;
     transform: translate(-50%);
     white-space: nowrap;

--- a/lib/src/components/Tabs/theme.ts
+++ b/lib/src/components/Tabs/theme.ts
@@ -62,7 +62,7 @@ export const getTabs = (theme: ThemeValues): ThemeTabs => {
         textDecoration: 'none',
       },
       disabled: {
-        color: colors['neutral-50'],
+        color: colors['neutral-60'],
       },
       focus: {
         color: colors['neutral-90'],

--- a/lib/src/theme/defaultFields.ts
+++ b/lib/src/theme/defaultFields.ts
@@ -116,7 +116,7 @@ export const getDefaultFields = (theme: ThemeValues): ThemeDefaultFields => {
       },
     },
     placeholder: {
-      color: colors['neutral-50'],
+      color: colors['neutral-60'],
     },
     select: {
       default: {


### PR DESCRIPTION
This pull request updates the color palette usage across several components to improve visual consistency and accessibility. The main change is replacing the use of `neutral-50` with `neutral-60` for disabled and placeholder states in various UI elements. 
Additionally, some unnecessary explicit color settings have been removed from certain components.

**Theme color updates:**

* Updated disabled and placeholder text color from `neutral-50` to `neutral-60` in `Breadcrumb`, `Link`, `Tabs`, and default field themes for better contrast and consistency. [[1]](diffhunk://#diff-ec90dbeba0a7f574471730f692870dbb526b14479f2b572082f12e201136256aL24-R24) [[2]](diffhunk://#diff-ed7d085ea112453cd7ebd3779184379d26427bbde9309fe7702fe00f3cea4942L30-R30) [[3]](diffhunk://#diff-fb2168bda3ad71593e8f5f951a7c2cd2621b345b3788b1b7e3b7114c3aab1cbaL65-R65) [[4]](diffhunk://#diff-9d4a01b273712dfe482531a6ac0cf2eba3e9f54745eb47d811915c2df864d546L119-R119)

**Component rendering improvements:**

* Removed explicit `color="neutral-50"` prop from `Hint` components in `Slider/Range.tsx` and `Slider/index.tsx`, allowing the theme to control hint color. [[1]](diffhunk://#diff-64b6ea74f93f10be1bd444fcae308ef406939995065772234641ecc57a3b80c8L404-R404) [[2]](diffhunk://#diff-ac5b4f4e0d81a165d33bd364e0e23b2005b7dfc7961e1435d4cf91fb1abc0f7fL231-R231)
* Deleted the hardcoded `color: neutral-50` style from `ThickLabel` in `Slider/styles.ts` to rely on theme defaults.