### PR TITLE
fix: use inline-flex on button by default

### DIFF
--- a/lib/src/components/Button/button.module.scss
+++ b/lib/src/components/Button/button.module.scss
@@ -1,8 +1,8 @@
 .root {
   position: relative;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   border-style: solid;
 
@@ -49,7 +49,7 @@
   }
 
   &:has(:global(i.wui-icon-font)),
-  &:has(:global(svg.wui-icon)) {
+  &:has(svg) {
     /* when button has icon(s) we reduce horizontal padding */
     padding-inline: var(--paddingInlineHasIcon);
   }
@@ -57,8 +57,7 @@
   /* CHILDREN */
 
   :global(i.wui-icon-font),
-  :global(svg.wui-icon) {
-    display: inline-block;
+  svg {
     font-weight: initial;
 
     &:only-child {


### PR DESCRIPTION
I initially wanted to handle overflow ellipsis for direct text inside button but it conflicts with the flex based buttons.
So if we want to handle ellipsis on a button, we should use the (yet to come) text component to do so. 