### PR TITLE
chore: migrate input text to tailwind

### DIFF
--- a/lib/src/components/InputText/docs/examples/clearable.tsx
+++ b/lib/src/components/InputText/docs/examples/clearable.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react'
+
+import { AvatarIcon } from '@/components/Icon'
+import { InputText } from '@/components/InputText'
+
+const Example = () => {
+  const [value, setValue] = useState('Welcome')
+  return (
+    <InputText
+      icon={<AvatarIcon />}
+      iconPlacement="right"
+      isClearable
+      onChange={e => setValue(e.target.value)}
+      placeholder="Welcome"
+      value={value}
+    />
+  )
+}
+
+export default Example

--- a/lib/src/components/InputText/docs/examples/disabled.tsx
+++ b/lib/src/components/InputText/docs/examples/disabled.tsx
@@ -1,0 +1,7 @@
+import { InputText } from '@/components/InputText'
+
+const Example = () => {
+  return <InputText disabled placeholder="Welcome" />
+}
+
+export default Example

--- a/lib/src/components/InputText/docs/examples/icon.tsx
+++ b/lib/src/components/InputText/docs/examples/icon.tsx
@@ -1,0 +1,20 @@
+import { AvatarIcon } from '@/components/Icon'
+import { InputText } from '@/components/InputText'
+
+const Example = () => {
+  return (
+    <>
+      <InputText icon={<AvatarIcon />} placeholder="Welcome" />
+      <InputText icon={<AvatarIcon />} iconPlacement="right" placeholder="Welcome" />
+      <InputText
+        icon={<AvatarIcon />}
+        iconPlacement="right"
+        isClearable
+        placeholder="Welcome"
+        size="xs"
+      />
+    </>
+  )
+}
+
+export default Example

--- a/lib/src/components/InputText/docs/examples/overview.tsx
+++ b/lib/src/components/InputText/docs/examples/overview.tsx
@@ -1,0 +1,7 @@
+import { InputText } from '@/components/InputText'
+
+const Example = () => {
+  return <InputText name="firstName" placeholder="Welcome" />
+}
+
+export default Example

--- a/lib/src/components/InputText/docs/examples/sizes.tsx
+++ b/lib/src/components/InputText/docs/examples/sizes.tsx
@@ -1,0 +1,15 @@
+import { AvatarIcon } from '@/components/Icon'
+import { InputText } from '@/components/InputText'
+
+const Example = () => {
+  return (
+    <>
+      <InputText icon={<AvatarIcon />} placeholder="Welcome" size="xs" />
+      <InputText icon={<AvatarIcon />} placeholder="Welcome" size="sm" />
+      <InputText icon={<AvatarIcon />} placeholder="Welcome" />
+      <InputText icon={<AvatarIcon />} placeholder="Welcome" size="lg" />
+    </>
+  )
+}
+
+export default Example

--- a/lib/src/components/InputText/docs/examples/transparent.tsx
+++ b/lib/src/components/InputText/docs/examples/transparent.tsx
@@ -1,0 +1,8 @@
+import { AvatarIcon } from '@/components/Icon'
+import { InputText } from '@/components/InputText'
+
+const Example = () => {
+  return <InputText icon={<AvatarIcon />} placeholder="Welcome" transparent />
+}
+
+export default Example

--- a/lib/src/components/InputText/docs/examples/variants.tsx
+++ b/lib/src/components/InputText/docs/examples/variants.tsx
@@ -1,0 +1,13 @@
+import { InputText } from '@/components/InputText'
+
+const Example = () => {
+  return (
+    <>
+      <InputText placeholder="Welcome" variant="warning" />
+      <InputText placeholder="Welcome" variant="danger" />
+      <InputText placeholder="Welcome" variant="success" />
+    </>
+  )
+}
+
+export default Example

