### PR TITLE
chore: migrate textarea to tailwind

### DIFF
--- a/lib/src/components/Textarea/docs/examples/overview.tsx
+++ b/lib/src/components/Textarea/docs/examples/overview.tsx
@@ -1,0 +1,12 @@
+import { Textarea } from '@/components/Textarea'
+
+const Example = () => {
+  return (
+    <Textarea
+      name="textarea"
+      placeholder="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    />
+  )
+}
+
+export default Example

--- a/lib/src/components/Textarea/docs/examples/variants.tsx
+++ b/lib/src/components/Textarea/docs/examples/variants.tsx
@@ -1,0 +1,13 @@
+import { Textarea } from '@/components/Textarea'
+
+const Example = () => {
+  return (
+    <>
+      <Textarea placeholder="Welcome" variant="warning" />
+      <Textarea placeholder="Welcome" variant="danger" />
+      <Textarea placeholder="Welcome" variant="success" />
+    </>
+  )
+}
+
+export default Example

--- a/lib/src/components/Textarea/docs/index.mdx
+++ b/lib/src/components/Textarea/docs/index.mdx
@@ -1,0 +1,12 @@
+---
+category: forms
+description: The Textarea component is a multi-line input field that allows users to enter and edit larger blocks of text. It is commonly used in forms and applications where more extensive text input is required, such as comments, descriptions, or messages. This component provides features like resizing, placeholder text, and validation, enhancing the user experience by accommodating detailed text entry.
+packageName: textarea
+title: Textarea
+---
+
+### Variants
+
+Use `warning`, `danger`, or `success` properties to add a variant status on your textarea.
+
+<div data-playground="variants.tsx" data-component="Textarea"></div>

--- a/lib/src/components/Textarea/docs/properties.json
+++ b/lib/src/components/Textarea/docs/properties.json
@@ -1,0 +1,63 @@
+{
+  "Textarea": {
+    "props": {
+      "minRows": {
+        "defaultValue": {
+          "value": 5
+        },
+        "description": "",
+        "name": "minRows",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Textarea/types.ts",
+          "name": "TextareaOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Textarea/types.ts",
+            "name": "TextareaOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "number"
+        }
+      },
+      "variant": {
+        "defaultValue": {
+          "value": "default"
+        },
+        "description": "",
+        "name": "variant",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Textarea/types.ts",
+          "name": "TextareaOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Textarea/types.ts",
+            "name": "TextareaOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "Variant",
+          "value": [
+            {
+              "value": "\"danger\""
+            },
+            {
+              "value": "\"default\""
+            },
+            {
+              "value": "\"success\""
+            },
+            {
+              "value": "\"warning\""
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/lib/src/components/Textarea/index.tsx
+++ b/lib/src/components/Textarea/index.tsx
@@ -1,0 +1,14 @@
+import { forwardRef } from 'react'
+
+import { classNames } from '@/utils'
+
+import textareaStyles from './textarea.module.scss'
+import type { TextareaProps } from './types'
+
+const cx = classNames(textareaStyles)
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ minRows = 5, variant = 'default', ...rest }, ref) => (
+    <textarea className={cx('root', `variant-${variant}`)} ref={ref} rows={minRows} {...rest} />
+  )
+)

--- a/lib/src/components/Textarea/tests/index.test.tsx
+++ b/lib/src/components/Textarea/tests/index.test.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react'
+
+import { Textarea } from '../'
+import { render } from '../../../../tests'
+import type { TextareaProps } from '../types'
+
+const TextareaWrapper: React.FC<TextareaProps> = props => {
+  const [value, setValue] = useState('test')
+
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(event.target.value)
+  }
+
+  return (
+    <Textarea
+      data-testid="textarea"
+      name="textarea"
+      onChange={handleChange}
+      value={value}
+      {...props}
+    />
+  )
+}
+
+describe('<Textarea />', () => {
+  it('displays given value', () => {
+    const { getByTestId } = render(<TextareaWrapper />)
+
+    const textarea = getByTestId('textarea') as HTMLTextAreaElement
+    expect(textarea.value).toBe('test')
+  })
+})

--- a/lib/src/components/Textarea/textarea.module.scss
+++ b/lib/src/components/Textarea/textarea.module.scss
@@ -1,0 +1,73 @@
+.root {
+  border-radius: var(--radius-md);
+  border-style: solid;
+  border-width: var(--border-width-sm);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-16);
+  outline: transparent solid var(--border-width-md);
+  width: 100%;
+  transition: var(--duration-medium);
+  appearance: none;
+  padding: var(--spacing-md);
+  min-height: 8.125rem;
+
+  /* VARIABLES THAT CHANGE WITH REACT PROPS */
+  background-color: var(--backgroundColor);
+  color: var(--color);
+  border-color: var(--borderColor);
+
+  --borderColor: var(--color-neutral-30);
+  --backgroundColor: var(--color-neutral-10);
+  --color: var(--color-neutral-90);
+
+  &:disabled,
+  &[aria-disabled] {
+    --backgroundColor: var(--color-beige-40);
+    --color: var(--color-beige-70);
+    cursor: not-allowed;
+  }
+
+  &:hover {
+    --borderColor: var(--borderColorHover);
+  }
+
+  &[data-focus-visible],
+  &:focus-visible {
+    --borderColor: var(--borderColorFocused);
+    outline-color: var(--outlineColorFocus);
+  }
+
+  &::placeholder {
+    --color: var(--color-neutral-60);
+  }
+}
+
+.variant {
+  &-default {
+    --borderColorHover: var(--color-neutral-40);
+    --outlineColorFocus: var(--color-brand-20);
+    --borderColorFocused: var(--color-brand-40);
+  }
+
+  &-danger {
+    --borderColor: var(--color-red-70);
+    --borderColorHover: var(--color-red-70);
+    --borderColorFocused: var(--color-red-70);
+    --outlineColorFocus: var(--color-red-30);
+  }
+
+  &-warning {
+    --borderColor: var(--color-orange-60);
+    --borderColorHover: var(--color-orange-60);
+    --borderColorFocused: var(--color-orange-60);
+    --outlineColorFocus: var(--color-orange-30);
+  }
+
+  &-success {
+    --borderColor: var(--color-green-60);
+    --borderColorHover: var(--color-green-60);
+    --borderColorFocused: var(--color-green-60);
+    --outlineColorFocus: var(--color-green-30);
+  }
+}

