### PR TITLE
fix: tailwind spacing-0 based utility classes

### DIFF
--- a/lib/src/theme/theme.css
+++ b/lib/src/theme/theme.css
@@ -182,7 +182,7 @@
 
 @theme {
   --*: initial;
-
+ 
   /* ===== PRIMITIVES ===== */
 
   /* borders */
@@ -292,9 +292,9 @@
   --color-yellow-90: #423500;
 
   /* fontFamilies */
-  --default-font-family: 'Work Sans', sans-serif;
-  --font-family-headings: 'welcome-font', sans-serif;
-  --font-family-icons: 'welcome-icon-font';
+  --default-font-family: "Work Sans", sans-serif;
+  --font-family-headings: "welcome-font", sans-serif;
+  --font-family-icons: "welcome-icon-font";
 
   /* fontSizes */
   --font-size-10: 0.625rem; /* 10px */
@@ -381,6 +381,7 @@
   --shadow-sm: 1px 2px 4px 0 color-mix(in oklab, var(--color-neutral-90) 5%, transparent);
 
   /* spacings */
+  --spacing-0: 0;
   --spacing-2: 0.125rem; /* 2px */
   --spacing-4: 0.25rem; /* 4px */
   --spacing-8: 0.5rem; /* 8px */

--- a/lib/src/theme/tokens.ts
+++ b/lib/src/theme/tokens.ts
@@ -190,6 +190,7 @@ export const primitives = {
     '--font-family-icons': '"welcome-icon-font"',
   },
   fontSizes: {
+    '--font-size-10': '0.625rem',
     '--font-size-11': '0.6875rem',
     '--font-size-12': '0.75rem',
     '--font-size-13': '0.8125rem',
@@ -273,6 +274,7 @@ export const primitives = {
     '--shadow-sm': '1px 2px 4px 0 color-mix(in oklab, var(--color-neutral-90) 5%, transparent)',
   },
   spacings: {
+    '--spacing-0': '0',
     '--spacing-2': '0.125rem',
     '--spacing-4': '0.25rem',
     '--spacing-8': '0.5rem',


### PR DESCRIPTION
This pull request makes minor updates to the theme configuration, focusing on font family formatting and adding a new font size token.

Theme variable updates:

* Standardized the quotation style for font family variables in `theme.css` to use double quotes for consistency.
* Added a new `--font-size-10` token (0.625rem) to the `fontSizes` section in `tokens.ts` instead of `theme.css` which is a generated file ⚠️ 