### PR TITLE
chore: update aliases config

### DIFF
--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -9,7 +9,7 @@
       "@old/fonts/*": ["./src/old/components/IconsFont/fonts/*"],
       "@old/theme": ["./src/old/theme"],
       "@old/*": ["./src/old/components/*"],
-      "@*": ["./src/*"]
+      "@/*": ["./src/*"]
     },
     "plugins": [{ "name": "typescript-plugin-css-modules" }],
     "types": ["vitest/globals", "@testing-library/jest-dom"]

--- a/lib/vite.config.mjs
+++ b/lib/vite.config.mjs
@@ -73,14 +73,13 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@/utils': path.resolve(__dirname, './src/utils'),
       '@old/fonts': path.resolve(__dirname, './src/old/components/IconsFont/fonts'),
       '@old/theme': path.resolve(__dirname, './src/old/theme'),
       '@old/utils': path.resolve(__dirname, './src/old/utils'),
       // eslint-disable-next-line perfectionist/sort-objects
       '@old': path.resolve(__dirname, './src/old/components'),
       // eslint-disable-next-line perfectionist/sort-objects
-      '@*': path.resolve(__dirname, './src'),
+      '@': path.resolve(__dirname, './src'),
     },
   },
   test: {


### PR DESCRIPTION
## DESCRIPTION

TLDR:
`@*` doesn't work 😎 

**Configuration improvements:**

* Updated the `@` path alias in `tsconfig.json` from `"@*": ["./src/*"]` to `"@/*": ["./src/*"]` for clearer and more accurate path mapping.
* Changed the Vite alias from `'@*': path.resolve(__dirname, './src')` to `'@': path.resolve(__dirname, './src')`, and removed the redundant `'@/utils'` alias, simplifying and standardizing how imports from `src` are handled.
