### PR TITLE
Chore: add classnames test

### DIFF
--- a/lib/src/tailwindComponents/Button/index.tsx
+++ b/lib/src/tailwindComponents/Button/index.tsx
@@ -1,6 +1,6 @@
 import { Button as AriakitButton } from '@ariakit/react'
 
-import { classNames } from '../../tailwindUtils/classNames'
+import { classNames } from '../../utils/classNames'
 
 import buttonStyles from './button.module.scss'
 import type { ButtonProps } from './types'

--- a/lib/src/utils/classNames.test.ts
+++ b/lib/src/utils/classNames.test.ts
@@ -1,0 +1,64 @@
+import { classNames } from './classNames'
+
+describe('classNames', () => {
+  it('should return an empty string when no arguments are provided', () => {
+    const cx = classNames()
+    expect(cx()).toBe('')
+  })
+
+  it('should handle string arguments', () => {
+    const cx = classNames()
+    expect(cx('class1', 'class2')).toBe('class1 class2')
+  })
+
+  it('should handle false, null, and undefined values', () => {
+    const cx = classNames()
+    expect(cx('class1', false, null, undefined, 'class2')).toBe('class1 class2')
+  })
+
+  it('should handle arrays of class names', () => {
+    const cx = classNames()
+    expect(cx(['class1', 'class2', false, null, undefined], 'class3')).toBe('class1 class2 class3')
+  })
+
+  it('should handle objects with truthy values', () => {
+    const cx = classNames()
+    expect(cx({ class1: true, class2: false, class3: true })).toBe('class1 class3')
+  })
+
+  it('should handle mixed arguments', () => {
+    const cx = classNames()
+    expect(
+      cx(
+        'class1',
+        ['class2', null, 'class3'],
+        { class4: true, class5: false },
+        // eslint-disable-next-line no-constant-binary-expression
+        true && 'class5',
+        // eslint-disable-next-line no-constant-binary-expression
+        false && 'class6'
+      )
+    ).toBe('class1 class2 class3 class4 class5')
+  })
+
+  it('should deduplicate class names', () => {
+    const cx = classNames()
+    expect(
+      cx('class1', 'class2', 'class1', 'class3', 'class2', ['class1', 'class2'], {
+        class2: true,
+        class3: true,
+        class4: false,
+      })
+    ).toBe('class1 class2 class3')
+  })
+
+  it('should work with CSS modules', () => {
+    const fakeModule = {
+      button: 'button_xyz',
+      primary: 'primary_123',
+    }
+
+    const cx = classNames(fakeModule)
+    expect(cx('button', 'plain')).toBe('button_xyz plain')
+  })
+})

--- a/lib/src/utils/classNames.ts
+++ b/lib/src/utils/classNames.ts
@@ -24,7 +24,7 @@ export function classNames<C extends CSSModule>(module?: C) {
         if (!arg) continue
 
         if (typeof arg === 'string') {
-          cx.add(module[arg] || arg)
+          cx.add(module?.[arg] || arg)
         } else if (Array.isArray(arg)) {
           // Recursively resolve class names in the array
           _classNames(...arg)
@@ -33,7 +33,7 @@ export function classNames<C extends CSSModule>(module?: C) {
             // Require the className to be truthy to add it to the set.
             // We make sure the className object has the hasOwnProperty prototype
             if (Object.prototype.hasOwnProperty.call(arg, key) && arg[key]) {
-              cx.add(module[key] || key)
+              cx.add(module?.[key] || key)
             }
           }
         }


### PR DESCRIPTION
## DESCRIPTION

This pull request refactors the location of the `classNames` utility and adds comprehensive unit tests to ensure its correctness. It also makes minor improvements to how CSS module class names are resolved within the utility.

**Refactoring and Testing Improvements:**

* Moved the `classNames` utility from `lib/src/classNames.ts` to `lib/src/utils/classNames.ts`, and updated all imports accordingly.
* Added a new test file `lib/src/utils/classNames.test.ts` with thorough unit tests covering various use cases for the `classNames` utility, including handling of strings, arrays, objects, falsy values, deduplication, and CSS modules.

**Code Quality Enhancements:**

* Updated the `classNames` implementation to use optional chaining (`module?.[arg]`) for safer access to CSS module properties, preventing runtime errors if the module is undefined. [[1]](diffhunk://#diff-922ef17fc7bc0d351397386f082ceb3e7773f66692e0f363a890a5f643a47ef1L27-R27) [[2]](diffhunk://#diff-922ef17fc7bc0d351397386f082ceb3e7773f66692e0f363a890a5f643a47ef1L36-R36)

## HOW TO TEST

`yarn test` 😎 
