### PR TITLE
chore: migrate checkbox to tailwind

### DIFF
--- a/lib/src/components/Checkbox/checkbox.module.scss
+++ b/lib/src/components/Checkbox/checkbox.module.scss
@@ -1,0 +1,129 @@
+@layer components {
+  .root {
+    position: relative;
+    padding: 0;
+    cursor: pointer;
+    transition: medium;
+    overflow: hidden;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-regular);
+    line-height: 1rem;
+    appearance: none;
+    outline: transparent solid var(--border-width-md);
+    border-radius: var(--radius-sm);
+    border-style: solid;
+    border-width: var(--border-width-sm);
+    flex-shrink: 0;
+    height: 1rem;
+    width: 1rem;
+    color: var(--color-neutral-90);
+
+    /* VARIABLES THAT CHANGE WITH REACT PROPS */
+    background-color: var(--backgroundColor, var(--color-neutral-10));
+    border-color: var(--borderColor, var(--color-neutral-30));
+
+    &::after {
+      background-color: var(--afterBackgroundColor);
+      content: '';
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      margin: auto;
+      mask-size: contain;
+      width: 10px;
+    }
+
+    &:disabled,
+    &[aria-disabled] {
+      --backgroundColor: var(--color-beige-40);
+      --borderColor: var(--color-beige-50);
+
+      cursor: not-allowed;
+    }
+
+    &:hover {
+      --borderColor: var(--borderColorHover, var(--color-neutral-40));
+    }
+
+    &[data-focus-visible],
+    &:focus-visible {
+      --borderColor: var(--borderColorFocused, var(--color-brand-40));
+      outline-color: var(--outlineColorFocus, var(--color-brand-20));
+    }
+
+    &::placeholder {
+      --color: var(--color-neutral-60);
+    }
+
+    &[aria-checked='true'] {
+      &:not(:disabled) {
+        --backgroundColor: var(--color-brand-40);
+        --borderColor: var(--color-brand-40);
+        --color: var(--color-neutral-90);
+
+        &::after {
+          --afterBackgroundColor: var(--color-beige-90);
+        }
+      }
+
+      &:hover {
+        --backgroundColor: var(--color-brand-30);
+        --borderColor: var(--backgroundColor);
+      }
+
+      &::after {
+        --afterBackgroundColor: var(--color-beige-50);
+        height: 8px;
+        mask: url('data:image/svg+xml; utf8, <svg viewBox="0 0 10 8" xmlns="http://www.w3.org/2000/svg"><path fill="000000" d="M7.96171 0.596898C8.24912 0.27893 8.74024 0.25262 9.06024 0.537743C9.37208 0.815607 9.40671 1.28712 9.14514 1.60662L9.11975 1.63611L3.90331 7.40311C3.75365 7.5687 3.54304 7.66003 3.32401 7.66003C3.15017 7.66003 2.98077 7.60235 2.84241 7.49383L2.80848 7.46564L0.943652 5.82577C0.620151 5.54147 0.590221 5.04928 0.877091 4.72749C1.15398 4.41772 1.62383 4.38076 1.94536 4.6368L1.97506 4.66166L3.26156 5.79276L7.96171 0.596898Z" /></svg>');
+      }
+    }
+  }
+
+  .variant {
+    &-danger {
+      --borderColor: var(--color-red-70);
+      --borderColorHover: var(--color-red-70);
+      --borderColorFocused: var(--color-red-70);
+      --outlineColorFocus: var(--color-red-30);
+    }
+
+    &-warning {
+      --borderColor: var(--color-orange-60);
+      --borderColorHover: var(--color-orange-60);
+      --borderColorFocused: var(--color-orange-60);
+      --outlineColorFocus: var(--color-orange-30);
+    }
+
+    &-success {
+      --borderColor: var(--color-green-60);
+      --borderColorHover: var(--color-green-60);
+      --borderColorFocused: var(--color-green-60);
+      --outlineColorFocus: var(--color-green-30);
+    }
+  }
+
+  .indeterminate {
+    &:not(:disabled) {
+      --backgroundColor: var(--color-brand-40);
+      --borderColor: var(--color-brand-40);
+      --color: var(--color-neutral-90);
+
+      &::after {
+        --afterBackgroundColor: var(--color-beige-90);
+      }
+    }
+
+    &:hover {
+      --backgroundColor: var(--color-brand-30);
+      --borderColor: var(--backgroundColor);
+    }
+
+    &::after {
+      --afterBackgroundColor: var(--color-beige-50);
+      height: 4px;
+      mask: url("data:image/svg+xml,%3Csvg width='10' height='4' viewBox='0 0 10 4' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M1.3973 1.76919C0.953776 1.81988 0.634816 2.04775 0.685235 2.49156C0.732149 2.90436 1.08212 3.03624 1.48789 3.03624L8.6029 2.23086C9.04669 2.18017 9.36538 1.9523 9.31469 1.50849C9.26427 1.06468 8.86389 0.917163 8.41956 0.969201C4.90971 1.38026 4.90828 1.36792 1.3973 1.76919Z' fill='000000'/%3E%3C/svg%3E");
+    }
+  }
+}

