### PR TITLE
chore: migrate the Avatar component to be tailwind-compatible

### DIFF
--- a/lib/src/components/Avatar/avatar.module.scss
+++ b/lib/src/components/Avatar/avatar.module.scss
@@ -1,0 +1,76 @@
+@layer components {
+  .root {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+
+    width: var(--avatar-width);
+    height: var(--avatar-width);
+    font-size: calc(var(--avatar-width) / 2.5);
+
+    img {
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
+    }
+
+    p {
+      font-weight: 500;
+      font-size: inherit;
+      color: var(--color-neutral-90);
+    }
+  }
+
+  .size {
+    &-sm {
+      --avatar-width: 20px;
+    }
+
+    &-md {
+      --avatar-width: 30px;
+    }
+
+    &-lg {
+      --avatar-width: 40px;
+    }
+
+    &-xl {
+      --avatar-width: 50px;
+    }
+
+    &-xxl {
+      --avatar-width: 60px;
+    }
+  }
+
+  .background {
+    &-secondary-blue {
+      background-color: var(--color-secondary-blue);
+    }
+
+    &-secondary-green {
+      background-color: var(--color-secondary-green);
+    }
+
+    &-secondary-orange {
+      background-color: var(--color-secondary-orange);
+    }
+
+    &-secondary-pink {
+      background-color: var(--color-secondary-pink);
+    }
+
+    &-secondary-teal {
+      background-color: var(--color-secondary-teal);
+    }
+
+    &-secondary-violet {
+      background-color: var(--color-secondary-violet);
+    }
+  }
+}

--- a/lib/src/components/Avatar/avatar.module.scss
+++ b/lib/src/components/Avatar/avatar.module.scss
@@ -9,42 +9,38 @@
     aspect-ratio: 1 / 1;
     border-radius: 50%;
 
-    width: var(--avatar-width);
-    height: var(--avatar-width);
-    font-size: calc(var(--avatar-width) / 2.5);
+    width: var(--avatar-size);
+    height: var(--avatar-size);
+    font-size: calc(var(--avatar-size) / 2.5);
+    color: var(--color-neutral-90);
+    font-weight: 500;
 
     img {
       object-fit: cover;
       width: 100%;
       height: 100%;
     }
-
-    p {
-      font-weight: 500;
-      font-size: inherit;
-      color: var(--color-neutral-90);
-    }
   }
 
   .size {
     &-sm {
-      --avatar-width: 20px;
+      --avatar-size: 1.25rem; // 20px
     }
 
     &-md {
-      --avatar-width: 30px;
+      --avatar-size: 1.875rem; // 30px
     }
 
     &-lg {
-      --avatar-width: 40px;
+      --avatar-size: 2.5rem; // 40px
     }
 
     &-xl {
-      --avatar-width: 50px;
+      --avatar-size: 3.125rem; // 50px
     }
 
     &-xxl {
-      --avatar-width: 60px;
+      --avatar-size: 3.75rem; // 60px
     }
   }
 

--- a/lib/src/components/Avatar/docs/examples/images.tsx
+++ b/lib/src/components/Avatar/docs/examples/images.tsx
@@ -1,0 +1,20 @@
+import { Avatar } from '@/components/Avatar'
+
+const Example = () => {
+  return (
+    <>
+      <Avatar
+        name="Welcome jungle"
+        size="xxl"
+        src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"
+      />
+      <Avatar
+        name="Custom"
+        size="xxl"
+        src="https://images.unsplash.com/photo-1517849845537-4d257902454a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=500&q=80"
+      />
+    </>
+  )
+}
+
+export default Example

--- a/lib/src/components/Avatar/docs/examples/overview.tsx
+++ b/lib/src/components/Avatar/docs/examples/overview.tsx
@@ -1,0 +1,12 @@
+import { Avatar } from '@/components/Avatar'
+
+const Example = () => {
+  return (
+    <Avatar
+      name="Welcome jungle"
+      src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"
+    />
+  )
+}
+
+export default Example

