### PR TITLE
chore: migrate Shape component to be tailwind-compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 website/out
 website/.next
+website/next-env.d.ts
 node_modules/
 .DS_Store
 .size-snapshot.json

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,4 @@
+import eslint from '@eslint/js'
 import perfectionist from 'eslint-plugin-perfectionist'
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
 import react from 'eslint-plugin-react'
@@ -6,15 +7,13 @@ import { globalIgnores } from 'eslint/config'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
-import eslint from '@eslint/js'
-
 export default tseslint.config(
   eslint.configs.recommended,
   tseslint.configs.recommended,
   eslintPluginPrettierRecommended,
   reactHooks.configs['recommended-latest'],
   perfectionist.configs['recommended-natural'],
-  globalIgnores(['lib/dist', 'website/.next', 'website/out']),
+  globalIgnores(['lib/dist', 'website/.next', 'website/out', 'website/next-env.d.ts']),
   {
     languageOptions: {
       ecmaVersion: 'latest',

--- a/lib/src/components/Shape/docs/examples/border-radius.tsx
+++ b/lib/src/components/Shape/docs/examples/border-radius.tsx
@@ -1,0 +1,11 @@
+import { Shape } from '@/components/Shape'
+
+const Example = () => {
+  return (
+    <Shape borderRadius="lg" h="150px" w="150px">
+      <img src="https://images.unsplash.com/photo-1517849845537-4d257902454a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=500&q=80" />
+    </Shape>
+  )
+}
+
+export default Example

--- a/lib/src/components/Shape/docs/examples/overview.tsx
+++ b/lib/src/components/Shape/docs/examples/overview.tsx
@@ -1,0 +1,11 @@
+import { Shape } from '@/components/Shape'
+
+const Example = () => {
+  return (
+    <Shape h="150px" w="150px">
+      <img src="https://images.unsplash.com/photo-1517849845537-4d257902454a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=500&q=80" />
+    </Shape>
+  )
+}
+
+export default Example

--- a/lib/src/components/Shape/docs/examples/shapes.tsx
+++ b/lib/src/components/Shape/docs/examples/shapes.tsx
@@ -1,0 +1,19 @@
+import { Shape } from '@/components/Shape'
+
+const Example = () => {
+  return (
+    <>
+      <Shape h="150px" shape="square" w="150px">
+        <img src="https://images.unsplash.com/photo-1517849845537-4d257902454a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=500&q=80" />
+      </Shape>
+      <Shape h="150px" shape="circle" w="150px">
+        <img src="https://images.unsplash.com/photo-1517849845537-4d257902454a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=500&q=80" />
+      </Shape>
+      <Shape h="50px" shape="circle" w="1px">
+        <img src="https://images.unsplash.com/photo-1517849845537-4d257902454a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=500&q=80" />
+      </Shape>
+    </>
+  )
+}
+
+export default Example

--- a/lib/src/components/Shape/docs/index.mdx
+++ b/lib/src/components/Shape/docs/index.mdx
@@ -1,0 +1,20 @@
+---
+category: layout
+description: The Shape component is a versatile UI element used to create and display geometric shapes such as circles, squares, rectangles, and more with an overflow on child elements.
+packageName: shape
+title: Shape
+---
+
+Add `w` and `h` to set size of shape.
+
+### Border radius
+
+Add `borderRadius` from theme or what you want.
+
+<div data-playground="border-radius.tsx" data-component="Shape"></div>
+
+### Shape
+
+Set `shape` to `square` or `circle`, also, using `shape` with unequal sizes will match the biggest value between width / height.
+
+<div data-playground="shapes.tsx" data-component="Shape"></div>

--- a/lib/src/components/Shape/docs/properties.json
+++ b/lib/src/components/Shape/docs/properties.json
@@ -1,0 +1,112 @@
+{
+  "Shape": {
+    "props": {
+      "borderRadius": {
+        "defaultValue": null,
+        "description": "",
+        "name": "borderRadius",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Shape/index.tsx",
+          "name": "ShapeOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Shape/index.tsx",
+            "name": "ShapeOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "className": {
+        "defaultValue": null,
+        "description": "",
+        "name": "className",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Shape/index.tsx",
+          "name": "ShapeOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Shape/index.tsx",
+            "name": "ShapeOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "h": {
+        "defaultValue": null,
+        "description": "",
+        "name": "h",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Shape/index.tsx",
+          "name": "ShapeOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Shape/index.tsx",
+            "name": "ShapeOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "shape": {
+        "defaultValue": {
+          "value": "square"
+        },
+        "description": "",
+        "name": "shape",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Shape/index.tsx",
+          "name": "ShapeOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Shape/index.tsx",
+            "name": "ShapeOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "\"circle\" | \"square\"",
+          "value": [
+            {
+              "value": "\"circle\""
+            },
+            {
+              "value": "\"square\""
+            }
+          ]
+        }
+      },
+      "w": {
+        "defaultValue": null,
+        "description": "",
+        "name": "w",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Shape/index.tsx",
+          "name": "ShapeOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Shape/index.tsx",
+            "name": "ShapeOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      }
+    }
+  }
+}

--- a/lib/src/components/Shape/index.tsx
+++ b/lib/src/components/Shape/index.tsx
@@ -23,17 +23,15 @@ export const Shape = forwardRef<'div', ShapeProps>(
 
     let style = {}
 
-    if (borderRadius && shape !== 'circle') {
-      style = { ...style, borderRadius: `var(--radius-${borderRadius})` }
-    }
-
     if (maxWidthHeight) {
       style = { ...style, height: maxWidthHeight, width: maxWidthHeight }
     }
 
+    const radius = borderRadius && shape !== 'circle'
+
     return (
       <div
-        className={cx('root', `shape-${shape}`, className)}
+        className={cx('root', `shape-${shape}`, radius && `radius-${borderRadius}`, className)}
         data-testid={dataTestId}
         ref={ref}
         style={style}

--- a/lib/src/components/Shape/index.tsx
+++ b/lib/src/components/Shape/index.tsx
@@ -1,0 +1,47 @@
+import { classNames } from '@/utils'
+import type { CreateWuiProps } from '@old/System'
+import { forwardRef } from '@old/System'
+
+import styles from './shape.module.scss'
+import { getMax } from './utils'
+
+const cx = classNames(styles)
+
+export interface ShapeOptions {
+  borderRadius?: string
+  className?: string
+  h?: string
+  shape?: 'circle' | 'square'
+  w?: string
+}
+
+export type ShapeProps = CreateWuiProps<'div', ShapeOptions>
+
+export const Shape = forwardRef<'div', ShapeProps>(
+  ({ borderRadius, children, className, dataTestId, h, shape = 'square', w }, ref) => {
+    const maxWidthHeight = (w || h) && getMax(w, h)
+
+    let style = {}
+
+    if (borderRadius && shape !== 'circle') {
+      style = { ...style, borderRadius: `var(--radius-${borderRadius})` }
+    }
+
+    if (maxWidthHeight) {
+      style = { ...style, height: maxWidthHeight, width: maxWidthHeight }
+    }
+
+    return (
+      <div
+        className={cx('root', `shape-${shape}`, className)}
+        data-testid={dataTestId}
+        ref={ref}
+        style={style}
+      >
+        {children}
+      </div>
+    )
+  }
+)
+
+Shape.displayName = 'Shape'

--- a/lib/src/components/Shape/shape.module.scss
+++ b/lib/src/components/Shape/shape.module.scss
@@ -14,11 +14,35 @@
     }
   }
 
-  .shape-circle {
-    border-radius: 50%;
+  .shape {
+    &-circle {
+      border-radius: var(--radius-circle);
+    }
+
+    &-square {
+      border-radius: 0;
+    }
   }
 
-  .shape-square {
-    border-radius: 0;
+  .radius {
+    &-sm {
+      border-radius: var(--radius-sm);
+    }
+
+    &-md {
+      border-radius: var(--radius-md);
+    }
+
+    &-lg {
+      border-radius: var(--radius-lg);
+    }
+
+    &-xl {
+      border-radius: var(--radius-xl);
+    }
+
+    &-2xl {
+      border-radius: var(--radius-2xl);
+    }
   }
 }

--- a/lib/src/components/Shape/shape.module.scss
+++ b/lib/src/components/Shape/shape.module.scss
@@ -1,0 +1,24 @@
+@layer components {
+  .root {
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    img {
+      object-fit: cover;
+      overflow: hidden;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  .shape-circle {
+    border-radius: 50%;
+  }
+
+  .shape-square {
+    border-radius: 0;
+  }
+}

--- a/lib/src/components/Shape/tests/index.test.tsx
+++ b/lib/src/components/Shape/tests/index.test.tsx
@@ -1,0 +1,55 @@
+import { screen } from '@testing-library/react'
+
+import { render } from '../../../../tests/index'
+import { Shape } from '../index'
+
+const content = 'Jungle'
+
+describe('<Shape>', () => {
+  it('should render correctly', () => {
+    render(
+      <Shape h="100px" w="100px">
+        {content}
+      </Shape>
+    )
+
+    expect(screen.getByText(content)).toBeVisible()
+  })
+
+  it('should render correctly with borderRadius', () => {
+    render(
+      <Shape borderRadius="lg" dataTestId="shape" h="100px" w="100px">
+        {content}
+      </Shape>
+    )
+
+    const shape = screen.getByTestId('shape')
+
+    expect(shape).toHaveStyle({ 'border-radius': 'var(--radius-lg)' })
+  })
+
+  it('using shape with unequal width / height props should use biggest value', () => {
+    render(
+      <Shape dataTestId="shape" h="1px" w="100px">
+        {content}
+      </Shape>
+    )
+
+    const shape = screen.getByTestId('shape')
+
+    expect(shape).toHaveStyle({ width: '100px' })
+    expect(shape).toHaveStyle({ height: '100px' })
+  })
+
+  it('should render a circle shape', () => {
+    render(
+      <Shape dataTestId="shape" h="100px" shape="circle" w="100px">
+        {content}
+      </Shape>
+    )
+
+    const shape = screen.getByTestId('shape')
+
+    expect(shape.className).toMatch(/shape-circle/)
+  })
+})

--- a/lib/src/components/Shape/tests/utils.test.ts
+++ b/lib/src/components/Shape/tests/utils.test.ts
@@ -1,0 +1,26 @@
+import { getMax } from '../utils'
+
+describe('getMax', () => {
+  it('returns the width if width >= height', () => {
+    expect(getMax('100px', '50')).toBe('100px')
+    expect(getMax('100', '100px')).toBe('100')
+  })
+
+  it('returns the height if height > width', () => {
+    expect(getMax('50', '100px')).toBe('100px')
+  })
+
+  it('parses string numbers and px units', () => {
+    expect(getMax('42px', '24')).toBe('42px')
+    expect(getMax('24', '42px')).toBe('42px')
+  })
+
+  it('uses width if height is not provided', () => {
+    expect(getMax('77px')).toBe('77px')
+  })
+
+  it('handles negative numbers', () => {
+    expect(getMax('-10px', '5rem')).toBe('5rem')
+    expect(getMax('5rem', '-10px')).toBe('5rem')
+  })
+})

--- a/lib/src/components/Shape/utils.ts
+++ b/lib/src/components/Shape/utils.ts
@@ -1,0 +1,8 @@
+export const getMax = (width: string, height: string = width): string => {
+  const widthValue = parseInt(width, 10)
+  const heightValue = parseInt(height, 10)
+
+  const diff = widthValue - heightValue
+
+  return diff >= 0 ? width : height
+}

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -3,6 +3,7 @@
 @import '../../lib/src/theme/theme.css';
 
 @import '../../lib/src/components/Button/button.module.scss';
+@import '../../lib/src/components/Shape/shape.module.scss';
 
 @source '../../lib/src/**/*.{ts,tsx}';
 

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /** WARNING
 This file is auto-generate with yarn watch command, do not change it directly!
 **/

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -3,18 +3,66 @@
 This file is auto-generate with yarn watch command, do not change it directly!
 **/
 
-import dynamic from "next/dynamic";
+import dynamic from 'next/dynamic'
 
 export default {
-  "/Button/docs/examples/ai.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/ai.tsx").then(mod => mod), { ssr: false }),
-  "/Button/docs/examples/danger.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/danger.tsx").then(mod => mod), { ssr: false }),
-  "/Button/docs/examples/disabled.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/disabled.tsx").then(mod => mod), { ssr: false }),
-  "/Button/docs/examples/icons.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/icons.tsx").then(mod => mod), { ssr: false }),
-  "/Button/docs/examples/is-loading.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/is-loading.tsx").then(mod => mod), { ssr: false }),
-  "/Button/docs/examples/link.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/link.tsx").then(mod => mod), { ssr: false }),
-  "/Button/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
-  "/Button/docs/examples/shapes.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/shapes.tsx").then(mod => mod), { ssr: false }),
-  "/Button/docs/examples/sizes.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/sizes.tsx").then(mod => mod), { ssr: false }),
-  "/Button/docs/examples/tailwind-class-overrides.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/tailwind-class-overrides.tsx").then(mod => mod), { ssr: false }),
-  "/Button/docs/examples/variants.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/variants.tsx").then(mod => mod), { ssr: false })
-};
+  '/Button/docs/examples/ai.tsx': dynamic(
+    () => import('../../lib/src/components/Button/docs/examples/ai.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Button/docs/examples/danger.tsx': dynamic(
+    () => import('../../lib/src/components/Button/docs/examples/danger.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Button/docs/examples/disabled.tsx': dynamic(
+    () => import('../../lib/src/components/Button/docs/examples/disabled.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Button/docs/examples/icons.tsx': dynamic(
+    () => import('../../lib/src/components/Button/docs/examples/icons.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Button/docs/examples/is-loading.tsx': dynamic(
+    () => import('../../lib/src/components/Button/docs/examples/is-loading.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Button/docs/examples/link.tsx': dynamic(
+    () => import('../../lib/src/components/Button/docs/examples/link.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Button/docs/examples/overview.tsx': dynamic(
+    () => import('../../lib/src/components/Button/docs/examples/overview.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Button/docs/examples/shapes.tsx': dynamic(
+    () => import('../../lib/src/components/Button/docs/examples/shapes.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Button/docs/examples/sizes.tsx': dynamic(
+    () => import('../../lib/src/components/Button/docs/examples/sizes.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Button/docs/examples/tailwind-class-overrides.tsx': dynamic(
+    () =>
+      import('../../lib/src/components/Button/docs/examples/tailwind-class-overrides.tsx').then(
+        mod => mod
+      ),
+    { ssr: false }
+  ),
+  '/Button/docs/examples/variants.tsx': dynamic(
+    () => import('../../lib/src/components/Button/docs/examples/variants.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Shape/docs/examples/border-radius.tsx': dynamic(
+    () => import('../../lib/src/components/Shape/docs/examples/border-radius.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Shape/docs/examples/overview.tsx': dynamic(
+    () => import('../../lib/src/components/Shape/docs/examples/overview.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+  '/Shape/docs/examples/shapes.tsx': dynamic(
+    () => import('../../lib/src/components/Shape/docs/examples/shapes.tsx').then(mod => mod),
+    { ssr: false }
+  ),
+}

--- a/website/loaders/generate-examples.js
+++ b/website/loaders/generate-examples.js
@@ -28,7 +28,7 @@ function generateWebsiteExamplesPages() {
     }
   }
 
-  const fileContent = `/* eslint-disable */\n/** WARNING\nThis file is auto-generate with yarn watch command, do not change it directly!\n**/\n\nimport dynamic from "next/dynamic";\n\nexport default {\n${examples
+  const fileContent = `/** WARNING\nThis file is auto-generate with yarn watch command, do not change it directly!\n**/\n\nimport dynamic from "next/dynamic";\n\nexport default {\n${examples
     .map(
       path =>
         `  "${path}": dynamic(() => import("../../lib/src/components${path}").then(mod => mod), { ssr: false })`


### PR DESCRIPTION
## DESCRIPTION

Migrate Shape component to be Tailwind-compatible

Notes:
- Uses inline styles so we can pass a height and width in px

## SCREENSHOTS / SCREEN RECORDINGS

<img width="861" height="818" alt="image" src="https://github.com/user-attachments/assets/74da0187-6672-465b-bb3c-aff3dd83ec2d" />

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [x] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [x] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