--- a/lib/src/components/Checkbox/docs/examples/overview.tsx
+++ b/lib/src/components/Checkbox/docs/examples/overview.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+
+import { Checkbox } from '@/components/Checkbox'
+
+const Example = () => {
+  const [checkbox, setCheckbox] = React.useState(false)
+  const [checkboxChecked, setCheckboxChecked] = React.useState(true)
+  const [checkboxIndeterminate, setCheckboxIndeterminate] = React.useState(false)
+
+  return (
+    <>
+      <Checkbox checked={checkbox} name="default" onChange={() => setCheckbox(!checkbox)} />
+      <Checkbox
+        checked={checkboxChecked}
+        name="not-checked"
+        onChange={() => setCheckboxChecked(!checkboxChecked)}
+      />
+      <Checkbox
+        checked={checkboxIndeterminate}
+        indeterminate
+        name="indeterminate"
+        onChange={() => setCheckboxIndeterminate(!checkboxIndeterminate)}
+      />
+      <Checkbox disabled name="default-disabled" />
+      <Checkbox checked disabled name="not-checked-disabled" />
+    </>
+  )
+}
+
+export default Example

--- a/lib/src/components/Checkbox/docs/examples/variants.tsx
+++ b/lib/src/components/Checkbox/docs/examples/variants.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+
+import { Checkbox } from '@/components/Checkbox'
+
+const Example = () => {
+  const [checkbox, setCheckbox] = React.useState(false)
+
+  return (
+    <div className="items-center flex gap-sm">
+      <Checkbox
+        checked={checkbox}
+        name="default-variant"
+        onChange={() => setCheckbox(!checkbox)}
+        variant="danger"
+      />
+      <Checkbox
+        checked={checkbox}
+        name="default-variant"
+        onChange={() => setCheckbox(!checkbox)}
+        variant="warning"
+      />
+      <Checkbox
+        checked={checkbox}
+        name="default-variant"
+        onChange={() => setCheckbox(!checkbox)}
+        variant="success"
+      />
+    </div>
+  )
+}
+
+export default Example

--- a/lib/src/components/Checkbox/docs/index.mdx
+++ b/lib/src/components/Checkbox/docs/index.mdx
@@ -1,0 +1,13 @@
+---
+ariakit: https://ariakit.org/components/checkbox
+category: forms
+description: The Checkbox component allows users to select multiple options from a set of choices. It consists of a small box that, when clicked, toggles between checked and unchecked states. Checkboxes are commonly used in forms and lists to enable users to make multiple selections efficiently.
+packageName: checkbox
+title: Checkbox
+---
+
+### Variants
+
+Use `warning`, `danger` or `success` to add a variant color on your checkbox. The label or hint are set with Label or Field component.
+
+<div data-playground="variants.tsx" data-component="Checkbox"></div>

