### PR TITLE
[WUI-213] Chore: add forwardRefWithAs to handle polymorphism

### DIFF
--- a/lib/src/components/Button/docs/index.mdx
+++ b/lib/src/components/Button/docs/index.mdx
@@ -58,7 +58,7 @@ You can set an `isLoading` property to display a loading indicator that matches 
 
 <div data-playground="is-loading.tsx" data-component="Button"></div>
 
-### Transform to a link FIXME
+### Transform to a link
 
 You can transform your Button component with `as` property to add you linker, `href` or `to`... all that you want.
 

--- a/lib/src/components/Button/docs/properties.json
+++ b/lib/src/components/Button/docs/properties.json
@@ -1,6 +1,130 @@
 {
   "Button": {
     "props": {
+      "accessibleWhenDisabled": {
+        "defaultValue": null,
+        "description": "Indicates whether the element should be focusable even when it is\n[`disabled`](https://ariakit.org/reference/focusable#disabled).\n\nThis is important when discoverability is a concern. For example:\n\n> A toolbar in an editor contains a set of special smart paste functions\nthat are disabled when the clipboard is empty or when the function is not\napplicable to the current content of the clipboard. It could be helpful to\nkeep the disabled buttons focusable if the ability to discover their\nfunctionality is primarily via their presence on the toolbar.\n\nLearn more on [Focusability of disabled\ncontrols](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols).\n\nLive examples:\n- [Combobox with Tabs](https://ariakit.org/examples/combobox-tabs)",
+        "name": "accessibleWhenDisabled",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+          "name": "FocusableOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+            "name": "FocusableOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "autoFocus": {
+        "defaultValue": {
+          "value": "false"
+        },
+        "description": "Automatically focuses the element upon mounting, similar to the native\n`autoFocus` prop. This addresses an issue where the element with the native\n`autoFocus` attribute might receive focus before React effects are\nexecuted.\n\nThe `autoFocus` prop can also be used with\n[Focusable](https://ariakit.org/components/focusable) elements within a\n[Dialog](https://ariakit.org/components/dialog) component, establishing the\ninitial focus as the dialog opens.\n\n**Note**: For this prop to work, the\n[`focusable`](https://ariakit.org/reference/command#focusable) prop must be\nset to `true`, if it's not set by default.\n\nLive examples:\n- [Warning on Dialog\n  hide](https://ariakit.org/examples/dialog-hide-warning)\n- [Dialog with React\n  Router](https://ariakit.org/examples/dialog-react-router)\n- [Nested Dialog](https://ariakit.org/examples/dialog-nested)",
+        "name": "autoFocus",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+          "name": "FocusableOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+            "name": "FocusableOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "clickOnEnter": {
+        "defaultValue": {
+          "value": "true"
+        },
+        "description": "If set to `true`, pressing the enter key while this element is focused will\ntrigger a click on the element, regardless of whether it's a native button\nor not. If this prop is set to `false`, pressing enter will not initiate a\nclick.",
+        "name": "clickOnEnter",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/command/command.d.ts",
+          "name": "CommandOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/command/command.d.ts",
+            "name": "CommandOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "clickOnSpace": {
+        "defaultValue": {
+          "value": "true"
+        },
+        "description": "If set to `true`, pressing and releasing the space key while this element\nis focused will trigger a click on the element, regardless of whether it's\na native button or not. If this prop is set to `false`, space will not\ninitiate a click.",
+        "name": "clickOnSpace",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/command/command.d.ts",
+          "name": "CommandOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/command/command.d.ts",
+            "name": "CommandOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "disabled": {
+        "defaultValue": {
+          "value": "false"
+        },
+        "description": "Determines if the element is disabled. This sets the `aria-disabled`\nattribute accordingly, enabling support for all elements, including those\nthat don't support the native `disabled` attribute.\n\nThis feature can be combined with the\n[`accessibleWhenDisabled`](https://ariakit.org/reference/focusable#accessiblewhendisabled)\nprop to make disabled elements still accessible via keyboard.\n\n**Note**: For this prop to work, the\n[`focusable`](https://ariakit.org/reference/command#focusable) prop must be\nset to `true`, if it's not set by default.\n\nLive examples:\n- [Submenu](https://ariakit.org/examples/menu-nested)\n- [Combobox with Tabs](https://ariakit.org/examples/combobox-tabs)\n- [Context Menu](https://ariakit.org/examples/menu-context-menu)",
+        "name": "disabled",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+          "name": "FocusableOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+            "name": "FocusableOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "focusable": {
+        "defaultValue": {
+          "value": "true"
+        },
+        "description": "Determines if [Focusable](https://ariakit.org/components/focusable)\nfeatures should be active on non-native focusable elements.\n\n**Note**: This prop only turns off the additional features provided by the\n[`Focusable`](https://ariakit.org/reference/focusable) component.\nNon-native focusable elements will lose their focusability entirely.\nHowever, native focusable elements will retain their inherent focusability,\nbut without added features such as improved\n[`autoFocus`](https://ariakit.org/reference/focusable#autofocus),\n[`accessibleWhenDisabled`](https://ariakit.org/reference/focusable#accessiblewhendisabled),\n[`onFocusVisible`](https://ariakit.org/reference/focusable#onfocusvisible),\netc.",
+        "name": "focusable",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+          "name": "FocusableOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+            "name": "FocusableOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
       "isLoading": {
         "defaultValue": null,
         "description": "",
@@ -27,6 +151,44 @@
               "value": "true"
             }
           ]
+        }
+      },
+      "onFocusVisible": {
+        "defaultValue": null,
+        "description": "Custom event handler invoked when the element gains focus through keyboard\ninteraction or a key press occurs while the element is in focus. This is\nthe programmatic equivalent of the\n[`data-focus-visible`](https://ariakit.org/guide/styling#data-focus-visible)\nattribute.\n\n**Note**: For this prop to work, the\n[`focusable`](https://ariakit.org/reference/command#focusable) prop must be\nset to `true`, if it's not set by default.\n\nLive examples:\n- [Navigation Menubar](https://ariakit.org/examples/menubar-navigation)\n- [Custom Checkbox](https://ariakit.org/examples/checkbox-custom)",
+        "name": "onFocusVisible",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+          "name": "FocusableOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/focusable/focusable.d.ts",
+            "name": "FocusableOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
+        }
+      },
+      "render": {
+        "defaultValue": null,
+        "description": "Allows the component to be rendered as a different HTML element or React\ncomponent. The value can be a React element or a function that takes in the\noriginal component props and gives back a React element with the props\nmerged.\n\nCheck out the [Composition](https://ariakit.org/guide/composition) guide\nfor more details.",
+        "name": "render",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/utils/types.d.ts",
+          "name": "Options"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/utils/types.d.ts",
+            "name": "Options"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
         }
       },
       "shape": {
@@ -61,9 +223,7 @@
         }
       },
       "size": {
-        "defaultValue": {
-          "value": "md"
-        },
+        "defaultValue": null,
         "description": "",
         "name": "size",
         "parent": {
@@ -97,9 +257,7 @@
         }
       },
       "variant": {
-        "defaultValue": {
-          "value": "primary"
-        },
+        "defaultValue": null,
         "description": "",
         "name": "variant",
         "parent": {
@@ -148,6 +306,25 @@
               "value": "\"tertiary-danger\""
             }
           ]
+        }
+      },
+      "wrapElement": {
+        "defaultValue": null,
+        "description": "",
+        "name": "wrapElement",
+        "parent": {
+          "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/utils/types.d.ts",
+          "name": "Options"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/node_modules/@ariakit/react-core/esm/utils/types.d.ts",
+            "name": "Options"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "any"
         }
       }
     }

