### PR TITLE
fix: export properties crash

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,4 @@
+import eslint from '@eslint/js'
 import perfectionist from 'eslint-plugin-perfectionist'
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
 import react from 'eslint-plugin-react'
@@ -5,8 +6,6 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import { globalIgnores } from 'eslint/config'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
-
-import eslint from '@eslint/js'
 
 export default tseslint.config(
   eslint.configs.recommended,
@@ -36,6 +35,7 @@ export default tseslint.config(
         },
       ],
       '@typescript-eslint/no-unused-vars': 'error',
+      '@typescript-eslint/triple-slash-reference': 'off',
       'no-console': 'error',
       'no-unused-vars': 'off',
       'perfectionist/sort-imports': [

--- a/lib/src/components/Button/docs/properties.json
+++ b/lib/src/components/Button/docs/properties.json
@@ -1,17 +1,19 @@
 {
   "Button": {
     "props": {
-      "disabled": {
-        "defaultValue": null,
+      "isLoading": {
+        "defaultValue": {
+          "value": false
+        },
         "description": "",
-        "name": "disabled",
+        "name": "isLoading",
         "parent": {
-          "fileName": "welcome-ui/lib/src/components/Button/index.tsx",
+          "fileName": "welcome-ui/lib/src/components/Button/types.ts",
           "name": "ButtonOptions"
         },
         "declarations": [
           {
-            "fileName": "welcome-ui/lib/src/components/Button/index.tsx",
+            "fileName": "welcome-ui/lib/src/components/Button/types.ts",
             "name": "ButtonOptions"
           }
         ],
@@ -30,26 +32,31 @@
         }
       },
       "shape": {
-        "defaultValue": null,
+        "defaultValue": {
+          "value": "default"
+        },
         "description": "",
         "name": "shape",
         "parent": {
-          "fileName": "welcome-ui/lib/src/components/Button/index.tsx",
+          "fileName": "welcome-ui/lib/src/components/Button/types.ts",
           "name": "ButtonOptions"
         },
         "declarations": [
           {
-            "fileName": "welcome-ui/lib/src/components/Button/index.tsx",
+            "fileName": "welcome-ui/lib/src/components/Button/types.ts",
             "name": "ButtonOptions"
           }
         ],
         "required": false,
         "type": {
           "name": "enum",
-          "raw": "\"circle\" | \"square\"",
+          "raw": "Shape",
           "value": [
             {
               "value": "\"circle\""
+            },
+            {
+              "value": "\"default\""
             },
             {
               "value": "\"square\""
@@ -64,12 +71,12 @@
         "description": "",
         "name": "size",
         "parent": {
-          "fileName": "welcome-ui/lib/src/components/Button/index.tsx",
+          "fileName": "welcome-ui/lib/src/components/Button/types.ts",
           "name": "ButtonOptions"
         },
         "declarations": [
           {
-            "fileName": "welcome-ui/lib/src/components/Button/index.tsx",
+            "fileName": "welcome-ui/lib/src/components/Button/types.ts",
             "name": "ButtonOptions"
           }
         ],
@@ -79,16 +86,16 @@
           "raw": "Size",
           "value": [
             {
-              "value": "\"xs\""
-            },
-            {
-              "value": "\"sm\""
+              "value": "\"lg\""
             },
             {
               "value": "\"md\""
             },
             {
-              "value": "\"lg\""
+              "value": "\"sm\""
+            },
+            {
+              "value": "\"xs\""
             }
           ]
         }
@@ -100,12 +107,12 @@
         "description": "",
         "name": "variant",
         "parent": {
-          "fileName": "welcome-ui/lib/src/components/Button/index.tsx",
+          "fileName": "welcome-ui/lib/src/components/Button/types.ts",
           "name": "ButtonOptions"
         },
         "declarations": [
           {
-            "fileName": "welcome-ui/lib/src/components/Button/index.tsx",
+            "fileName": "welcome-ui/lib/src/components/Button/types.ts",
             "name": "ButtonOptions"
           }
         ],
@@ -114,6 +121,15 @@
           "name": "enum",
           "raw": "Variant",
           "value": [
+            {
+              "value": "\"ghost\""
+            },
+            {
+              "value": "\"ghost-ai\""
+            },
+            {
+              "value": "\"ghost-danger\""
+            },
             {
               "value": "\"primary\""
             },
@@ -134,20 +150,10 @@
             },
             {
               "value": "\"tertiary-danger\""
-            },
-            {
-              "value": "\"ghost\""
-            },
-            {
-              "value": "\"ghost-ai\""
-            },
-            {
-              "value": "\"ghost-danger\""
             }
           ]
         }
       }
-    },
-    "tag": "button"
+    }
   }
 }

