### PR TITLE
[WUI-211] Chore: migrate button group

### DIFF
--- a/lib/src/components/Button/button.module.scss
+++ b/lib/src/components/Button/button.module.scss
@@ -23,6 +23,7 @@
     color: var(--color, var(--color-neutral-90));
     background-color: var(--backgroundColor);
     border-color: var(--borderColor);
+    line-height: var(--lineHeight);
 
     &[data-focus-visible],
     &:focus-visible {
@@ -134,6 +135,7 @@
       --paddingInlineHasIcon: var(--spacing-sm);
       --iconDefaultSize: 0.75rem; /* 12px */
       --iconOnlySize: 1rem; /* 16px */
+      --lineHeight: var(--line-height-xs);
     }
 
     &-sm {
@@ -143,6 +145,7 @@
       --paddingInlineHasIcon: var(--spacing-md);
       --iconDefaultSize: 1rem; /* 16px */
       --iconOnlySize: 1rem; /* 16px */
+      --lineHeight: var(--line-height-xs);
     }
 
     &-md {
@@ -152,6 +155,7 @@
       --paddingInlineHasIcon: var(--spacing-md);
       --iconDefaultSize: 1rem; /* 16px */
       --iconOnlySize: 1rem; /* 16px */
+      --lineHeight: var(--line-height-sm);
     }
 
     &-lg {
@@ -161,6 +165,7 @@
       --paddingInlineHasIcon: var(--spacing-lg);
       --iconDefaultSize: 1rem; /* 16px */
       --iconOnlySize: 1.5rem; /* 24px */
+      --lineHeight: var(--line-height-sm);
     }
   }
 

