### PR TITLE
fix(button-group): missing layer component to override with tailwind

### DIFF
--- a/lib/src/components/ButtonGroup/button-group.module.scss
+++ b/lib/src/components/ButtonGroup/button-group.module.scss
@@ -1,29 +1,31 @@
-.root {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  margin-top: -3px;
+@layer components {
+  .root {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-top: -3px;
 
-  > * {
-    margin-top: 3px;
+    > * {
+      margin-top: 3px;
 
-    &:not(:only-child) {
-      &:not(:last-child) {
-        border-right-color: rgba(255, 255, 255, 0.4);
-      }
+      &:not(:only-child) {
+        &:not(:last-child) {
+          border-right-color: rgba(255, 255, 255, 0.4);
+        }
 
-      &:first-child {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-      }
+        &:first-child {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
 
-      &:last-child {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-      }
+        &:last-child {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+        }
 
-      &:not(:last-child):not(:first-child) {
-        border-radius: 0;
+        &:not(:last-child):not(:first-child) {
+          border-radius: 0;
+        }
       }
     }
   }


### PR DESCRIPTION
## DESCRIPTION

This pull request makes a minor update to the `button-group.module.scss` file, introducing a new CSS layer for the ButtonGroup component to be able to override with tailwind.

* Added the `@layer components` directive to wrap the ButtonGroup styles, improving maintainability and preventing style conflicts. [[1]](diffhunk://#diff-16ec23437e4ab78956221bf0777cab88584a7c662d27d0b21b73c7102fdc0098R1) [[2]](diffhunk://#diff-16ec23437e4ab78956221bf0777cab88584a7c662d27d0b21b73c7102fdc0098R32)

