### PR TITLE
Chore: infer screen hook keys from theme

### DIFF
--- a/lib/src/utils/use-screens.test.ts
+++ b/lib/src/utils/use-screens.test.ts
@@ -1,0 +1,25 @@
+// import * as tokens from '@/theme/tokens'
+
+import { useScreens } from './use-screens'
+
+vi.mock('@/theme/tokens', () => ({
+  primitives: {
+    screens: {
+      '--breakpoint-md': '768px',
+      '--breakpoint-sm': '640px',
+      mobile: '24rem',
+      tablet: 380,
+    },
+  },
+}))
+
+describe('useScreens', () => {
+  it('should return the correct screen sizes', async () => {
+    const screens = useScreens()
+    expect(screens).toEqual({
+      md: 768,
+      sm: 640,
+      tablet: 380,
+    })
+  })
+})

--- a/lib/src/utils/use-screens.ts
+++ b/lib/src/utils/use-screens.ts
@@ -4,9 +4,18 @@ import { primitives } from '@/theme/tokens'
 type ScreenSize = keyof typeof primitives.screens extends `--breakpoint-${infer K}` ? K : never
 type Screens = Record<ScreenSize, number>
 
+/**
+ * A custom hook to retrieve the screen sizes defined in the theme tokens.
+ * @returns An object containing the screen sizes defined in the theme tokens,
+ * with keys as screen names and absolute values.
+ * Only supports number values (e.g. no 'rem', '%', etc.).
+ */
 export function useScreens() {
   return Object.entries(primitives.screens).reduce((acc, [key, value]) => {
-    acc[key.replace('--breakpoint-', '') as keyof Screens] = Number(value.replace('px', ''))
+    const parsedValue = typeof value === 'string' ? Number(value.replace('px', '')) : value
+    if (!isNaN(parsedValue)) {
+      acc[key.replace('--breakpoint-', '') as keyof Screens] = parsedValue
+    }
     return acc
   }, {} as Screens)
 }


### PR DESCRIPTION
This pull request updates the type definitions to dynamically infer screen size keys theme:

* Refactored the `Screens` type to dynamically infer screen size keys from `primitives.screens`, improving type safety.
* Simplified the logic in `useScreens` by switching from `Object.keys` to `Object.entries`, allowing direct access to both key and value.
* Supports arbitrary breakpoint name like `tablet` for example.
* Support absolute values 
* Ignores anything not absolute or px based