--- a/lib/src/components/Button/docs/properties.json
+++ b/lib/src/components/Button/docs/properties.json
@@ -1,6 +1,132 @@
 {
   "Button": {
     "props": {
+      "accessibleWhenDisabled": {
+        "defaultValue": {
+          "value": true
+        },
+        "description": "Indicates whether the element should be focusable even when it is\n[`disabled`](https://ariakit.org/reference/focusable#disabled).\n\nThis is important when discoverability is a concern. For example:\n\n> A toolbar in an editor contains a set of special smart paste functions\nthat are disabled when the clipboard is empty or when the function is not\napplicable to the current content of the clipboard. It could be helpful to\nkeep the disabled buttons focusable if the ability to discover their\nfunctionality is primarily via their presence on the toolbar.\n\nLearn more on [Focusability of disabled\ncontrols](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols).\n\nLive examples:\n- [Combobox with Tabs](https://ariakit.org/examples/combobox-tabs)",
+        "name": "accessibleWhenDisabled",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+          "name": "FocusableOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+            "name": "FocusableOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "autoFocus": {
+        "defaultValue": {
+          "value": "false"
+        },
+        "description": "Automatically focuses the element upon mounting, similar to the native\n`autoFocus` prop. This addresses an issue where the element with the native\n`autoFocus` attribute might receive focus before React effects are\nexecuted.\n\nThe `autoFocus` prop can also be used with\n[Focusable](https://ariakit.org/components/focusable) elements within a\n[Dialog](https://ariakit.org/components/dialog) component, establishing the\ninitial focus as the dialog opens.\n\n**Note**: For this prop to work, the\n[`focusable`](https://ariakit.org/reference/command#focusable) prop must be\nset to `true`, if it's not set by default.\n\nLive examples:\n- [Warning on Dialog\n  hide](https://ariakit.org/examples/dialog-hide-warning)\n- [Dialog with React\n  Router](https://ariakit.org/examples/dialog-react-router)\n- [Nested Dialog](https://ariakit.org/examples/dialog-nested)",
+        "name": "autoFocus",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+          "name": "FocusableOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+            "name": "FocusableOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "clickOnEnter": {
+        "defaultValue": {
+          "value": "true"
+        },
+        "description": "If set to `true`, pressing the enter key while this element is focused will\ntrigger a click on the element, regardless of whether it's a native button\nor not. If this prop is set to `false`, pressing enter will not initiate a\nclick.",
+        "name": "clickOnEnter",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/command/command.d.ts",
+          "name": "CommandOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/command/command.d.ts",
+            "name": "CommandOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "clickOnSpace": {
+        "defaultValue": {
+          "value": "true"
+        },
+        "description": "If set to `true`, pressing and releasing the space key while this element\nis focused will trigger a click on the element, regardless of whether it's\na native button or not. If this prop is set to `false`, space will not\ninitiate a click.",
+        "name": "clickOnSpace",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/command/command.d.ts",
+          "name": "CommandOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/command/command.d.ts",
+            "name": "CommandOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "disabled": {
+        "defaultValue": {
+          "value": false
+        },
+        "description": "Determines if the element is disabled. This sets the `aria-disabled`\nattribute accordingly, enabling support for all elements, including those\nthat don't support the native `disabled` attribute.\n\nThis feature can be combined with the\n[`accessibleWhenDisabled`](https://ariakit.org/reference/focusable#accessiblewhendisabled)\nprop to make disabled elements still accessible via keyboard.\n\n**Note**: For this prop to work, the\n[`focusable`](https://ariakit.org/reference/command#focusable) prop must be\nset to `true`, if it's not set by default.\n\nLive examples:\n- [Submenu](https://ariakit.org/examples/menu-nested)\n- [Combobox with Tabs](https://ariakit.org/examples/combobox-tabs)\n- [Context Menu](https://ariakit.org/examples/menu-context-menu)",
+        "name": "disabled",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+          "name": "FocusableOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+            "name": "FocusableOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "focusable": {
+        "defaultValue": {
+          "value": "true"
+        },
+        "description": "Determines if [Focusable](https://ariakit.org/components/focusable)\nfeatures should be active on non-native focusable elements.\n\n**Note**: This prop only turns off the additional features provided by the\n[`Focusable`](https://ariakit.org/reference/focusable) component.\nNon-native focusable elements will lose their focusability entirely.\nHowever, native focusable elements will retain their inherent focusability,\nbut without added features such as improved\n[`autoFocus`](https://ariakit.org/reference/focusable#autofocus),\n[`accessibleWhenDisabled`](https://ariakit.org/reference/focusable#accessiblewhendisabled),\n[`onFocusVisible`](https://ariakit.org/reference/focusable#onfocusvisible),\netc.",
+        "name": "focusable",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+          "name": "FocusableOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+            "name": "FocusableOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
       "isLoading": {
         "defaultValue": {
           "value": false
@@ -31,6 +157,44 @@
           ]
         }
       },
+      "onFocusVisible": {
+        "defaultValue": null,
+        "description": "Custom event handler invoked when the element gains focus through keyboard\ninteraction or a key press occurs while the element is in focus. This is\nthe programmatic equivalent of the\n[`data-focus-visible`](https://ariakit.org/guide/styling#data-focus-visible)\nattribute.\n\n**Note**: For this prop to work, the\n[`focusable`](https://ariakit.org/reference/command#focusable) prop must be\nset to `true`, if it's not set by default.\n\nLive examples:\n- [Navigation Menubar](https://ariakit.org/examples/menubar-navigation)\n- [Custom Checkbox](https://ariakit.org/examples/checkbox-custom)",
+        "name": "onFocusVisible",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+          "name": "FocusableOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+            "name": "FocusableOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "render": {
+        "defaultValue": null,
+        "description": "Allows the component to be rendered as a different HTML element or React\ncomponent. The value can be a React element or a function that takes in the\noriginal component props and gives back a React element with the props\nmerged.\n\nCheck out the [Composition](https://ariakit.org/guide/composition) guide\nfor more details.",
+        "name": "render",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/utils/types.d.ts",
+          "name": "Options"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/utils/types.d.ts",
+            "name": "Options"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
       "shape": {
         "defaultValue": {
           "value": "default"
@@ -50,7 +214,7 @@
         "required": false,
         "type": {
           "name": "enum",
-          "raw": "Shape",
+          "raw": "ButtonShape",
           "value": [
             {
               "value": "\"circle\""
@@ -83,7 +247,7 @@
         "required": false,
         "type": {
           "name": "enum",
-          "raw": "Size",
+          "raw": "ButtonSize",
           "value": [
             {
               "value": "\"lg\""
@@ -119,7 +283,7 @@
         "required": false,
         "type": {
           "name": "enum",
-          "raw": "Variant",
+          "raw": "ButtonVariant",
           "value": [
             {
               "value": "\"ghost\""
@@ -152,6 +316,25 @@
               "value": "\"tertiary-danger\""
             }
           ]
+        }
+      },
+      "wrapElement": {
+        "defaultValue": null,
+        "description": "",
+        "name": "wrapElement",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/utils/types.d.ts",
+          "name": "Options"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/utils/types.d.ts",
+            "name": "Options"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
         }
       }
     }

--- a/lib/src/components/Button/index.tsx
+++ b/lib/src/components/Button/index.tsx
@@ -2,6 +2,8 @@ import { Button as AriakitButton } from '@ariakit/react'
 
 import { classNames } from '@/utils'
 
+import { useButtonGroup } from '../ButtonGroup'
+
 import buttonStyles from './button.module.scss'
 import type { ButtonProps } from './types'
 
@@ -15,13 +17,17 @@ export const Button = <T extends React.ElementType = 'button'>({
   isLoading = false,
   ref,
   shape = 'default',
-  size = 'md',
-  variant = 'primary',
+  size: propSize = 'md',
+  variant: propVariant = 'primary',
   ...rest
 }: ButtonProps<T>) => {
-  const isDisabled = disabled || isLoading
+  const { disabled: groupDisabled, size: groupSize, variant: groupVariant } = useButtonGroup()
+
+  const isDisabled = groupDisabled || disabled || isLoading
   // some variants like 'disabled' preprend over the others
-  const activeVariant = (isDisabled && 'disabled') || variant
+  const variant = (isDisabled && 'disabled') || groupVariant || propVariant
+
+  const size = groupSize || propSize
 
   return (
     <AriakitButton
@@ -29,7 +35,7 @@ export const Button = <T extends React.ElementType = 'button'>({
       accessibleWhenDisabled={accessibleWhenDisabled}
       className={cx(
         'root',
-        variant && `variant-${activeVariant}`,
+        variant && `variant-${variant}`,
         shape && `shape-${shape}`,
         size && `size-${size}`,
         className

--- a/lib/src/components/Button/types.ts
+++ b/lib/src/components/Button/types.ts
@@ -1,28 +1,15 @@
 import type { ButtonProps as AriakitButtonProps } from '@ariakit/react'
-import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 
 import type { PolymorphicProps } from '@/theme/types'
 
-export type ButtonProps<T extends React.ElementType> = AriakitButtonProps &
-  ButtonHTMLAttributes<HTMLButtonElement> &
+export type ButtonProps<T extends React.ElementType = 'button'> = AriakitButtonProps &
   ButtonOptions &
-  PolymorphicProps<T> & {
-    children?: ReactNode
-    className?: string
-    ref?: React.Ref<HTMLButtonElement>
-    style?: CSSProperties
-  }
+  PolymorphicProps<T>
 
-interface ButtonOptions {
-  children?: ReactNode
-  isLoading?: boolean
-  shape?: Shape
-  size?: Size
-  variant?: Variant
-}
-type Shape = 'circle' | 'default' | 'square'
-type Size = 'lg' | 'md' | 'sm' | 'xs'
-type Variant =
+export type ButtonShape = 'circle' | 'default' | 'square'
+export type ButtonSize = 'lg' | 'md' | 'sm' | 'xs'
+export type ButtonVariant =
   | 'ghost'
   | 'ghost-ai'
   | 'ghost-danger'
@@ -33,3 +20,10 @@ type Variant =
   | 'tertiary'
   | 'tertiary-ai'
   | 'tertiary-danger'
+interface ButtonOptions {
+  children?: ReactNode
+  isLoading?: boolean
+  shape?: ButtonShape
+  size?: ButtonSize
+  variant?: ButtonVariant
+}

--- a/lib/src/components/ButtonGroup/button-group.module.scss
+++ b/lib/src/components/ButtonGroup/button-group.module.scss
@@ -1,0 +1,30 @@
+.root {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: -3px;
+
+  > * {
+    margin-top: 3px;
+
+    &:not(:only-child) {
+      &:not(:last-child) {
+        border-right-color: rgba(255, 255, 255, 0.4);
+      }
+
+      &:first-child {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+
+      &:last-child {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
+
+      &:not(:last-child):not(:first-child) {
+        border-radius: 0;
+      }
+    }
+  }
+}

--- a/lib/src/components/ButtonGroup/docs/examples/overload.tsx
+++ b/lib/src/components/ButtonGroup/docs/examples/overload.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@components/Button'
-import { ButtonGroup } from '@components/ButtonGroup'
+import { Button } from '@/components/Button'
+import { ButtonGroup } from '@/components/ButtonGroup'
 
 const Example = () => {
   return (

--- a/lib/src/components/ButtonGroup/docs/examples/overload.tsx
+++ b/lib/src/components/ButtonGroup/docs/examples/overload.tsx
@@ -1,0 +1,15 @@
+import { ButtonGroup } from '../..'
+import { Button } from '../../../Button'
+
+const Example = () => {
+  return (
+    <ButtonGroup size="sm" variant="tertiary">
+      <Button>First</Button>
+      <Button variant="secondary">Second</Button>
+      <Button variant="tertiary">Third</Button>
+      <Button variant="ghost">Last</Button>
+    </ButtonGroup>
+  )
+}
+
+export default Example

--- a/lib/src/components/ButtonGroup/docs/examples/overload.tsx
+++ b/lib/src/components/ButtonGroup/docs/examples/overload.tsx
@@ -6,7 +6,9 @@ const Example = () => {
     <ButtonGroup size="sm" variant="tertiary">
       <Button>First</Button>
       <Button variant="secondary">Second</Button>
-      <Button variant="tertiary">Third</Button>
+      <Button size="lg" variant="tertiary">
+        Third
+      </Button>
       <Button variant="ghost">Last</Button>
     </ButtonGroup>
   )

--- a/lib/src/components/ButtonGroup/docs/examples/overload.tsx
+++ b/lib/src/components/ButtonGroup/docs/examples/overload.tsx
@@ -1,5 +1,5 @@
-import { ButtonGroup } from '../..'
-import { Button } from '../../../Button'
+import { Button } from '@components/Button'
+import { ButtonGroup } from '@components/ButtonGroup'
 
 const Example = () => {
   return (

--- a/lib/src/components/ButtonGroup/docs/examples/overview.tsx
+++ b/lib/src/components/ButtonGroup/docs/examples/overview.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@components/Button'
-import { ButtonGroup } from '@components/ButtonGroup'
+import { Button } from '@/components/Button'
+import { ButtonGroup } from '@/components/ButtonGroup'
 
 const Example = () => {
   return (

--- a/lib/src/components/ButtonGroup/docs/examples/overview.tsx
+++ b/lib/src/components/ButtonGroup/docs/examples/overview.tsx
@@ -1,0 +1,15 @@
+import { ButtonGroup } from '../..'
+import { Button } from '../../../Button'
+
+const Example = () => {
+  return (
+    <ButtonGroup>
+      <Button>First</Button>
+      <Button>Second</Button>
+      <Button>Third</Button>
+      <Button>Last</Button>
+    </ButtonGroup>
+  )
+}
+
+export default Example

--- a/lib/src/components/ButtonGroup/docs/examples/overview.tsx
+++ b/lib/src/components/ButtonGroup/docs/examples/overview.tsx
@@ -1,5 +1,5 @@
-import { ButtonGroup } from '../..'
-import { Button } from '../../../Button'
+import { Button } from '@components/Button'
+import { ButtonGroup } from '@components/ButtonGroup'
 
 const Example = () => {
   return (

--- a/lib/src/components/ButtonGroup/docs/index.mdx
+++ b/lib/src/components/ButtonGroup/docs/index.mdx
@@ -1,0 +1,12 @@
+---
+category: actions
+description: The Button Group component arranges multiple buttons in a horizontal or vertical stack, allowing users to group related actions together. It provides a cohesive and organized way to present multiple buttons, ensuring consistent spacing and alignment.
+packageName: button-group
+title: ButtonGroup
+---
+
+### Overload
+
+`ButtonGroup` overloads the child components properties.
+
+<div data-playground="overload.tsx" data-component="ButtonGroup"></div>

--- a/lib/src/components/ButtonGroup/docs/properties.json
+++ b/lib/src/components/ButtonGroup/docs/properties.json
@@ -1,0 +1,102 @@
+{
+  "ButtonGroup": {
+    "props": {
+      "disabled": {
+        "defaultValue": null,
+        "description": "Disable all your buttons components",
+        "name": "disabled",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/ButtonGroup/index.tsx",
+          "name": "ButtonGroupOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/ButtonGroup/index.tsx",
+            "name": "ButtonGroupOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "size": {
+        "defaultValue": null,
+        "description": "",
+        "name": "size",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/ButtonGroup/index.tsx",
+          "name": "ButtonGroupOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/ButtonGroup/index.tsx",
+            "name": "ButtonGroupOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "Size",
+          "value": [
+            {
+              "value": "\"xs\""
+            },
+            {
+              "value": "\"sm\""
+            },
+            {
+              "value": "\"md\""
+            },
+            {
+              "value": "\"lg\""
+            }
+          ]
+        }
+      },
+      "variant": {
+        "defaultValue": null,
+        "description": "",
+        "name": "variant",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/ButtonGroup/index.tsx",
+          "name": "ButtonGroupOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/ButtonGroup/index.tsx",
+            "name": "ButtonGroupOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "Variant",
+          "value": [
+            {
+              "value": "\"ghost\""
+            },
+            {
+              "value": "\"primary\""
+            },
+            {
+              "value": "\"secondary\""
+            },
+            {
+              "value": "\"tertiary\""
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/lib/src/components/ButtonGroup/index.test.tsx
+++ b/lib/src/components/ButtonGroup/index.test.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@/components/Button'
+
+import { render } from '../../../tests'
+
+import { ButtonGroup } from '.'
+
+describe('<ButtonGroup>', () => {
+  it('should render correctly', () => {
+    const { getByTestId } = render(
+      <ButtonGroup data-testid="group">
+        <Button>One</Button>
+        {null}
+        <Button>Two</Button>
+        {false}
+        <Button>Tree</Button>
+        {undefined}
+      </ButtonGroup>
+    )
+    const group = getByTestId('group')
+
+    expect(group).toHaveTextContent('OneTwoTree')
+  })
+})

--- a/lib/src/components/ButtonGroup/index.tsx
+++ b/lib/src/components/ButtonGroup/index.tsx
@@ -1,0 +1,36 @@
+import React, { Children, cloneElement, forwardRef } from 'react'
+
+import { classNames } from '@/utils'
+
+import type { ButtonProps } from '../Button/types'
+
+import buttonGroupStyles from './button-group.module.scss'
+import type { ButtonGroupProps, ChildrenProps } from './types'
+
+const cx = classNames(buttonGroupStyles)
+
+export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
+  (
+    { children, className = '', disabled = false, size = 'md', variant = 'primary', ...rest },
+    ref
+  ) => {
+    function setGlobalProps(children: ChildrenProps) {
+      return Children.toArray(children)
+        .filter(Boolean)
+        .map((child: React.ReactElement<ButtonProps<'button'>>) =>
+          cloneElement(child, {
+            ...child.props,
+            disabled: disabled || child.props.disabled,
+            size: size || child.props.size,
+            variant: variant || child.props.variant,
+          })
+        )
+    }
+
+    return (
+      <div {...rest} className={cx('root', className)} ref={ref}>
+        {setGlobalProps(children)}
+      </div>
+    )
+  }
+)

--- a/lib/src/components/ButtonGroup/index.tsx
+++ b/lib/src/components/ButtonGroup/index.tsx
@@ -1,6 +1,6 @@
-import type { ButtonProps } from '@components/Button/types'
 import React, { Children, cloneElement, forwardRef } from 'react'
 
+import type { ButtonProps } from '@/components/Button/types'
 import { classNames } from '@/utils'
 
 import buttonGroupStyles from './button-group.module.scss'

--- a/lib/src/components/ButtonGroup/index.tsx
+++ b/lib/src/components/ButtonGroup/index.tsx
@@ -1,8 +1,7 @@
+import type { ButtonProps } from '@components/Button/types'
 import React, { Children, cloneElement, forwardRef } from 'react'
 
 import { classNames } from '@/utils'
-
-import type { ButtonProps } from '../Button/types'
 
 import buttonGroupStyles from './button-group.module.scss'
 import type { ButtonGroupProps, ChildrenProps } from './types'

--- a/lib/src/components/ButtonGroup/index.tsx
+++ b/lib/src/components/ButtonGroup/index.tsx
@@ -1,35 +1,28 @@
-import React, { Children, cloneElement, forwardRef } from 'react'
+import { createContext, forwardRef, useContext, useMemo } from 'react'
 
-import type { ButtonProps } from '@/components/Button/types'
 import { classNames } from '@/utils'
 
 import buttonGroupStyles from './button-group.module.scss'
-import type { ButtonGroupProps, ChildrenProps } from './types'
+import type { ButtonGroupProps, ButtonGroupState } from './types'
 
 const cx = classNames(buttonGroupStyles)
 
+export const ButtonGroupContext = createContext<ButtonGroupState>({} as ButtonGroupState)
+
+export function useButtonGroup() {
+  return useContext(ButtonGroupContext)
+}
+
 export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
-  (
-    { children, className = '', disabled = false, size = 'md', variant = 'primary', ...rest },
-    ref
-  ) => {
-    function setGlobalProps(children: ChildrenProps) {
-      return Children.toArray(children)
-        .filter(Boolean)
-        .map((child: React.ReactElement<ButtonProps<'button'>>) =>
-          cloneElement(child, {
-            ...child.props,
-            disabled: disabled || child.props.disabled,
-            size: size || child.props.size,
-            variant: variant || child.props.variant,
-          })
-        )
-    }
+  ({ children, className, disabled = false, size = 'md', variant = 'primary', ...rest }, ref) => {
+    const state = useMemo(() => ({ disabled, size, variant }), [disabled, size, variant])
 
     return (
-      <div {...rest} className={cx('root', className)} ref={ref}>
-        {setGlobalProps(children)}
-      </div>
+      <ButtonGroupContext.Provider value={state}>
+        <div {...rest} className={cx('root', className)} ref={ref}>
+          {children}
+        </div>
+      </ButtonGroupContext.Provider>
     )
   }
 )

--- a/lib/src/components/ButtonGroup/types.ts
+++ b/lib/src/components/ButtonGroup/types.ts
@@ -1,15 +1,10 @@
-import type { PolymorphicProps } from '../../theme/types'
-import type { Button } from '../Button'
-import type { ButtonProps } from '../Button/types'
+import type { ButtonSize, ButtonVariant } from '@/components/Button/types'
+import type { PolymorphicProps } from '@/theme/types'
 
-export type ButtonGroupProps<T extends React.ElementType = 'div'> = PolymorphicProps<T> &
-  React.HTMLAttributes<HTMLDivElement> & {
-    children: ChildrenProps
-    className?: string
-    disabled?: boolean
-    size?: ButtonProps<'button'>['size']
-    variant?: ButtonProps<'button'>['variant']
-  }
+export type ButtonGroupProps<T extends React.ElementType = 'div'> = PolymorphicProps<T> & {
+  disabled?: boolean
+  size?: ButtonSize
+  variant?: ButtonVariant
+}
 
-export type ChildrenProps = ChildType | ChildType[]
-type ChildType = boolean | null | React.ReactElement<typeof Button> | undefined
+export type ButtonGroupState = Pick<ButtonGroupProps, 'disabled' | 'size' | 'variant'>

--- a/lib/src/components/ButtonGroup/types.ts
+++ b/lib/src/components/ButtonGroup/types.ts
@@ -1,0 +1,15 @@
+import type { PolymorphicProps } from '../../theme/types'
+import type { Button } from '../Button'
+import type { ButtonProps } from '../Button/types'
+
+export type ButtonGroupProps<T extends React.ElementType = 'div'> = PolymorphicProps<T> &
+  React.HTMLAttributes<HTMLDivElement> & {
+    children: ChildrenProps
+    className?: string
+    disabled?: boolean
+    size?: ButtonProps<'button'>['size']
+    variant?: ButtonProps<'button'>['variant']
+  }
+
+export type ChildrenProps = ChildType | ChildType[]
+type ChildType = boolean | null | React.ReactElement<typeof Button> | undefined

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -17,6 +17,8 @@ export default {
   "/Button/docs/examples/sizes.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/sizes.tsx").then(mod => mod), { ssr: false }),
   "/Button/docs/examples/tailwind-class-overrides.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/tailwind-class-overrides.tsx").then(mod => mod), { ssr: false }),
   "/Button/docs/examples/variants.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/variants.tsx").then(mod => mod), { ssr: false }),
+  "/ButtonGroup/docs/examples/overload.tsx": dynamic(() => import("../../lib/src/components/ButtonGroup/docs/examples/overload.tsx").then(mod => mod), { ssr: false }),
+  "/ButtonGroup/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/ButtonGroup/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/VariantIcon/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/VariantIcon/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/VariantIcon/docs/examples/sizes.tsx": dynamic(() => import("../../lib/src/components/VariantIcon/docs/examples/sizes.tsx").then(mod => mod), { ssr: false })
 };


### PR DESCRIPTION
## DESCRIPTION

This pull request introduces a new `ButtonGroup` component, complete with styling, documentation, type definitions, and example usage. It also makes minor improvements to the existing `Button` component's styles to support better integration with `ButtonGroup`. The update ensures that grouped buttons are visually cohesive and that shared props like `size`, `variant`, and `disabled` are consistently applied.

**ButtonGroup Component Addition:**

* Added the new `ButtonGroup` component in `index.tsx`, which wraps multiple `Button` components, propagates shared props (`size`, `variant`, `disabled`), and applies group-specific styles.
* Introduced SCSS module `button-group.module.scss` to handle layout, spacing, and border-radius adjustments for grouped buttons.
* Defined types for `ButtonGroupProps` and children in `types.ts` for type safety and prop validation.

**Button Component Style Enhancements:**

* Updated `button.module.scss` to support a configurable `line-height` via CSS variables, with appropriate values for each button size, improving alignment within button groups. [[1]](diffhunk://#diff-ec6f34fab33c004f73ff41ee152f2a8d61fad915d738fbfe604318ff9d6ebde6R25) [[2]](diffhunk://#diff-ec6f34fab33c004f73ff41ee152f2a8d61fad915d738fbfe604318ff9d6ebde6R136) [[3]](diffhunk://#diff-ec6f34fab33c004f73ff41ee152f2a8d61fad915d738fbfe604318ff9d6ebde6R146) [[4]](diffhunk://#diff-ec6f34fab33c004f73ff41ee152f2a8d61fad915d738fbfe604318ff9d6ebde6R156) [[5]](diffhunk://#diff-ec6f34fab33c004f73ff41ee152f2a8d61fad915d738fbfe604318ff9d6ebde6R166)