--- a/lib/src/components/Button/docs/properties.json
+++ b/lib/src/components/Button/docs/properties.json
@@ -2,9 +2,7 @@
   "Button": {
     "props": {
       "isLoading": {
-        "defaultValue": {
-          "value": false
-        },
+        "defaultValue": null,
         "description": "",
         "name": "isLoading",
         "parent": {
@@ -32,9 +30,7 @@
         }
       },
       "shape": {
-        "defaultValue": {
-          "value": "default"
-        },
+        "defaultValue": null,
         "description": "",
         "name": "shape",
         "parent": {

--- a/lib/src/components/Button/index.test.tsx
+++ b/lib/src/components/Button/index.test.tsx
@@ -1,10 +1,12 @@
 import { screen } from '@testing-library/react'
 
-import { render } from '@tests'
+import { expectAsSupport, render } from '@tests'
 
 import { Button } from '.'
 
 describe('Button', () => {
+  expectAsSupport(Button)
+
   it('should render correctly', () => {
     render(<Button>Button</Button>)
 

--- a/lib/src/components/Button/index.tsx
+++ b/lib/src/components/Button/index.tsx
@@ -1,6 +1,7 @@
 import { Button as AriakitButton } from '@ariakit/react'
 
 import { classNames } from '@/utils'
+import { forwardRefWithAs } from '@/utils/forwardRefWithAs'
 
 import { useButtonGroup } from '../ButtonGroup'
 
@@ -9,43 +10,53 @@ import type { ButtonProps } from './types'
 
 const cx = classNames(buttonStyles)
 
-export const Button = <T extends React.ElementType = 'button'>({
-  accessibleWhenDisabled = true,
-  children,
-  className = '',
-  disabled = false,
-  isLoading = false,
-  ref,
-  shape = 'default',
-  size: propSize = 'md',
-  variant: propVariant = 'primary',
-  ...rest
-}: ButtonProps<T>) => {
-  const { disabled: groupDisabled, size: groupSize, variant: groupVariant } = useButtonGroup()
+export const Button = forwardRefWithAs<ButtonProps, 'button'>(
+  (
+    {
+      accessibleWhenDisabled = true,
+      as,
+      children,
+      className = '',
+      disabled = false,
+      isLoading = false,
+      shape = 'default',
+      size: propSize = 'md',
+      variant: propVariant = 'primary',
+      ...rest
+    },
+    ref
+  ) => {
+    const { disabled: groupDisabled, size: groupSize, variant: groupVariant } = useButtonGroup()
 
-  const isDisabled = groupDisabled || disabled || isLoading
-  // some variants like 'disabled' preprend over the others
-  const variant = (isDisabled && 'disabled') || groupVariant || propVariant
+    const isDisabled = groupDisabled || disabled || isLoading
+    // some variants like 'disabled' preprend over the others
+    const variant = (isDisabled && 'disabled') || groupVariant || propVariant
 
-  const size = groupSize || propSize
+    const size = groupSize || propSize
 
-  return (
-    <AriakitButton
-      {...rest}
-      accessibleWhenDisabled={accessibleWhenDisabled}
-      className={cx(
-        'root',
-        variant && `variant-${variant}`,
-        shape && `shape-${shape}`,
-        size && `size-${size}`,
-        className
-      )}
-      disabled={isDisabled}
-      ref={ref}
-      type="button"
-    >
-      {isLoading ? <span className={cx('loader')} /> : null}
-      {!isLoading && children}
-    </AriakitButton>
-  )
-}
+    const Element = as || 'button'
+
+    return (
+      <AriakitButton
+        {...rest}
+        accessibleWhenDisabled={accessibleWhenDisabled}
+        className={cx(
+          'root',
+          variant && `variant-${variant}`,
+          shape && `shape-${shape}`,
+          size && `size-${size}`,
+          className
+        )}
+        disabled={isDisabled}
+        ref={ref}
+        render={as ? <Element /> : undefined}
+        type="button"
+      >
+        {isLoading ? <span className={cx('loader')} /> : null}
+        {!isLoading && children}
+      </AriakitButton>
+    )
+  }
+)
+
+Button.displayName = 'Button'

--- a/lib/src/components/Button/types.ts
+++ b/lib/src/components/Button/types.ts
@@ -1,11 +1,8 @@
 import type { ButtonProps as AriakitButtonProps } from '@ariakit/react'
-import type { ReactNode } from 'react'
 
-import type { PolymorphicProps } from '@/theme/types'
+import type { MergeProps } from '@/utils/forwardRefWithAs'
 
-export type ButtonProps<T extends React.ElementType = 'button'> = AriakitButtonProps &
-  ButtonOptions &
-  PolymorphicProps<T>
+export type ButtonProps = MergeProps<ButtonOptions, AriakitButtonProps>
 
 export type ButtonShape = 'circle' | 'default' | 'square'
 export type ButtonSize = 'lg' | 'md' | 'sm' | 'xs'
@@ -21,7 +18,6 @@ export type ButtonVariant =
   | 'tertiary-ai'
   | 'tertiary-danger'
 interface ButtonOptions {
-  children?: ReactNode
   isLoading?: boolean
   shape?: ButtonShape
   size?: ButtonSize

--- a/lib/src/components/Button/types.ts
+++ b/lib/src/components/Button/types.ts
@@ -1,4 +1,5 @@
 import type { ButtonProps as AriakitButtonProps } from '@ariakit/react'
+import type { ReactNode } from 'react'
 
 import type { MergeProps } from '@/utils/forwardRefWithAs'
 
@@ -18,6 +19,7 @@ export type ButtonVariant =
   | 'tertiary-ai'
   | 'tertiary-danger'
 interface ButtonOptions {
+  children?: ReactNode
   isLoading?: boolean
   shape?: ButtonShape
   size?: ButtonSize

--- a/lib/src/components/ButtonGroup/index.test.tsx
+++ b/lib/src/components/ButtonGroup/index.test.tsx
@@ -1,10 +1,12 @@
 import { Button } from '@/components/Button'
 
-import { render } from '@tests'
+import { expectAsSupport, render } from '@tests'
 
 import { ButtonGroup } from '.'
 
 describe('<ButtonGroup>', () => {
+  expectAsSupport(ButtonGroup)
+
   it('should render correctly', () => {
     const { getByTestId } = render(
       <ButtonGroup data-testid="group">

--- a/lib/src/components/ButtonGroup/index.tsx
+++ b/lib/src/components/ButtonGroup/index.tsx
@@ -16,18 +16,24 @@ export function useButtonGroup() {
 
 export const ButtonGroup = forwardRefWithAs<ButtonGroupProps, 'div'>(
   (
-    { as, children, className, disabled = false, size = 'md', variant = 'primary', ...rest },
+    {
+      as: Component = 'div',
+      children,
+      className,
+      disabled = false,
+      size = 'md',
+      variant = 'primary',
+      ...rest
+    },
     ref
   ) => {
     const state = useMemo(() => ({ disabled, size, variant }), [disabled, size, variant])
 
-    const Element = as || 'div'
-
     return (
       <ButtonGroupContext.Provider value={state}>
-        <Element {...rest} className={cx('root', className)} ref={ref}>
+        <Component {...rest} className={cx('root', className)} ref={ref}>
           {children}
-        </Element>
+        </Component>
       </ButtonGroupContext.Provider>
     )
   }

--- a/lib/src/components/ButtonGroup/index.tsx
+++ b/lib/src/components/ButtonGroup/index.tsx
@@ -1,6 +1,7 @@
-import { createContext, forwardRef, useContext, useMemo } from 'react'
+import { createContext, useContext, useMemo } from 'react'
 
 import { classNames } from '@/utils'
+import { forwardRefWithAs } from '@/utils/forwardRefWithAs'
 
 import buttonGroupStyles from './button-group.module.scss'
 import type { ButtonGroupProps, ButtonGroupState } from './types'
@@ -13,16 +14,23 @@ export function useButtonGroup() {
   return useContext(ButtonGroupContext)
 }
 
-export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
-  ({ children, className, disabled = false, size = 'md', variant = 'primary', ...rest }, ref) => {
+export const ButtonGroup = forwardRefWithAs<ButtonGroupProps, 'div'>(
+  (
+    { as, children, className, disabled = false, size = 'md', variant = 'primary', ...rest },
+    ref
+  ) => {
     const state = useMemo(() => ({ disabled, size, variant }), [disabled, size, variant])
+
+    const Element = as || 'div'
 
     return (
       <ButtonGroupContext.Provider value={state}>
-        <div {...rest} className={cx('root', className)} ref={ref}>
+        <Element {...rest} className={cx('root', className)} ref={ref}>
           {children}
-        </div>
+        </Element>
       </ButtonGroupContext.Provider>
     )
   }
 )
+
+ButtonGroup.displayName = 'ButtonGroup'

--- a/lib/src/utils/forwardRefWithAs.tsx
+++ b/lib/src/utils/forwardRefWithAs.tsx
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react'
+
+/**
+ * The following source code is mainly inspired by
+ * https://github.com/pluralsight/classic-design-system/blob/08f0962dec18d99e1799a16c7b7eac86f01cbc27/packages/util/src/primatives.ts
+ */
+
+export type As<BaseProps = any> = React.ElementType<BaseProps>
+/**
+ * Omit will not distribute over unions by default, this utility type will
+ * distribute it, allowing to omit keys from each member of the union.
+ *
+ * @example
+ *  type A = { a: string; b: number }
+ *  type B = { a: string; c: boolean }
+ *  type Union = A | B
+ *
+ *  // Without DistributiveOmit
+ *  type Test1 = Omit<Union, 'a'> // never  (because 'a' is in both A and B)
+ *  type Test2 = Omit<Union, 'b'> // B      (because 'b' is not in B)
+ */
+export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never
+export interface ForwardRefWithAsRenderFunction<
+  DefaultComponentType extends As,
+  ComponentProps extends PropsType = Record<string, any>,
+> {
+  (
+    props: PropsFromAs<DefaultComponentType, ComponentProps>,
+    ref: React.Ref<React.ElementRef<DefaultComponentType>>
+  ): null | React.ReactElement
+  // explicit rejected with `never` required due to
+  // https://github.com/microsoft/TypeScript/issues/36826
+  /**
+   * defaultProps are not supported on render functions
+   */
+  defaultProps?: never
+  displayName?: string
+  /**
+   * propTypes are not supported on render functions
+   */
+  propTypes?: never
+}
+
+export interface FunctionComponentWithAs<
+  DefaultComponentType extends As,
+  ComponentProps extends PropsType,
+> {
+  /**
+   * Inherited from React.FunctionComponent with modification to support `as`
+   */
+  <CompType extends As = DefaultComponentType>(
+    props: PropsWithAs<CompType, ComponentProps>,
+    context?: any
+  ): null | React.ReactElement<any, any>
+  /**
+   * Inherited from React.FunctionComponent
+   */
+  defaultProps?: Partial<PropsWithAs<DefaultComponentType, ComponentProps>>
+  displayName?: string
+}
+
+/**
+ * This will merge two prop objects, giving P1 priority over P2
+ * In other words, any props in P1 that are also in P2 will override the ones in P2
+ * This is useful when combining the props of the `as` component with your own props
+ */
+export type MergeProps<P1 = EmptyProps, P2 = EmptyProps> = DistributiveOmit<P2, keyof P1> & P1
+
+/**
+ * Get the props of a component with `as` support
+ * This will take care of the ref and the merging of the props
+ */
+export type PropsFromAs<
+  CompType extends As,
+  ComponentProps extends PropsType,
+> = React.PropsWithoutRef<PropsWithAs<CompType, ComponentProps>>
+
+/**
+ * Props of a component with `as` support
+ */
+export type PropsWithAs<CompType extends As, ComponentProps extends PropsType> = MergeProps<
+  WithAs<CompType, ComponentProps>,
+  React.ComponentProps<CompType>
+>
+
+/**
+ * An empty object type
+ */
+type EmptyProps = Record<never, never>
+
+/**
+ * PropsType can either be an object or null/undefined
+ */
+type PropsType = null | Record<string, any>
+
+/**
+ * Adds the `as` prop to a component's props
+ */
+type WithAs<DefaultComponentType extends As, ComponentProps extends EmptyProps> = MergeProps<
+  { as?: DefaultComponentType },
+  ComponentProps
+>
+
+/**
+ * Wraps a component with a forwardRef and adds the `as` prop support
+ */
+export function forwardRefWithAs<
+  ComponentProps extends PropsType,
+  DefaultComponentType extends As = 'div',
+>(render: ForwardRefWithAsRenderFunction<DefaultComponentType, ComponentProps>) {
+  return React.forwardRef(render) as unknown as FunctionComponentWithAs<
+    DefaultComponentType,
+    ComponentProps
+  >
+}

--- a/lib/tests/index.tsx
+++ b/lib/tests/index.tsx
@@ -2,7 +2,8 @@ import type { RenderOptions } from '@testing-library/react'
 import { render as rtlRender } from '@testing-library/react'
 import type { UserEvent } from '@testing-library/user-event'
 import userEvent from '@testing-library/user-event'
-import React from 'react'
+import type { ComponentProps, PropsWithChildren } from 'react'
+import React, { forwardRef } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 
 import { createTheme } from '@old/theme'
@@ -31,6 +32,33 @@ const customRender = (ui: JSX.Element, options?: RenderOptions): RenderResult =>
     user: userEvent.setup(),
     ...renderResult,
   }
+}
+
+const PolymorphicComponent = forwardRef<HTMLDivElement, PropsWithChildren>((props, ref) => {
+  return <div ref={ref} {...props} data-polymorphism="true" />
+})
+
+/**
+ * Test that a component supports the `as` prop for polymorphism
+ * @param Component The component to test
+ * @param options Additional options
+ */
+export function expectAsSupport<C extends React.ElementType>(
+  Component: C,
+  options: { props?: ComponentProps<C> } = {}
+) {
+  const { props = {} } = options
+
+  it('should support polymorphism', () => {
+    const { getByTestId } = customRender(
+      // @ts-expect-error: We intentionally test polymorphism even if 'as' is not in props
+      <Component as={PolymorphicComponent} data-testid="polymorphism" {...props} />
+    )
+    const element = getByTestId('polymorphism')
+
+    expect(element).toBeInTheDocument()
+    expect(element).toHaveAttribute('data-polymorphism', 'true')
+  })
 }
 
 // override render method


### PR DESCRIPTION
## DESCRIPTION

This pull request introduces polymorphic `as` prop support to the `Button` and `ButtonGroup` components, allowing them to render as different HTML elements or custom components. It achieves this by adding a new utility, `forwardRefWithAs`, and refactoring component and type definitions accordingly. The changes also update tests and documentation to reflect the new polymorphic capabilities.

**Polymorphism and Refactoring:**

* Added `forwardRefWithAs` utility to enable polymorphic `as` prop support and ref forwarding for components. (`lib/src/utils/forwardRefWithAs.tsx`)
* Refactored `Button` and `ButtonGroup` components to use `forwardRefWithAs`, supporting the `as` prop and updating their display names. (`lib/src/components/Button/index.tsx`, `lib/src/components/ButtonGroup/index.tsx`) [[1]](diffhunk://#diff-d4e82533e762d850a9ca9db946769e7864e18bbae4b0412e67cc6c93a53762b5R4) [[2]](diffhunk://#diff-d4e82533e762d850a9ca9db946769e7864e18bbae4b0412e67cc6c93a53762b5L12-R28) [[3]](diffhunk://#diff-d4e82533e762d850a9ca9db946769e7864e18bbae4b0412e67cc6c93a53762b5R37-R38) [[4]](diffhunk://#diff-d4e82533e762d850a9ca9db946769e7864e18bbae4b0412e67cc6c93a53762b5R52-R62) [[5]](diffhunk://#diff-86394fca6451715c691e8a17d3019e9f4e9d00ae682ce19ee921ee55ee174376L1-R4) [[6]](diffhunk://#diff-86394fca6451715c691e8a17d3019e9f4e9d00ae682ce19ee921ee55ee174376L16-R36)
* Updated `ButtonProps` type to use new polymorphic type utilities and simplified options, removing unnecessary generic and children props. (`lib/src/components/Button/types.ts`) [[1]](diffhunk://#diff-72bcab09e1c72dd104afe2f9c5413c29f2ac03d72bae84a952d968c133d5ffe9L2-R5) [[2]](diffhunk://#diff-72bcab09e1c72dd104afe2f9c5413c29f2ac03d72bae84a952d968c133d5ffe9L24)

**Testing Improvements:**

* Added `expectAsSupport` test utility to verify polymorphic support and updated tests for `Button` and `ButtonGroup` to use it. (`lib/tests/index.tsx`, `lib/src/components/Button/index.test.tsx`, `lib/src/components/ButtonGroup/index.test.tsx`) [[1]](diffhunk://#diff-4be892268795b1e1d742e5a46db34cc597962af9d9b7bc19a9b27868707c6051L5-R6) [[2]](diffhunk://#diff-4be892268795b1e1d742e5a46db34cc597962af9d9b7bc19a9b27868707c6051R37-R63) [[3]](diffhunk://#diff-25002ba758fa4d73d8ca1bc17dc65e2abd2740326475bd009d7f35f8e16e42c7L3-R9) [[4]](diffhunk://#diff-b2908083bbf0feb358f80c50350cfae362743a12ed645f2efb3f037762a2b9d6L3-R9)