--- a/lib/src/components/Textarea/types.ts
+++ b/lib/src/components/Textarea/types.ts
@@ -1,0 +1,8 @@
+export interface TextareaOptions {
+  minRows?: number
+  variant?: Variant
+}
+
+export type TextareaProps = React.InputHTMLAttributes<HTMLTextAreaElement> & TextareaOptions
+
+export type Variant = 'danger' | 'default' | 'success' | 'warning'

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -6,6 +6,7 @@
 @import '../../lib/src/components/VariantIcon/variant-icon.module.scss';
 @import '../../lib/src/components/Toggle/toggle.module.scss';
 @import '../../lib/src/components/InputText/input-text.module.scss';
+@import '../../lib/src/components/Textarea/textarea.module.scss';
 
 @source '../../lib/src/**/*.{ts,tsx}';
 

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -35,6 +35,8 @@ export default {
   "/InputText/docs/examples/sizes.tsx": dynamic(() => import("../../lib/src/components/InputText/docs/examples/sizes.tsx").then(mod => mod), { ssr: false }),
   "/InputText/docs/examples/transparent.tsx": dynamic(() => import("../../lib/src/components/InputText/docs/examples/transparent.tsx").then(mod => mod), { ssr: false }),
   "/InputText/docs/examples/variants.tsx": dynamic(() => import("../../lib/src/components/InputText/docs/examples/variants.tsx").then(mod => mod), { ssr: false }),
+  "/Textarea/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/Textarea/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
+  "/Textarea/docs/examples/variants.tsx": dynamic(() => import("../../lib/src/components/Textarea/docs/examples/variants.tsx").then(mod => mod), { ssr: false }),
   "/VariantIcon/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/VariantIcon/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/VariantIcon/docs/examples/sizes.tsx": dynamic(() => import("../../lib/src/components/VariantIcon/docs/examples/sizes.tsx").then(mod => mod), { ssr: false })
 };


### PR DESCRIPTION
This pull request introduces a new `Textarea` component to the codebase, complete with implementation, documentation, examples, styles, type definitions, and tests. It also integrates the component into the website's global styles and example loader, ensuring it is available for documentation and demonstration purposes.

**New Textarea Component Implementation and Integration**

* Added the `Textarea` component in `lib/src/components/Textarea/index.tsx`, supporting custom variant and sizes. And with disabled, focused and hover states.
* Defined prop types and options for `Textarea` in `lib/src/components/Textarea/types.ts`, including support for custom size and variant.
* Created comprehensive SCSS styles for the `Textarea` component, including size variants and icon positioning, in `lib/src/components/Textarea/textarea.module.scss`.
* Added a test to verify basic rendering of the `Textarea` component in `lib/src/components/Textarea/tests/index.test.tsx`.
* Removed the `size` props because it's not a authorized use on the textarea field

**Documentation and Examples**

* Authored a detailed MDX documentation page for `Textarea` in `lib/src/components/Textarea/docs/index.mdx`, describing usage, variants, and properties.
* Documented the `Textarea` component's properties in JSON format for automated docs in `lib/src/components/Textarea/docs/properties.json`.

**Website Integration**

* Registered all new `Textarea` example files in the website's example loader (`website/build-app/examples.js`) for live documentation.
* Included `textarea.module.scss` in the global CSS for the website to ensure consistent styling.

**Other Minor Changes**

* Removed all textarea html default attributes from the internal props options (data-testid, onBlur, autoFocus ...)
* The documentation contains examples of the use of `Textarea` only, the other use cases should be defined in the `Field` component
* Create a `default` variant to be able to override border color and outline color with other variants