--- a/lib/src/components/InputText/docs/index.mdx
+++ b/lib/src/components/InputText/docs/index.mdx
@@ -1,0 +1,49 @@
+---
+category: forms
+description: The InputText component is a fundamental UI element that allows users to enter and edit text. It is commonly used in forms, search fields, and data entry interfaces. This component ensures efficient user input handling, offering features like placeholder text, validation, and various input types.
+packageName: input-text
+title: InputText
+---
+
+### Variants
+
+Use `warning`, `danger`, or `success` properties to add a variant status on your input text.
+
+<div data-playground="variants.tsx" data-component="InputText"></div>
+
+### Disabled
+
+Property `disabled` can be pass to the component or Field component
+
+<div data-playground="disabled.tsx" data-component="InputText"></div>
+
+### Sizes
+
+Use size propety with option:
+
+- `xs` (24px)
+- `sm` (32px)
+- `md` (40px - default)
+- `lg` (48px)
+
+<div data-playground="sizes.tsx" data-component="InputText"></div>
+
+### Icon
+
+Pass an `icon` through to decorate your `InputText`.
+
+Use `iconPlacement` to put on left (default) or right.
+
+<div data-playground="icon.tsx" data-component="InputText"></div>
+
+### Clearable
+
+Use the `isClearable` prop to add a cross button to remove the content (value) of the `TextInput`
+
+<div data-playground="clearable.tsx" data-component="InputText"></div>
+
+### Transparent
+
+Pass `transparent` to remove background-color and border-color
+
+<div data-playground="transparent.tsx" data-component="InputText"></div>