--- a/lib/src/components/Checkbox/docs/properties.json
+++ b/lib/src/components/Checkbox/docs/properties.json
@@ -1,0 +1,67 @@
+{
+  "Checkbox": {
+    "props": {
+      "indeterminate": {
+        "defaultValue": {
+          "value": false
+        },
+        "description": "",
+        "name": "indeterminate",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Checkbox/types.ts",
+          "name": "CheckboxOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Checkbox/types.ts",
+            "name": "CheckboxOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "variant": {
+        "defaultValue": null,
+        "description": "",
+        "name": "variant",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Checkbox/types.ts",
+          "name": "CheckboxOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Checkbox/types.ts",
+            "name": "CheckboxOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "Variant",
+          "value": [
+            {
+              "value": "\"danger\""
+            },
+            {
+              "value": "\"success\""
+            },
+            {
+              "value": "\"warning\""
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/lib/src/components/Checkbox/index.tsx
+++ b/lib/src/components/Checkbox/index.tsx
@@ -1,0 +1,38 @@
+import { Checkbox as AriaKitCheckbox } from '@ariakit/react'
+import React, { forwardRef } from 'react'
+
+import { classNames } from '@/utils'
+
+import checkboxStyles from './checkbox.module.scss'
+import type { CheckboxProps } from './types'
+
+const cx = classNames(checkboxStyles)
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  (
+    { checked = false, className, indeterminate = false, name, onChange, variant, ...rest },
+    ref
+  ) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      e.target.checked = !e.target.checked
+      if (onChange) onChange(e)
+    }
+
+    return (
+      <AriaKitCheckbox
+        checked={checked}
+        className={cx(
+          'root',
+          variant && `variant-${variant}`,
+          indeterminate && 'indeterminate',
+          className
+        )}
+        id={name}
+        name={name}
+        onChange={handleChange}
+        ref={ref}
+        {...rest}
+      />
+    )
+  }
+)

--- a/lib/src/components/Checkbox/tests/index.test.tsx
+++ b/lib/src/components/Checkbox/tests/index.test.tsx
@@ -1,0 +1,52 @@
+import { screen } from '@testing-library/react'
+import { useState } from 'react'
+
+import { render } from '@tests'
+
+import { Checkbox } from '../'
+import type { CheckboxProps } from '../types'
+
+const CheckboxWrapper = (props: CheckboxProps) => {
+  const [value, setValue] = useState(false)
+
+  const handleChange = () => {
+    setValue(!value)
+  }
+
+  return (
+    <Checkbox
+      checked={value}
+      data-testid="checkbox"
+      name="checkbox"
+      onChange={handleChange}
+      {...props}
+    />
+  )
+}
+
+describe('<Checkbox />', () => {
+  it('should toggle checked attribute on click', async () => {
+    const { user } = render(<CheckboxWrapper />)
+
+    const checkbox = screen.getByTestId('checkbox')
+
+    expect(checkbox.getAttribute('aria-checked')).toBe('false')
+
+    await user.click(checkbox)
+
+    expect(checkbox.getAttribute('aria-checked')).toBe('true')
+
+    await user.click(checkbox)
+
+    expect(checkbox.getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('should do nothing on click on disabled checkbox', async () => {
+    render(<CheckboxWrapper disabled />)
+
+    const checkbox = screen.getByTestId('checkbox')
+
+    expect(checkbox.getAttribute('aria-checked')).toBe('false')
+    expect(checkbox).toBeDisabled()
+  })
+})

--- a/lib/src/components/Checkbox/types.ts
+++ b/lib/src/components/Checkbox/types.ts
@@ -1,0 +1,10 @@
+import type { ComponentProps } from 'react'
+
+export interface CheckboxOptions {
+  indeterminate?: boolean
+  variant?: Variant
+}
+
+export type CheckboxProps = CheckboxOptions & ComponentProps<'input'>
+
+export type Variant = 'danger' | 'success' | 'warning'

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -5,6 +5,7 @@
 @import '../../lib/src/components/Alert/alert.module.scss';
 @import '../../lib/src/components/AspectRatio/aspect-ratio.module.scss';
 @import '../../lib/src/components/Button/button.module.scss';
+@import '../../lib/src/components/Checkbox/checkbox.module.scss';
 @import '../../lib/src/components/Icon/icon.module.scss';
 @import '../../lib/src/components/InputText/input-text.module.scss';
 @import '../../lib/src/components/Label/label.module.scss';
@@ -21,6 +22,8 @@
 @import '../../lib/src/components/Toast/toast.module.scss';
 @import '../../lib/src/components/Toggle/toggle.module.scss';
 @import '../../lib/src/components/VariantIcon/variant-icon.module.scss';
+@import '../../lib/src//components/Tag/tag.module.scss';
+@import '../../lib/src/components/Loader/loader.module.scss';
 
 @source '../../lib/src/**/*.{ts,tsx}';
 

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -49,6 +49,8 @@ export default {
   "/Card/docs/examples/content.tsx": dynamic(() => import("../../lib/src/components/Card/docs/examples/content.tsx").then(mod => mod), { ssr: false }),
   "/Card/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/Card/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/Card/docs/examples/picture.tsx": dynamic(() => import("../../lib/src/components/Card/docs/examples/picture.tsx").then(mod => mod), { ssr: false }),
+  "/Checkbox/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/Checkbox/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
+  "/Checkbox/docs/examples/variants.tsx": dynamic(() => import("../../lib/src/components/Checkbox/docs/examples/variants.tsx").then(mod => mod), { ssr: false }),
   "/CloseButton/docs/examples/animate-presence.tsx": dynamic(() => import("../../lib/src/components/CloseButton/docs/examples/animate-presence.tsx").then(mod => mod), { ssr: false }),
   "/CloseButton/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/CloseButton/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/DropdownMenu/docs/examples/arrow.tsx": dynamic(() => import("../../lib/src/components/DropdownMenu/docs/examples/arrow.tsx").then(mod => mod), { ssr: false }),


### PR DESCRIPTION
Migrate Checkbox component to tailwind css:
- [x] Add module scss and use className
- [x] Delete docs with Field, Label or Hint examples, should be in each component example
- [x] Migrate test with correct props

Notable, but non-breaking, change:
- use mask css property to set the check icon svg to be able to change the color of the icon when disabled with background color css property. Before, we used content with a dynamic value on the svg fill property.