--- a/lib/src/components/Button/types.ts
+++ b/lib/src/components/Button/types.ts
@@ -5,20 +5,24 @@ import type { PolymorphicProps } from '../../theme/types'
 
 export type ButtonProps<T extends React.ElementType> = AriakitButtonProps &
   ButtonHTMLAttributes<HTMLButtonElement> &
+  ButtonOptions &
   PolymorphicProps<T> & {
     children?: ReactNode
     className?: string
-    isLoading?: boolean
     ref?: React.Ref<HTMLButtonElement>
-    shape?: Shapes
-    size?: Sizes
     style?: CSSProperties
-    variant?: Variants
   }
-type Shapes = 'circle' | 'default' | 'square'
-type Sizes = 'lg' | 'md' | 'sm' | 'xs'
 
-type Variants =
+interface ButtonOptions {
+  children?: ReactNode
+  isLoading?: boolean
+  shape?: Shape
+  size?: Size
+  variant?: Variant
+}
+type Shape = 'circle' | 'default' | 'square'
+type Size = 'lg' | 'md' | 'sm' | 'xs'
+type Variant =
   | 'ghost'
   | 'ghost-ai'
   | 'ghost-danger'

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release:alpha": "cd lib && yarn release-it --preRelease=alpha",
     "release": "cd lib && yarn release-it",
     "start": "cd website && yarn dev -p 3020",
-    "export-properties": "node ./scripts/generate-types-doc.js",
+    "export-properties": "node ./scripts/generate-types-doc.mjs",
     "test": "cd lib && yarn test"
   },
   "private": true,
@@ -83,7 +83,7 @@
     "postcss-styled-syntax": "^0.7.1",
     "prettier": "3.5.3",
     "react": "^18.3.1",
-    "react-docgen-typescript": "^2.2.2",
+    "react-docgen-typescript": "^2.4.0",
     "react-dom": "^18.3.1",
     "react-router-dom": "7.5.2",
     "sass-embedded": "^1.90.0",

--- a/scripts/generate-types-doc.mjs
+++ b/scripts/generate-types-doc.mjs
@@ -1,26 +1,20 @@
 /* eslint-disable no-console */
 
-const { accessSync, existsSync, readdirSync, writeFileSync } = require('fs')
-const { join, resolve } = require('path')
+import { accessSync, existsSync, readdirSync, writeFileSync } from 'fs'
+import { dirname, join, resolve } from 'path'
 
-const { withCustomConfig } = require('react-docgen-typescript')
+import { withCustomConfig } from 'react-docgen-typescript'
 
 const tsConfigPath = join(process.cwd(), 'lib', 'tsconfig.json')