--- a/lib/src/components/Avatar/docs/examples/sizes.tsx
+++ b/lib/src/components/Avatar/docs/examples/sizes.tsx
@@ -25,7 +25,7 @@ const Example = () => {
         src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"
       />
       <Avatar
-        className="w-[130px] h-[130px]"
+        className="size-[130px]"
         name="Custom value"
         src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"
       />

--- a/lib/src/components/Avatar/docs/examples/sizes.tsx
+++ b/lib/src/components/Avatar/docs/examples/sizes.tsx
@@ -1,0 +1,36 @@
+import { Avatar } from '@/components/Avatar'
+
+const Example = () => {
+  return (
+    <>
+      <Avatar
+        name="Small"
+        size="sm"
+        src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"
+      />
+      <Avatar name="Medium" src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4" />
+      <Avatar
+        name="Large"
+        size="lg"
+        src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"
+      />
+      <Avatar
+        name="Extra Larga"
+        size="xl"
+        src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"
+      />
+      <Avatar
+        name="XX Large"
+        size="xxl"
+        src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"
+      />
+      <Avatar
+        className="w-[130px] h-[130px]"
+        name="Custom value"
+        src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"
+      />
+    </>
+  )
+}
+
+export default Example

--- a/lib/src/components/Avatar/docs/examples/texts.tsx
+++ b/lib/src/components/Avatar/docs/examples/texts.tsx
@@ -8,7 +8,7 @@ const Example = () => {
       <Avatar name="Wel" size="lg" />
       <Avatar name="Welc" size="xl" />
       <Avatar name="Welco" size="xxl" />
-      <Avatar className="bg-brand-40 w-[130px] h-[130px] text-[60px]" name="Custom" size="lg" />
+      <Avatar className="bg-brand-40 size-[130px] text-[60px]" name="Custom" />
     </>
   )
 }

--- a/lib/src/components/Avatar/docs/examples/texts.tsx
+++ b/lib/src/components/Avatar/docs/examples/texts.tsx
@@ -1,0 +1,16 @@
+import { Avatar } from '@/components/Avatar'
+
+const Example = () => {
+  return (
+    <>
+      <Avatar name="W" size="sm" />
+      <Avatar name="We" size="md" />
+      <Avatar name="Wel" size="lg" />
+      <Avatar name="Welc" size="xl" />
+      <Avatar name="Welco" size="xxl" />
+      <Avatar className="bg-brand-40 w-[130px] h-[130px] text-[60px]" name="Custom" size="lg" />
+    </>
+  )
+}
+
+export default Example

--- a/lib/src/components/Avatar/docs/index.mdx
+++ b/lib/src/components/Avatar/docs/index.mdx
@@ -1,0 +1,26 @@
+---
+category: data-display
+description: The Avatar component displays a user's profile picture or initials in a circular or square format. It helps create a personalized and recognizable interface element, representing users visually across different parts of the application.
+packageName: avatar
+title: Avatar
+---
+
+### Size
+
+You can use a size from the theme or override with a specific value e.g. `size="md"` or `size="100px"`.
+
+<div data-playground="sizes.tsx" data-component="Avatar"></div>
+
+### Image
+
+Pass an image url with `src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"`.
+
+<div data-playground="images.tsx" data-component="Avatar"></div>
+
+### Only text
+
+If no image is provided we create a two-letter initial based on the name. We choose a random colour from `secondary-xxx` theme colours for the background. Font size is calculated automatically.
+
+Note: if overriding the size, you must specify both a width and height to maintain the aspect-ratio and a (rational) font-size.
+
+<div data-playground="texts.tsx" data-component="Avatar"></div>

--- a/lib/src/components/Avatar/docs/properties.json
+++ b/lib/src/components/Avatar/docs/properties.json
@@ -1,0 +1,121 @@
+{
+  "Avatar": {
+    "props": {
+      "className": {
+        "defaultValue": null,
+        "description": "",
+        "name": "className",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+          "name": "AvatarOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+            "name": "AvatarOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "getInitials": {
+        "defaultValue": null,
+        "description": "",
+        "name": "getInitials",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+          "name": "AvatarOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+            "name": "AvatarOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "(name: string) => string"
+        }
+      },
+      "name": {
+        "defaultValue": null,
+        "description": "",
+        "name": "name",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+          "name": "AvatarOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+            "name": "AvatarOptions"
+          }
+        ],
+        "required": true,
+        "type": {
+          "name": "string"
+        }
+      },
+      "size": {
+        "defaultValue": {
+          "value": "md"
+        },
+        "description": "",
+        "name": "size",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+          "name": "AvatarOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+            "name": "AvatarOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "Size",
+          "value": [
+            {
+              "value": "\"sm\""
+            },
+            {
+              "value": "\"md\""
+            },
+            {
+              "value": "\"lg\""
+            },
+            {
+              "value": "\"xl\""
+            },
+            {
+              "value": "\"xxl\""
+            }
+          ]
+        }
+      },
+      "src": {
+        "defaultValue": null,
+        "description": "",
+        "name": "src",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+          "name": "AvatarOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+            "name": "AvatarOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      }
+    }
+  }
+}

