### PR TITLE
Chore: migrate import to use and namespaced include

### DIFF
--- a/lib/src/components/Select/select.module.scss
+++ b/lib/src/components/Select/select.module.scss
@@ -1,4 +1,4 @@
-@import './../../utils/text-ellipsis.scss';
+@use './../../utils/text-ellipsis' as ellipsis;
 
 @layer components {
   .root {
@@ -19,7 +19,7 @@
     transition-timing-function: var(--timing-primary);
     transition-duration: var(--duration-medium);
     appearance: none;
-    @include text-ellipsis;
+    @include ellipsis.text-ellipsis;
 
     height: var(--select-height);
     padding-bottom: var(--select-padding-bottom);
@@ -109,7 +109,7 @@
         left: 0;
         padding: inherit;
         color: var(--select-placeholder-color);
-        @include text-ellipsis;
+        @include ellipsis.text-ellipsis;
       }
 
       &::before {
@@ -253,7 +253,7 @@
     transition-property: background;
     transition-duration: var(--duration-medium);
     transition-timing-function: var(--timing-primary);
-    @include text-ellipsis;
+    @include ellipsis.text-ellipsis;
 
     &.highlighted {
       background-color: var(--color-beige-20);

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -8,7 +8,7 @@ export default {
         'at-rule-no-unknown': [
           true,
           {
-            ignoreAtRules: ['apply', 'theme', 'mixin', 'include', 'source'],
+            ignoreAtRules: ['apply', 'theme', 'mixin', 'source', 'use'],
           },
         ],
         'selector-pseudo-class-no-unknown': [


### PR DESCRIPTION
### So long @import, it's been fun 
This pull request updates how the `text-ellipsis` mixin is imported and used in the `Select` component styles, switching from `@import` to `@use`: 

`@import` is **deprecated** in Sass. It is recommended to use the `@use` and `@forward` rules instead. These newer rules provide better modularity, scoping, and performance for managing styles.

### Why is `@import` deprecated?
- **Global namespace pollution**: `@import` makes all imported variables, mixins, and functions globally available, which can lead to conflicts.
- **Performance issues**: `@import` can result in the same file being imported multiple times, leading to redundant processing.
- **Lack of clarity**: It doesn't clearly indicate which files are dependencies or how they are used.

### What to use instead?
Use `@use` to import files. It ensures that styles, variables, and mixins are scoped to the imported file, avoiding global namespace pollution.

### Example:
If you have a file text-ellipsis.scss:

```scss
@mixin text-ellipsis {
  white-space: nowrap;
  overflow: hidden;
  text-overflow: ellipsis;
}
```

You can replace `@import` with `@use`:

```scss
@use './../../utils/text-ellipsis' as ellipsis;

@layer components {
  .root {
    @include ellipsis.text-ellipsis;
  }
}
```

### Key differences:
- With `@use`, you must prefix imported members (e.g., `ellipsis.text-ellipsis`) unless you use `as *` to import everything globally (not recommended).
- `@use` improves maintainability and avoids conflicts.

You should gradually migrate from `@import` to `@use` in your project.

* Changed `@import` to `@use` for the `text-ellipsis` mixin in `select.module.scss`, and updated all usages to reference the mixin via the `ellipsis` namespace. [[1]](diffhunk://#diff-35b9ead320e9efe931d67525869092f6921bd6a24a89364584bdafb25809a9bcL1-R1) [[2]](diffhunk://#diff-35b9ead320e9efe931d67525869092f6921bd6a24a89364584bdafb25809a9bcL22-R22) [[3]](diffhunk://#diff-35b9ead320e9efe931d67525869092f6921bd6a24a89364584bdafb25809a9bcL112-R112) [[4]](diffhunk://#diff-35b9ead320e9efe931d67525869092f6921bd6a24a89364584bdafb25809a9bcL256-R256)

* Added `use` to the list of ignored at-rules in `stylelint.config.mjs` to prevent linting errors with the new SCSS `@use` syntax.