--- a/lib/src/components/InputText/docs/properties.json
+++ b/lib/src/components/InputText/docs/properties.json
@@ -1,0 +1,183 @@
+{
+  "InputText": {
+    "props": {
+      "icon": {
+        "defaultValue": null,
+        "description": "",
+        "name": "icon",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+          "name": "InputTextOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+            "name": "InputTextOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "Element"
+        }
+      },
+      "iconPlacement": {
+        "defaultValue": {
+          "value": "left"
+        },
+        "description": "",
+        "name": "iconPlacement",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+          "name": "InputTextOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+            "name": "InputTextOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "\"left\" | \"right\"",
+          "value": [
+            {
+              "value": "\"left\""
+            },
+            {
+              "value": "\"right\""
+            }
+          ]
+        }
+      },
+      "isClearable": {
+        "defaultValue": null,
+        "description": "",
+        "name": "isClearable",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+          "name": "InputTextOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+            "name": "InputTextOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "size": {
+        "defaultValue": {
+          "value": "md"
+        },
+        "description": "",
+        "name": "size",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+          "name": "InputTextOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+            "name": "InputTextOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "Size",
+          "value": [
+            {
+              "value": "\"lg\""
+            },
+            {
+              "value": "\"md\""
+            },
+            {
+              "value": "\"sm\""
+            },
+            {
+              "value": "\"xs\""
+            }
+          ]
+        }
+      },
+      "transparent": {
+        "defaultValue": null,
+        "description": "",
+        "name": "transparent",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+          "name": "InputTextOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+            "name": "InputTextOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "variant": {
+        "defaultValue": {
+          "value": "default"
+        },
+        "description": "",
+        "name": "variant",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+          "name": "InputTextOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/InputText/types.ts",
+            "name": "InputTextOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "Variant",
+          "value": [
+            {
+              "value": "\"danger\""
+            },
+            {
+              "value": "\"default\""
+            },
+            {
+              "value": "\"success\""
+            },
+            {
+              "value": "\"warning\""
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/lib/src/components/InputText/index.tsx
+++ b/lib/src/components/InputText/index.tsx
@@ -1,0 +1,80 @@
+import React, { forwardRef } from 'react'
+
+import { classNames } from '@/utils'
+// @WUI-214 - replace old CleanButton component when it will be updated
+import { ClearButton } from '@old/ClearButton'
+
+import inputTextStyles from './input-text.module.scss'
+import type { InputTextProps, Size } from './types'
+
+const cx = classNames(inputTextStyles)
+
+const FIELD_ICON_SIZE: { [key in Size]: string } = { lg: 'sm', md: 'sm', sm: 'sm', xs: 'xs' }
+
+export const InputText = forwardRef<HTMLInputElement, InputTextProps>(
+  (
+    {
+      className,
+      icon,
+      iconPlacement = 'left',
+      isClearable,
+      name,
+      onChange,
+      size = 'md',
+      transparent,
+      type = 'text',
+      value,
+      variant = 'default',
+      ...rest
+    },
+    ref
+  ) => {
+    const hasIcon = icon && iconPlacement
+    const hasRightIcon = hasIcon && iconPlacement === 'right'
+    const hasLeftIcon = hasIcon && iconPlacement === 'left'
+    const iconSize = FIELD_ICON_SIZE[size]
+
+    const handleReset = () => {
+      const event = {
+        preventDefault: () => null,
+        target: { name, value: '' },
+      } as React.ChangeEvent<HTMLInputElement>
+      if (onChange) onChange(event)
+    }
+
+    return (
+      <div className={cx('input-text-wrapper')}>
+        <input
+          {...rest}
+          className={cx(
+            'root',
+            `variant-${variant}`,
+            `size-${size}`,
+            transparent && 'transparent',
+            hasIcon && `placement-${iconPlacement}`,
+            className
+          )}
+          id={name}
+          name={name}
+          onChange={onChange}
+          ref={ref}
+          type={type}
+          value={value}
+        />
+
+        {hasLeftIcon ? (
+          <div className={cx('icon-wrapper', `icon-placement-left-${iconSize}`)}>
+            {React.cloneElement(icon, { ...icon.props, size: iconSize })}
+          </div>
+        ) : null}
+
+        {isClearable || hasRightIcon ? (
+          <div className={cx('icon-wrapper', `icon-placement-right-${iconSize}`)}>
+            {isClearable && value ? <ClearButton onClick={handleReset} /> : null}
+            {hasRightIcon ? React.cloneElement(icon, { ...icon.props, size: iconSize }) : null}
+          </div>
+        ) : null}
+      </div>
+    )
+  }
+)

--- a/lib/src/components/InputText/input-text.module.scss
+++ b/lib/src/components/InputText/input-text.module.scss
@@ -1,0 +1,184 @@
+.input-text-wrapper {
+  position: relative;
+}
+
+.root {
+  border-radius: var(--radius-md);
+  border-style: solid;
+  border-width: var(--border-width-sm);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-16);
+  outline: transparent solid var(--border-width-md);
+  width: 100%;
+  transition: var(--duration-medium);
+  appearance: none;
+
+  /* VARIABLES THAT CHANGE WITH REACT PROPS */
+  background-color: var(--backgroundColor);
+  color: var(--color);
+  border-color: var(--borderColor);
+  height: var(--height);
+  padding-inline: var(--paddingInline);
+  padding-block: var(--paddingBlock);
+
+  --borderColor: var(--color-neutral-30);
+  --backgroundColor: var(--color-neutral-10);
+  --color: var(--color-neutral-90);
+
+  &:disabled,
+  &[aria-disabled] {
+    --backgroundColor: var(--color-beige-40);
+    --color: var(--color-beige-70);
+    cursor: not-allowed;
+  }
+
+  &:hover {
+    --borderColor: var(--borderColorHover);
+  }
+
+  &[data-focus-visible],
+  &:focus-visible {
+    --borderColor: var(--borderColorFocused);
+    outline-color: var(--outlineColorFocus);
+  }
+
+  &::placeholder {
+    --color: var(--color-neutral-60);
+  }
+}
+
+.variant {
+  &-default {
+    --borderColorHover: var(--color-neutral-40);
+    --outlineColorFocus: var(--color-brand-20);
+    --borderColorFocused: var(--color-brand-40);
+  }
+
+  &-danger {
+    --borderColor: var(--color-red-70);
+    --borderColorHover: var(--color-red-70);
+    --borderColorFocused: var(--color-red-70);
+    --outlineColorFocus: var(--color-red-30);
+  }
+
+  &-warning {
+    --borderColor: var(--color-orange-60);
+    --borderColorHover: var(--color-orange-60);
+    --borderColorFocused: var(--color-orange-60);
+    --outlineColorFocus: var(--color-orange-30);
+  }
+
+  &-success {
+    --borderColor: var(--color-green-60);
+    --borderColorHover: var(--color-green-60);
+    --borderColorFocused: var(--color-green-60);
+    --outlineColorFocus: var(--color-green-30);
+  }
+}
+
+.placement {
+  &-left.size {
+    &-xs {
+      padding-left: 1.75rem;
+    }
+    &-sm,
+    &-md,
+    &-lg {
+      padding-left: 2.25rem;
+    }
+  }
+
+  &-right.size {
+    &-xs {
+      padding-right: 1.75rem;
+    }
+    &-sm,
+    &-md,
+    &-lg {
+      padding-right: 2.25rem;
+    }
+  }
+}
+
+.transparent {
+  --borderColor: transparent;
+  --backgroundColor: transparent;
+  --borderColorHover: var(--color-neutral-20);
+}
+
+.size {
+  &-xs {
+    --height: var(--height-elements-sm);
+    --paddingBlock: var(--spacing-xs);
+    --paddingInline: var(--spacing-sm);
+  }
+
+  &-sm {
+    --height: var(--height-elements-md);
+    --paddingBlock: var(--spacing-sm);
+    --paddingInline: var(--spacing-md);
+  }
+
+  &-md {
+    --height: var(--height-elements-lg);
+    --paddingBlock: var(--spacing-md);
+    --paddingInline: var(--spacing-md);
+  }
+
+  &-lg {
+    --height: var(--height-elements-xl);
+    --paddingBlock: var(--spacing-lg);
+    --paddingInline: var(--spacing-md);
+  }
+}
+
+.clearable {
+  padding-right: var(--spacing-xl);
+}
+
+.icon-wrapper {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--left);
+  right: var(--right);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+  transition: var(--duration-medium);
+  transition-timing-function: var(--timing-primary);
+  color: var(--color-neutral-90);
+  gap: var(--spacing-xs);
+
+  --left: auto;
+  --right: auto;
+
+  /* for button action */
+  & > button {
+    pointer-events: auto;
+  }
+}
+
+.icon-placement {
+  &-left {
+    &-xs {
+      --left: var(--spacing-sm);
+    }
+
+    &-sm {
+      --left: var(--spacing-md);
+    }
+  }
+
+  &-right {
+    &-xs {
+      --right: var(--spacing-sm);
+    }
+
+    &-sm {
+      --right: var(--spacing-md);
+    }
+  }
+}

--- a/lib/src/components/InputText/tests/index.test.tsx
+++ b/lib/src/components/InputText/tests/index.test.tsx
@@ -1,0 +1,52 @@
+import { screen } from '@testing-library/react'
+import React, { useState } from 'react'
+
+import { InputText } from '../'
+import { render } from '../../../../tests'
+import type { InputTextProps } from '../types'
+
+const InputTextWrapper: React.FC<InputTextProps> = props => {
+  const [value, setValue] = useState('test')
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value)
+  }
+
+  return (
+    <InputText data-testid="input" name="input" onChange={handleChange} value={value} {...props} />
+  )
+}
+
+describe('<InputText />', () => {
+  it('displays given value', () => {
+    const { getByTestId } = render(<InputTextWrapper />)
+
+    const input = getByTestId('input') as HTMLInputElement
+    expect(input.value).toBe('test')
+  })
+
+  it("can't remove value", () => {
+    const { getByTestId, queryByRole } = render(<InputTextWrapper />)
+
+    const input = getByTestId('input') as HTMLInputElement
+
+    // Use `queryByTitle` to expect no close button
+    const clearButton = queryByRole('button')
+    expect(clearButton).toBeNull()
+
+    expect(input.value).toBe('test')
+  })
+
+  it('can remove value', async () => {
+    const { user } = render(<InputTextWrapper isClearable />)
+
+    const input = screen.getByTestId('input') as HTMLInputElement
+    expect(input.value).toBe('test')
+
+    const clearButton = screen.getByRole('button')
+
+    await user.click(clearButton)
+
+    expect(input.value).toBe('')
+  })
+})

--- a/lib/src/components/InputText/types.ts
+++ b/lib/src/components/InputText/types.ts
@@ -1,0 +1,15 @@
+export interface InputTextOptions {
+  icon?: JSX.Element
+  iconPlacement?: 'left' | 'right'
+  isClearable?: boolean
+  size?: Size
+  transparent?: boolean
+  variant?: Variant
+}
+
+export type InputTextProps = InputTextOptions &
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>
+
+export type Size = 'lg' | 'md' | 'sm' | 'xs'
+
+export type Variant = 'danger' | 'default' | 'success' | 'warning'

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -5,6 +5,7 @@
 @import '../../lib/src/components/Icon/icon.module.scss';
 @import '../../lib/src/components/VariantIcon/variant-icon.module.scss';
 @import '../../lib/src/components/Toggle/toggle.module.scss';
+@import '../../lib/src/components/InputText/input-text.module.scss';
 
 @source '../../lib/src/**/*.{ts,tsx}';
 

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -28,6 +28,13 @@ export default {
   "/Toggle/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/Toggle/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/Toggle/docs/examples/size.tsx": dynamic(() => import("../../lib/src/components/Toggle/docs/examples/size.tsx").then(mod => mod), { ssr: false }),
   "/Toggle/docs/examples/variant.tsx": dynamic(() => import("../../lib/src/components/Toggle/docs/examples/variant.tsx").then(mod => mod), { ssr: false }),
+  "/InputText/docs/examples/clearable.tsx": dynamic(() => import("../../lib/src/components/InputText/docs/examples/clearable.tsx").then(mod => mod), { ssr: false }),
+  "/InputText/docs/examples/disabled.tsx": dynamic(() => import("../../lib/src/components/InputText/docs/examples/disabled.tsx").then(mod => mod), { ssr: false }),
+  "/InputText/docs/examples/icon.tsx": dynamic(() => import("../../lib/src/components/InputText/docs/examples/icon.tsx").then(mod => mod), { ssr: false }),
+  "/InputText/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/InputText/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
+  "/InputText/docs/examples/sizes.tsx": dynamic(() => import("../../lib/src/components/InputText/docs/examples/sizes.tsx").then(mod => mod), { ssr: false }),
+  "/InputText/docs/examples/transparent.tsx": dynamic(() => import("../../lib/src/components/InputText/docs/examples/transparent.tsx").then(mod => mod), { ssr: false }),
+  "/InputText/docs/examples/variants.tsx": dynamic(() => import("../../lib/src/components/InputText/docs/examples/variants.tsx").then(mod => mod), { ssr: false }),
   "/VariantIcon/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/VariantIcon/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/VariantIcon/docs/examples/sizes.tsx": dynamic(() => import("../../lib/src/components/VariantIcon/docs/examples/sizes.tsx").then(mod => mod), { ssr: false })
 };


### PR DESCRIPTION
This pull request introduces a new `InputText` component to the codebase, complete with implementation, documentation, examples, styles, type definitions, and tests. It also integrates the component into the website's global styles and example loader, ensuring it is available for documentation and demonstration purposes.

**New InputText Component Implementation and Integration**

* Added the `InputText` component in `lib/src/components/InputText/index.tsx`, supporting custom variant and sizes. And with disabled, focused and hover states.
* Defined prop types and options for `InputText` in `lib/src/components/InputText/types.ts`, including support for custom size and variant.
* Created comprehensive SCSS styles for the `InputText` component, including size variants and icon positioning, in `lib/src/components/InputText/input-text.module.scss`.
* Added a test to verify basic rendering of the `InputText` component in `lib/src/components/InputText/tests/index.test.tsx`.

**Documentation and Examples**

* Authored a detailed MDX documentation page for `InputText` in `lib/src/components/InputText/docs/index.mdx`, describing usage, variants, and properties.
* Documented the `InputText` component's properties in JSON format for automated docs in `lib/src/components/InputText/docs/properties.json`.

**Website Integration**

* Registered all new `InputText` example files in the website's example loader (`website/build-app/examples.js`) for live documentation.
* Included `input-text.module.scss` in the global CSS for the website to ensure consistent styling.

**Other Minor Changes**

* Removed all input html default attributes from the internal props options (data-testid, onBlur, autoFocus ...)
* The documentation contains examples of the use of `InputText` only, the other use cases should be defined in the `Field` component
* Create a `default` variant to be able to override border color and outline color with other variants