-
-const shouldDisplayPropsFiles = [
-  'lib/src/dist/types/utils/field-styles.d.ts',
-  'lib/src/dist/types/old/Button/index.d.ts',
-  'lib/src/dist/types/old/InputText/index.d.ts',
-  'lib/node_modules/ariakit/ts/Tab/TabStore.d.ts',
-]
 
 // Get only ComponentOptions declarations for prevent all WuiProps
 const propFilter = prop => {
   if (prop.declarations?.length > 0) {
     const isOptionDeclaration = prop.declarations.find(declaration => {
-      if (declaration.name.includes('Options')) return true
-
-      return shouldDisplayPropsFiles.includes(declaration.fileName)
+      if (declaration.name.includes('Options') && !declaration.fileName.includes('node_modules')) {
+        return true
+      }
+      return false
     })
 
     return Boolean(isOptionDeclaration)
@@ -98,7 +92,7 @@ const arePropsEmpty = obj => {
 }
 
 async function generateTypesDoc() {
-  const parentDirectory = resolve(__dirname, '../')
+  const parentDirectory = resolve(dirname('../'))
   const componentsDir = resolve(parentDirectory, 'lib/src/components')
 
   // Read all directories in the components folder with a docs folder

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "paths": {
       "~/*": ["./*"],
-      "@old/utils": ["../lib/src/utils"],
       "@old/utils": ["../lib/src/old/utils"],
       "@old/fonts/*": ["../lib/src/old/components/IconsFont/fonts/*"],
       "@old/theme": ["../lib/src/old/theme"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8580,10 +8580,10 @@ react-datepicker@*, react-datepicker@^8.4.0:
     clsx "^2.1.1"
     date-fns "^4.1.0"
 
-react-docgen-typescript@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz"
-  integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
+react-docgen-typescript@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz#033428b4a6a639d050ac8baf2a5195c596521713"
+  integrity sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==
 
 react-dom@^18.3.1:
   version "18.3.1"


### PR DESCRIPTION
This pull request includes several updates across the codebase, primarily focusing on improvements to the Button component's type definitions and documentation, as well as some tooling and configuration updates. The most significant changes are the refactoring of Button prop types, updates to the properties documentation, and modernization of scripts and dependencies.

### Button Component Type and Documentation Refactor

* Refactored the Button component prop types by introducing a `ButtonOptions` interface, consolidating `isLoading`, `shape`, `size`, and `variant` props, and updating their types to enums (`Shape`, `Size`, `Variant`). This improves type safety and maintainability. (`lib/src/components/Button/types.ts`)
* Updated the Button properties documentation to reflect the new prop structure, default values, and enum options. Added new variants (`ghost`, `ghost-ai`, `ghost-danger`) and reordered the enum values for `size`. (`lib/src/components/Button/docs/properties.json`) [[1]](diffhunk://#diff-6e00d25b6985171b19e1124d3c7e4f05f7fb68a4c0c929f58510ec488092842aL4-R16) [[2]](diffhunk://#diff-6e00d25b6985171b19e1124d3c7e4f05f7fb68a4c0c929f58510ec488092842aL33-R60) [[3]](diffhunk://#diff-6e00d25b6985171b19e1124d3c7e4f05f7fb68a4c0c929f58510ec488092842aL82-R98) [[4]](diffhunk://#diff-6e00d25b6985171b19e1124d3c7e4f05f7fb68a4c0c929f58510ec488092842aR124-R132)

### Tooling and Script Updates

* Migrated the script for generating type documentation from CommonJS to ES module format (`.mjs`), updated imports to use `import` syntax, and improved the prop filtering logic to only include relevant option declarations. (`scripts/generate-types-doc.mjs`)
* Updated the npm script to use the new `.mjs` file for exporting properties. (`package.json`)
* Upgraded `react-docgen-typescript` dependency to version 2.4.0 for better compatibility and features. (`package.json`)

### Linting and Configuration

* Improved ESLint configuration by switching to the recommended config from `@eslint/js`, disabling the `@typescript-eslint/triple-slash-reference` rule, and cleaning up imports. (`eslint.config.mjs`) [[1]](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R1) [[2]](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L9-L10) [[3]](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R38)
* Fixed path mapping in the website TypeScript config to point to the correct legacy utils directory. (`website/tsconfig.json`)