--- a/lib/src/components/Avatar/docs/properties.json
+++ b/lib/src/components/Avatar/docs/properties.json
@@ -1,36 +1,17 @@
 {
   "Avatar": {
     "props": {
-      "className": {
-        "defaultValue": null,
-        "description": "",
-        "name": "className",
-        "parent": {
-          "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
-          "name": "AvatarOptions"
-        },
-        "declarations": [
-          {
-            "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
-            "name": "AvatarOptions"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string"
-        }
-      },
       "getInitials": {
         "defaultValue": null,
         "description": "",
         "name": "getInitials",
         "parent": {
-          "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+          "fileName": "welcome-ui/lib/src/components/Avatar/types.ts",
           "name": "AvatarOptions"
         },
         "declarations": [
           {
-            "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+            "fileName": "welcome-ui/lib/src/components/Avatar/types.ts",
             "name": "AvatarOptions"
           }
         ],
@@ -44,12 +25,12 @@
         "description": "",
         "name": "name",
         "parent": {
-          "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+          "fileName": "welcome-ui/lib/src/components/Avatar/types.ts",
           "name": "AvatarOptions"
         },
         "declarations": [
           {
-            "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+            "fileName": "welcome-ui/lib/src/components/Avatar/types.ts",
             "name": "AvatarOptions"
           }
         ],
@@ -65,12 +46,12 @@
         "description": "",
         "name": "size",
         "parent": {
-          "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+          "fileName": "welcome-ui/lib/src/components/Avatar/types.ts",
           "name": "AvatarOptions"
         },
         "declarations": [
           {
-            "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+            "fileName": "welcome-ui/lib/src/components/Avatar/types.ts",
             "name": "AvatarOptions"
           }
         ],
@@ -102,12 +83,12 @@
         "description": "",
         "name": "src",
         "parent": {
-          "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+          "fileName": "welcome-ui/lib/src/components/Avatar/types.ts",
           "name": "AvatarOptions"
         },
         "declarations": [
           {
-            "fileName": "welcome-ui/lib/src/components/Avatar/index.tsx",
+            "fileName": "welcome-ui/lib/src/components/Avatar/types.ts",
             "name": "AvatarOptions"
           }
         ],

--- a/lib/src/components/Avatar/index.tsx
+++ b/lib/src/components/Avatar/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+import { classNames } from '@/utils'
+import type { CreateWuiProps } from '@old/System'
+import { forwardRef } from '@old/System'
+import { Text } from '@old/Text'
+
+import styles from './avatar.module.scss'
+import type { Size } from './types'
+import { getInitials as defaultGetInitials, getColorFromName } from './utils'
+
+const cx = classNames(styles)
+
+export interface AvatarOptions {
+  className?: string
+  getInitials?: (name: string) => string
+  name: string
+  size?: Size
+  src?: string
+}
+
+export type AvatarProps = CreateWuiProps<'div', AvatarOptions>
+
+export const colors = [
+  'secondary-blue',
+  'secondary-green',
+  'secondary-orange',
+  'secondary-pink',
+  'secondary-teal',
+  'secondary-violet',
+] as const
+
+export const Avatar: React.FC<AvatarProps> = forwardRef<'div', AvatarProps>(
+  ({ className, getInitials = defaultGetInitials, name, size = 'md', src }, ref) => {
+    // Get default color based on name length
+    const color = getColorFromName(name)
+
+    return (
+      <div
+        aria-label={name}
+        className={cx('root', size && `size-${size}`, color && `background-${color}`, className)}
+        ref={ref}
+        role="img"
+      >
+        {src ? (
+          <img alt={name} src={src} />
+        ) : (
+          <Text className="m-0" fontSize="inherit">
+            {getInitials(name)}
+          </Text>
+        )}
+      </div>
+    )
+  }
+)

--- a/lib/src/components/Avatar/index.tsx
+++ b/lib/src/components/Avatar/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 
 import { classNames } from '@/utils'
-import type { CreateWuiProps } from '@old/System'
 import { forwardRef } from '@old/System'
-import { Text } from '@old/Text'
 
 import styles from './avatar.module.scss'
 import type { Size } from './types'
@@ -11,15 +9,13 @@ import { getInitials as defaultGetInitials, getColorFromName } from './utils'
 
 const cx = classNames(styles)
 
-export interface AvatarOptions {
+export interface AvatarProps {
   className?: string
   getInitials?: (name: string) => string
   name: string
   size?: Size
   src?: string
 }
-
-export type AvatarProps = CreateWuiProps<'div', AvatarOptions>
 
 export const colors = [
   'secondary-blue',
@@ -42,13 +38,7 @@ export const Avatar: React.FC<AvatarProps> = forwardRef<'div', AvatarProps>(
         ref={ref}
         role="img"
       >
-        {src ? (
-          <img alt={name} src={src} />
-        ) : (
-          <Text className="m-0" fontSize="inherit">
-            {getInitials(name)}
-          </Text>
-        )}
+        {src ? <img alt={name} src={src} /> : <p>{getInitials(name)}</p>}
       </div>
     )
   }

--- a/lib/src/components/Avatar/index.tsx
+++ b/lib/src/components/Avatar/index.tsx
@@ -4,18 +4,10 @@ import { classNames } from '@/utils'
 import { forwardRef } from '@old/System'
 
 import styles from './avatar.module.scss'
-import type { Size } from './types'
+import type { AvatarProps } from './types'
 import { getInitials as defaultGetInitials, getColorFromName } from './utils'
 
 const cx = classNames(styles)
-
-export interface AvatarProps {
-  className?: string
-  getInitials?: (name: string) => string
-  name: string
-  size?: Size
-  src?: string
-}
 
 export const colors = [
   'secondary-blue',

--- a/lib/src/components/Avatar/index.tsx
+++ b/lib/src/components/Avatar/index.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
+import { forwardRef } from 'react'
 
 import { classNames } from '@/utils'
-import { forwardRef } from '@old/System'
 
 import styles from './avatar.module.scss'
 import type { AvatarProps } from './types'
@@ -18,7 +17,7 @@ export const colors = [
   'secondary-violet',
 ] as const
 
-export const Avatar: React.FC<AvatarProps> = forwardRef<'div', AvatarProps>(
+export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
   ({ className, getInitials = defaultGetInitials, name, size = 'md', src }, ref) => {
     // Get default color based on name length
     const color = getColorFromName(name)

--- a/lib/src/components/Avatar/tests/index.test.tsx
+++ b/lib/src/components/Avatar/tests/index.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react'
+import { render } from '@tests'
 
-import { render } from '../../../../tests/index'
 import { Avatar } from '../index'
 
 describe('<Avatar>', () => {

--- a/lib/src/components/Avatar/tests/index.test.tsx
+++ b/lib/src/components/Avatar/tests/index.test.tsx
@@ -1,0 +1,30 @@
+import { screen } from '@testing-library/react'
+
+import { render } from '../../../../tests/index'
+import { Avatar } from '../index'
+
+describe('<Avatar>', () => {
+  it('should render without image and 2 words', () => {
+    render(<Avatar name="welcome jungle" />)
+
+    expect(screen.getByText('WJ')).toBeInTheDocument()
+  })
+
+  it('should render without image and 1 word', () => {
+    render(<Avatar name="welcomejungle" />)
+
+    expect(screen.getByText('WE')).toBeInTheDocument()
+  })
+
+  it('should render with an image', async () => {
+    render(
+      <Avatar
+        name="welcome jungle"
+        src="https://avatars3.githubusercontent.com/u/13100706?s=200&v=4"
+      />
+    )
+
+    expect(screen.getByAltText('welcome jungle')).toBeInTheDocument()
+    expect(await screen.queryByText('WJ')).toBeNull()
+  })
+})

--- a/lib/src/components/Avatar/tests/utils.test.ts
+++ b/lib/src/components/Avatar/tests/utils.test.ts
@@ -1,0 +1,38 @@
+import { getColorFromName, getInitials } from '../utils'
+
+describe('getColorFromName', () => {
+  it('returns a secondary color key based on text length', () => {
+    expect(getColorFromName('a')).toBe('secondary-green')
+    expect(getColorFromName('ab')).toBe('secondary-orange')
+    expect(getColorFromName('abc')).toBe('secondary-pink')
+    expect(getColorFromName('abcd')).toBe('secondary-teal')
+  })
+
+  it('returns the first secondary color for empty text', () => {
+    expect(getColorFromName('')).toBe('secondary-blue')
+  })
+
+  it('ignores non-secondary keys', () => {
+    expect(getColorFromName('a')).toBe('secondary-green')
+  })
+})
+
+describe('getInitials', () => {
+  it('returns initials for two words', () => {
+    expect(getInitials('John Doe')).toBe('JD')
+    expect(getInitials('alice smith')).toBe('AS')
+  })
+
+  it('returns first two letters for single word', () => {
+    expect(getInitials('Bob')).toBe('BO')
+    expect(getInitials('a')).toBe('A')
+  })
+
+  it('handles accents', () => {
+    expect(getInitials('Émile Douglas')).toBe('ÉD')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(getInitials('')).toBe('')
+  })
+})

--- a/lib/src/components/Avatar/types.ts
+++ b/lib/src/components/Avatar/types.ts
@@ -1,5 +1,13 @@
 import type { colors } from './index'
 
+export interface AvatarProps {
+  className?: string
+  getInitials?: (name: string) => string
+  name: string
+  size?: Size
+  src?: string
+}
+
 export type Colors = (typeof colors)[number]
 
 // we want to keep Size in a natural order for documentation

--- a/lib/src/components/Avatar/types.ts
+++ b/lib/src/components/Avatar/types.ts
@@ -1,12 +1,15 @@
+import type { PolymorphicProps } from '@/theme/types'
+
 import type { colors } from './index'
 
-export interface AvatarProps {
-  className?: string
+export interface AvatarOptions {
   getInitials?: (name: string) => string
   name: string
   size?: Size
   src?: string
 }
+
+export type AvatarProps<T extends React.ElementType = 'div'> = AvatarOptions & PolymorphicProps<T>
 
 export type Colors = (typeof colors)[number]
 

--- a/lib/src/components/Avatar/types.ts
+++ b/lib/src/components/Avatar/types.ts
@@ -1,0 +1,7 @@
+import type { colors } from './index'
+
+export type Colors = (typeof colors)[number]
+
+// we want to keep Size in a natural order for documentation
+// eslint-disable-next-line perfectionist/sort-union-types
+export type Size = 'sm' | 'md' | 'lg' | 'xl' | 'xxl'

--- a/lib/src/components/Avatar/utils.ts
+++ b/lib/src/components/Avatar/utils.ts
@@ -1,0 +1,18 @@
+import type { Colors } from './types'
+
+import { colors } from '.'
+
+export function getInitials(name = ''): string {
+  const [firstWord, lastWord] = name.split(' ')
+
+  if (firstWord && lastWord) {
+    return `${firstWord.charAt(0).toUpperCase()}${lastWord.charAt(0).toUpperCase()}`
+  } else {
+    return firstWord.substring(0, 2).toUpperCase()
+  }
+}
+
+export const getColorFromName = (name: string): Colors => {
+  const index = name.length % colors.length
+  return colors[index] as Colors
+}

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -6,6 +6,10 @@ This file is auto-generate with yarn watch command, do not change it directly!
 import dynamic from "next/dynamic";
 
 export default {
+  "/Avatar/docs/examples/images.tsx": dynamic(() => import("../../lib/src/components/Avatar/docs/examples/images.tsx").then(mod => mod), { ssr: false }),
+  "/Avatar/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/Avatar/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
+  "/Avatar/docs/examples/sizes.tsx": dynamic(() => import("../../lib/src/components/Avatar/docs/examples/sizes.tsx").then(mod => mod), { ssr: false }),
+  "/Avatar/docs/examples/texts.tsx": dynamic(() => import("../../lib/src/components/Avatar/docs/examples/texts.tsx").then(mod => mod), { ssr: false }),
   "/Button/docs/examples/ai.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/ai.tsx").then(mod => mod), { ssr: false }),
   "/Button/docs/examples/danger.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/danger.tsx").then(mod => mod), { ssr: false }),
   "/Button/docs/examples/disabled.tsx": dynamic(() => import("../../lib/src/components/Button/docs/examples/disabled.tsx").then(mod => mod), { ssr: false }),


### PR DESCRIPTION
## DESCRIPTION

Breaking changes:

- No more `color` prop. Override color using Tailwind instead (e.g. `<Avatar className="bg-brand-40" />`)
- No more `w` or `h` prop. Override size using Tailwind `size` (e.g. `<Avatar className="size-[100px]" />`)

## SCREENSHOTS / SCREEN RECORDINGS

<img width="688" height="865" alt="image" src="https://github.com/user-attachments/assets/f5fe7d5f-4c63-49e3-8eb5-2521cbb76ecb" />

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [x] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [x] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
