### PR TITLE
Chore: migrate Search component to tailwind [WUI-172]

### DIFF
--- a/lib/src/components/Search/docs/examples/option-groups.tsx
+++ b/lib/src/components/Search/docs/examples/option-groups.tsx
@@ -1,0 +1,56 @@
+import { Search } from '@/components/Search'
+import { Tag } from '@/components/Tag'
+import { Text } from '@/components/Text'
+
+type Acc = { movies: Item[]; series: Item[] }
+
+type Item = { Title: string; Type: 'movie' | 'serie' }
+
+const Example = () => {
+  const searchFunction = async (s: string) => {
+    const response = await fetch(`https://www.omdbapi.com?apikey=41514363&s=${s}`)
+    const data = await response.json()
+    const searchResults = (data.Search || []).reduce(
+      (acc: Acc, item: Item) => {
+        if (item.Type === 'movie') {
+          acc.movies.push(item)
+        } else {
+          acc.series.push(item)
+        }
+        return acc
+      },
+      { movies: [], series: [] }
+    )
+
+    return [
+      { label: 'Movies', options: searchResults.movies },
+      { label: 'Series', options: searchResults.series },
+    ]
+  }
+
+  return (
+    <Search
+      groupsEnabled
+      itemToString={(item: Item) => item && item.Title}
+      name="movies"
+      placeholder="Search a movie"
+      renderGroupHeader={({ label, options }) => (
+        <div className="p-var(--space-xxs)">
+          <div className="flex justify-between items-center">
+            <Text className="m-0" variant="lg">
+              {label}
+            </Text>
+            <Tag>{options.length}</Tag>
+          </div>
+          {options.length === 0 && <Text>No results found</Text>}
+        </div>
+      )}
+      renderItem={(item: Item) => (
+        <div style={{ alignItems: 'center', display: 'flex' }}>{item.Title}</div>
+      )}
+      search={searchFunction}
+    />
+  )
+}
+
+export default Example

--- a/lib/src/components/Search/docs/examples/overview.tsx
+++ b/lib/src/components/Search/docs/examples/overview.tsx
@@ -1,0 +1,25 @@
+import { Search } from '@/components/Search'
+
+type Item = { Title: string }
+
+const Example = () => {
+  const searchFunction = async (s: string) => {
+    const response = await fetch(`https://www.omdbapi.com?apikey=41514363&s=${s}`)
+    const data = await response.json()
+    return data.Search
+  }
+
+  return (
+    <Search
+      itemToString={(item: Item) => item && item.Title}
+      name="movies"
+      placeholder="Search a movie"
+      renderItem={(item: Item) => (
+        <div style={{ alignItems: 'center', display: 'flex' }}>{item.Title}</div>
+      )}
+      search={searchFunction}
+    />
+  )
+}
+
+export default Example

--- a/lib/src/components/Search/docs/index.mdx
+++ b/lib/src/components/Search/docs/index.mdx
@@ -1,0 +1,13 @@
+---
+category: forms
+description: The Search component is an input field designed for querying and retrieving information from a dataset or database. It typically includes features such as autocomplete, suggestions, and filters to enhance the search experience. This component helps users quickly find specific content or data within an application, improving overall usability and efficiency.
+packageName: search
+title: Search
+peerDependencies: 'downshift'
+---
+
+### With option groups
+
+To use option groups, you must provide two additional props: `groupsEnabled` that allow nested options and `renderGroupHeader` that renders the header of a specific group
+
+<div data-playground="option-groups.tsx" data-component="Search"></div>

--- a/lib/src/components/Search/docs/properties.json
+++ b/lib/src/components/Search/docs/properties.json
@@ -1,0 +1,383 @@
+{
+  "Search": {
+    "props": {
+      "dataTestId": {
+        "defaultValue": null,
+        "description": "",
+        "name": "dataTestId",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "groupsEnabled": {
+        "defaultValue": null,
+        "description": "",
+        "name": "groupsEnabled",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "hasIcon": {
+        "defaultValue": null,
+        "description": "",
+        "name": "hasIcon",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "icon": {
+        "defaultValue": null,
+        "description": "",
+        "name": "icon",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "ReactElement<any, string | JSXElementConstructor<any>>"
+        }
+      },
+      "iconPlacement": {
+        "defaultValue": {
+          "value": "left"
+        },
+        "description": "",
+        "name": "iconPlacement",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "\"left\" | \"right\"",
+          "value": [
+            {
+              "value": "\"left\""
+            },
+            {
+              "value": "\"right\""
+            }
+          ]
+        }
+      },
+      "itemToString": {
+        "defaultValue": null,
+        "description": "",
+        "name": "itemToString",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": true,
+        "type": {
+          "name": "(item: unknown) => string"
+        }
+      },
+      "minChars": {
+        "defaultValue": {
+          "value": 3
+        },
+        "description": "",
+        "name": "minChars",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "number"
+        }
+      },
+      "onChange": {
+        "defaultValue": null,
+        "description": "",
+        "name": "onChange",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "(item: unknown, event: CreateEvent) => void"
+        }
+      },
+      "renderGroupHeader": {
+        "defaultValue": null,
+        "description": "",
+        "name": "renderGroupHeader",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "(result: SearchOptionGroup) => ReactElement<any, string | JSXElementConstructor<any>>"
+        }
+      },
+      "renderItem": {
+        "defaultValue": null,
+        "description": "",
+        "name": "renderItem",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": true,
+        "type": {
+          "name": "(item: unknown) => string | ReactElement<any, string | JSXElementConstructor<any>>"
+        }
+      },
+      "search": {
+        "defaultValue": null,
+        "description": "",
+        "name": "search",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": true,
+        "type": {
+          "name": "(query: string) => Promise<unknown>"
+        }
+      },
+      "size": {
+        "defaultValue": {
+          "value": "md"
+        },
+        "description": "",
+        "name": "size",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "Size",
+          "value": [
+            {
+              "value": "\"xs\""
+            },
+            {
+              "value": "\"sm\""
+            },
+            {
+              "value": "\"md\""
+            },
+            {
+              "value": "\"lg\""
+            }
+          ]
+        }
+      },
+      "throttle": {
+        "defaultValue": {
+          "value": 500
+        },
+        "description": "",
+        "name": "throttle",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "number"
+        }
+      },
+      "transparent": {
+        "defaultValue": null,
+        "description": "",
+        "name": "transparent",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "boolean",
+          "value": [
+            {
+              "value": "false"
+            },
+            {
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "value": {
+        "defaultValue": {
+          "value": ""
+        },
+        "description": "",
+        "name": "value",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "unknown"
+        }
+      },
+      "variant": {
+        "defaultValue": null,
+        "description": "",
+        "name": "variant",
+        "parent": {
+          "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+          "name": "SearchOptions"
+        },
+        "declarations": [
+          {
+            "fileName": "welcome-ui/lib/src/components/Search/types.ts",
+            "name": "SearchOptions"
+          }
+        ],
+        "required": false,
+        "type": {
+          "name": "enum",
+          "raw": "\"danger\" | \"success\" | \"warning\"",
+          "value": [
+            {
+              "value": "\"danger\""
+            },
+            {
+              "value": "\"success\""
+            },
+            {
+              "value": "\"warning\""
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/lib/src/components/Search/index.test.tsx
+++ b/lib/src/components/Search/index.test.tsx
@@ -1,0 +1,202 @@
+import { screen, waitFor } from '@testing-library/react'
+
+import { AvatarIcon } from '@/components/Icon'
+
+import { render } from '@tests'
+
+import { Search } from './'
+
+type Item = {
+  poster?: string
+  title?: string
+}
+
+const results = [
+  { poster: 'big-fish.jpg', title: 'Big Fish', year: '2003' },
+  { poster: 'wanda.jpg', title: 'A Fish Called Wanda', year: '1988' },
+  { poster: 'food-tank.jpg', title: 'Food Tank', year: '2009' }, // Doesn't match 'fish'
+  { poster: 'rumble-fish.jpg', title: 'Rumble Fish', year: '1983' },
+  { poster: 'cold-fish.jpg', title: 'Cold Fish', year: '2010' },
+]
+
+export const opt_group_results = [
+  {
+    label: 'Good movies',
+    options: [
+      { poster: 'big-fish.jpg', title: 'Big Fish', year: '2003' },
+      { poster: 'wanda.jpg', title: 'A Fish Called Wanda', year: '1988' },
+      { poster: 'food-tank.jpg', title: 'Food Tank', year: '2009' }, // Doesn't match 'fish'
+    ],
+  },
+  {
+    label: 'Bad movies',
+    options: [
+      { poster: 'rumble-fish.jpg', title: 'Rumble Fish', year: '1983' },
+      { poster: 'cold-fish.jpg', title: 'Cold Fish', year: '2010' },
+    ],
+  },
+]
+
+const defaultProps = {
+  itemToString: (item: Item) => item.title,
+  renderItem: (item: Item) => (
+    <div style={{ alignItems: 'center', display: 'flex' }}>
+      <div className="mr-(var(--space-xs) w-[20px]">
+        <img src={item.poster} />
+      </div>
+      <span>{item.title}</span>
+    </div>
+  ),
+  search: async function asyncSearch(q: string) {
+    await new Promise(resolve => setTimeout(resolve, 100))
+    return results.filter(result => result.title.toLowerCase().indexOf(q) > -1)
+  },
+}
+
+describe('<Search>', () => {
+  it('<Search> has default attributes', () => {
+    render(<Search dataTestId="search" name="search" {...defaultProps} />)
+
+    const search = screen.getByTestId('search')
+
+    expect(search.getAttribute('placeholder')).toBe('Search…')
+    expect(search).toHaveTextContent('')
+  })
+
+  it('<Search> shows options when searching', async () => {
+    const { user } = render(<Search dataTestId="search" name="search" {...defaultProps} />)
+
+    const search = screen.getByTestId('search')
+    await user.type(search, 'fish')
+
+    const options = await waitFor(() => screen.getByRole('listbox').querySelectorAll('li'))
+
+    expect(options.length).toBe(4)
+    expect(options[0]).toHaveTextContent(results[0].title)
+  })
+
+  it('<Search> can choose option', async () => {
+    const { user } = render(<Search dataTestId="search" name="search" {...defaultProps} />)
+
+    const search = screen.getByTestId('search') as HTMLInputElement
+
+    await user.type(search, 'fish')
+
+    const options = await waitFor(() => screen.getByRole('listbox').querySelectorAll('li'))
+
+    await user.click(options[1])
+
+    expect(search.value).toEqual(results[1].title)
+  })
+
+  it('<Search> calls onChange with correct (object) values', async () => {
+    const handleChange = vi.fn()
+    const { user } = render(
+      <Search dataTestId="search" name="search" {...defaultProps} onChange={handleChange} />
+    )
+
+    const search = screen.getByTestId('search')
+
+    await user.type(search, 'fish')
+
+    const options = await waitFor(() => screen.getByRole('listbox').querySelectorAll('li'))
+
+    await user.click(options[1])
+
+    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(handleChange).toHaveBeenCalledWith(
+      results[1],
+      expect.objectContaining({
+        target: { name: 'search', value: results[1] },
+      }) // Ignore preventDefault
+    )
+  })
+
+  it('<Search> formats items', async () => {
+    const { user } = render(<Search dataTestId="search" name="search" {...defaultProps} />)
+
+    const search = screen.getByTestId('search')
+
+    await user.type(search, 'fish')
+
+    const options = await waitFor(() => screen.getByRole('listbox').querySelectorAll('li'))
+    const image = options[0].querySelector('img')
+
+    expect(image.getAttribute('src')).toBe('big-fish.jpg')
+  })
+
+  it('<Search icon> shows icon', () => {
+    render(
+      <Search
+        dataTestId="search"
+        icon={<AvatarIcon color="neutral-80" data-testid="icon-avatar" />}
+        name="search"
+        value="february"
+        {...defaultProps}
+      />
+    )
+
+    const icon = screen.getByTestId('icon-avatar')
+
+    expect(icon).toBeInTheDocument()
+  })
+
+  it("<Search> doesn't show list if no results", async () => {
+    const { user } = render(<Search dataTestId="search" name="search" {...defaultProps} />)
+
+    const search = screen.getByTestId('search')
+
+    await user.type(search, 'Fish')
+
+    const options = screen.queryByRole('listbox')
+    expect(options).toBeNull()
+  })
+
+  it('<Search groupsEnabled> shows groups header', async () => {
+    const { user } = render(
+      <Search
+        dataTestId="select"
+        groupsEnabled
+        name="search"
+        renderGroupHeader={({ label, options }) => (
+          <div data-testid="group-header">
+            <h4>{label}</h4>
+            <span>{options.length}</span>
+          </div>
+        )}
+        {...defaultProps}
+        search={() => Promise.resolve(opt_group_results)}
+      />
+    )
+
+    const search = screen.getByTestId('select')
+
+    await user.type(search, 'Fish')
+
+    const headers = await waitFor(() => screen.getAllByTestId('group-header'))
+
+    expect(headers.length).toBe(opt_group_results.length)
+
+    headers.forEach((header, i) => {
+      expect(header.querySelector('h4')).toHaveTextContent(opt_group_results[i].label)
+      expect(header.querySelector('span')).toHaveTextContent(
+        opt_group_results[i].options.length.toString()
+      )
+    })
+  })
+
+  it('<Search> shows options with minChars to 0', async () => {
+    const { user } = render(
+      <Search dataTestId="search" minChars={0} name="search" {...defaultProps} />
+    )
+
+    const search = screen.getByTestId('search')
+
+    await user.click(search)
+
+    const options = await waitFor(() => screen.getByRole('listbox').querySelectorAll('li'))
+
+    expect(options.length).toBe(results.length)
+    expect(options[0]).toHaveTextContent(results[0].title)
+  })
+})

--- a/lib/src/components/Search/index.tsx
+++ b/lib/src/components/Search/index.tsx
@@ -1,0 +1,269 @@
+import type { DownshiftProps, GetRootPropsOptions } from 'downshift'
+import DownshiftImport from 'downshift'
+import React, { forwardRef, Fragment, useCallback, useMemo, useState } from 'react'
+
+import { CloseButton as ClearButton } from '@/components/CloseButton'
+import { FIELD_ICON_SIZE } from '@/constants/field-icon-size'
+import { classNames } from '@/utils'
+import { createEvent } from '@/utils/create-event'
+import { throttle as handleThrottle } from '@/utils/throttle'
+
+import searchStyles from './search.module.scss'
+import type { Item, SearchOption, SearchOptionGroup, SearchProps } from './types'
+
+const EMPTY_STRING = ''
+
+const cx = classNames(searchStyles)
+
+// because of this issue: https://github.com/downshift-js/downshift/issues/1505
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const Downshift: typeof DownshiftImport = DownshiftImport.default || DownshiftImport
+
+export const Search = forwardRef<HTMLInputElement, SearchProps>(
+  (
+    {
+      autoComplete = 'off',
+      autoFocus,
+      className,
+      dataTestId,
+      disabled,
+      groupsEnabled,
+      icon,
+      iconPlacement = 'left',
+      id,
+      itemToString,
+      minChars = 3,
+      name,
+      onBlur,
+      onChange,
+      onClick,
+      onFocus,
+      placeholder = 'Search…',
+      renderGroupHeader,
+      renderItem,
+      search,
+      size = 'md',
+      throttle = 500,
+      transparent,
+      value: selected = EMPTY_STRING,
+      variant,
+      ...rest
+    },
+    ref
+  ) => {
+    // Get initial value from selected value(s)
+    const initialInputValue = selected ? itemToString(selected) : EMPTY_STRING
+
+    // Keep results in state
+    const [results, setResults] = useState<SearchOption[] | SearchOptionGroup[]>([])
+
+    // Update results when searching
+    const searchResults = useCallback(
+      async (value: string) => {
+        if (minChars === 0 || value?.length >= minChars) {
+          const data = await search(value)
+          setResults((data as SearchOption[] | SearchOptionGroup[]) || [])
+        } else {
+          setResults([])
+        }
+      },
+      [minChars, search]
+    )
+
+    const handleInputChange = useMemo(
+      () => handleThrottle(searchResults, throttle, false),
+      [searchResults, throttle]
+    )
+
+    // Send event to parent when value(s) changes
+    const handleChange = (value?: Item) => {
+      const event = createEvent({ name, value })
+      onChange?.(value, event)
+    }
+
+    const handleSelect = (result?: Item) => {
+      if (result) {
+        // If selecting result
+        handleChange(result)
+      } else {
+        // If removing result
+        handleChange()
+        setResults([])
+      }
+    }
+
+    const handleOuterClick = () => {
+      // Reset input value if not selecting a new item
+      if (!selected) {
+        handleSelect()
+      }
+      setResults([])
+    }
+
+    // prevents controlled to uncontrolled switch when itemToString returns falsy value
+    const handleItemToString = (item: Item) => itemToString(item) || ''
+
+    return (
+      <Downshift
+        initialInputValue={initialInputValue}
+        itemToString={handleItemToString}
+        onInputValueChange={handleInputChange}
+        onOuterClick={handleOuterClick}
+        onSelect={handleSelect}
+        selectedItem={selected}
+        {...(rest as DownshiftProps<Item>)}
+      >
+        {({
+          clearSelection,
+          getInputProps,
+          getItemProps,
+          getMenuProps,
+          getRootProps,
+          highlightedIndex,
+          inputValue,
+          isOpen,
+          selectedItem,
+          toggleMenu,
+        }) => {
+          const handleClearClick = () => {
+            setResults([])
+            handleChange()
+            clearSelection()
+          }
+          const isShowMenu = isOpen && results.length > 0
+          const DeleteIcon = (
+            <div className={cx('dropdown-indicator')}>
+              <ClearButton animatePresence onClick={handleClearClick} title="Clear" />
+            </div>
+          )
+          const handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+            onFocus?.(event)
+            handleInputChange('')
+            toggleMenu()
+          }
+          const rootProps = getRootProps(rest as GetRootPropsOptions, { suppressRefError: true })
+          const inputProps = getInputProps({
+            autoComplete,
+            autoFocus,
+            'data-testid': dataTestId,
+            disabled,
+            id,
+            name,
+            onBlur,
+            onClick: onClick,
+            onFocus: handleInputFocus,
+            placeholder,
+            ref,
+            size,
+            tabIndex: 0,
+            variant: isOpen ? 'focused' : variant,
+            ...rest,
+          }) as React.InputHTMLAttributes<HTMLInputElement>
+          const iconSize = FIELD_ICON_SIZE[size]
+
+          return (
+            <div {...rootProps} className={cx('wrapper')}>
+              <div className={cx('input-wrapper')}>
+                <input
+                  className={cx(
+                    'root',
+                    `size-${size}`,
+                    variant && `variant-${variant}`,
+                    transparent && 'transparent',
+                    icon && `icon-placement-${iconPlacement}`,
+                    className
+                  )}
+                  {...inputProps}
+                />
+                {icon ? (
+                  <div
+                    className={cx(
+                      'icon-wrapper',
+                      `icon-placement-${iconPlacement}`,
+                      `size-${size}`
+                    )}
+                  >
+                    {React.cloneElement(icon, { ...icon.props, size: iconSize })}
+                  </div>
+                ) : null}
+                <div className={cx('indicators', `size-${size}`)}>
+                  {inputValue ? DeleteIcon : null}
+                </div>
+              </div>
+              {isShowMenu ? (
+                <ul className={cx('menu')} {...getMenuProps()}>
+                  {
+                    (results as SearchOptionGroup[]).reduce(
+                      (acc, result, resultIndex) => {
+                        const index = acc.itemIndex++
+                        const isHighlighted = highlightedIndex === index
+
+                        if (groupsEnabled) {
+                          acc.itemsToRender.push(
+                            <Fragment key={resultIndex}>
+                              {renderGroupHeader(result as SearchOptionGroup)}
+                              {(result as SearchOptionGroup).options
+                                ? (result as SearchOptionGroup).options.map(
+                                    (option, optionIndex) => {
+                                      const isItemSelected =
+                                        selectedItem &&
+                                        itemToString(selectedItem) === itemToString(option)
+
+                                      return (
+                                        <li
+                                          className={cx(
+                                            'item',
+                                            isHighlighted && 'highlighted',
+                                            isItemSelected && 'selected'
+                                          )}
+                                          key={optionIndex}
+                                          {...getItemProps({
+                                            index,
+                                            item: option,
+                                          })}
+                                        >
+                                          {renderItem(option)}
+                                        </li>
+                                      )
+                                    }
+                                  )
+                                : null}
+                            </Fragment>
+                          )
+                        } else {
+                          const isItemSelected =
+                            selectedItem && itemToString(selectedItem) === itemToString(result)
+
+                          acc.itemsToRender.push(
+                            <li
+                              className={cx(
+                                'item',
+                                isHighlighted && 'highlighted',
+                                isItemSelected && 'selected'
+                              )}
+                              key={resultIndex}
+                              {...getItemProps({
+                                index: resultIndex,
+                                item: result,
+                              })}
+                            >
+                              {renderItem(result)}
+                            </li>
+                          )
+                        }
+
+                        return acc
+                      },
+                      { itemIndex: 0, itemsToRender: [] }
+                    ).itemsToRender
+                  }
+                </ul>
+              ) : null}
+            </div>
+          )
+        }}
+      </Downshift>
+    )
+  }
+)

--- a/lib/src/components/Search/search.module.scss
+++ b/lib/src/components/Search/search.module.scss
@@ -1,0 +1,262 @@
+@use '../../theme/utils/text-ellipsis.scss' as ellipsis;
+
+@layer components {
+  .wrapper {
+    position: relative;
+  }
+
+  .indicators {
+    position: absolute;
+    padding: 0;
+    top: 0;
+    bottom: 0;
+    right: var(--indicators-right, 0);
+    display: flex;
+    gap: var(--spacing-xs);
+  }
+
+  .dropdown-indicator {
+    position: relative;
+    height: 100%;
+    width: var(--search-clear-size);
+    padding: 0;
+    outline: none !important; /* important for firefox */
+    appearance: none;
+    cursor: pointer;
+    background: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .input-wrapper {
+    position: relative;
+
+    &:has(> .icon-placement-right) {
+      .indicators {
+        --indicators-right: calc((var(--search-icon-size, 1rem) + var(--spacing-sm)));
+      }
+    }
+  }
+
+  .root {
+    background-color: var(--search-background-color, var(--color-neutral-10));
+    border-color: var(--search-border-color, var(--color-neutral-30));
+    border-radius: var(--radius-md);
+    border-style: solid;
+    border-width: var(--border-width-sm);
+    color: var(--search-text-color, var(--color-neutral-90));
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-16);
+    outline: 2px solid var(--search-outline-color, transparent);
+    cursor: default;
+    width: 100%;
+    transition-property: all;
+    transition-timing-function: var(--timing-primary);
+    transition-duration: var(--duration-medium);
+    appearance: none;
+    @include ellipsis.text-ellipsis;
+
+    height: var(--search-height);
+    padding-bottom: var(--search-padding-bottom);
+    padding-left: var(--search-padding-left);
+    padding-right: var(--search-padding-right);
+    padding-top: var(--search-padding-top);
+
+    /* left icon */
+    &.icon-placement-left {
+      padding-left: calc(
+        var(--search-padding-left) + var(--search-icon-size, 1rem) + var(--spacing-sm)
+      );
+    }
+
+    /*  right icon */
+    &.icon-placement-right {
+      padding-right: calc(
+        var(--search-padding-right) + (var(--search-icon-size, 1rem) + var(--spacing-sm)) * 2
+      );
+    }
+
+    &:disabled {
+      --search-background-color: var(--search-color-beige-40);
+      --search-text-color: var(--search-color-beige-70);
+      cursor: not-allowed;
+    }
+
+    /* hover when no variant is defined */
+    &:hover:not([class*='variant']) {
+      --search-border-color: var(--color-brand-40);
+    }
+
+    /* focus when no variant is defined */
+    &:focus:not([class*='variant']) {
+      --search-outline-color: var(--color-brand-20);
+      --search-border-color: var(--color-brand-40);
+    }
+
+    &.transparent {
+      --search-border-color: transparent;
+      --search-background-color: transparent;
+
+      &:hover {
+        --search-border-color: var(--color-neutral-20);
+      }
+    }
+
+    &::placeholder {
+      color: var(--color-neutral-60);
+    }
+
+    br {
+      display: none;
+    }
+  }
+
+  .variant {
+    &-danger {
+      --search-border-color: var(--color-red-70);
+      --search-outline-color: var(--color-red-30);
+    }
+
+    &-success {
+      --search-border-color: var(--color-green-60);
+      --search-outline-color: var(--color-green-30);
+    }
+
+    &-warning {
+      --search-border-color: var(--color-orange-60);
+      --search-outline-color: var(--color-orange-20);
+    }
+  }
+
+  .size {
+    &-lg {
+      --search-height: var(--height-48);
+      --search-clear-size: var(--search-height);
+      --search-padding-bottom: var(--spacing-16);
+      --search-padding-left: var(--spacing-12);
+      --search-padding-right: var(--spacing-12);
+      --search-padding-top: var(--spacing-16);
+    }
+
+    &-md {
+      --search-height: var(--height-40);
+      --search-clear-size: var(--search-height);
+      --search-padding-bottom: var(--spacing-12);
+      --search-padding-left: var(--spacing-12);
+      --search-padding-right: var(--spacing-12);
+      --search-padding-top: var(--spacing-12);
+    }
+
+    &-sm {
+      --search-height: var(--height-32);
+      --search-clear-size: var(--search-height);
+      --search-padding-bottom: var(--spacing-8);
+      --search-padding-left: var(--spacing-12);
+      --search-padding-right: var(--spacing-12);
+      --search-padding-top: var(--spacing-8);
+    }
+
+    &-xs {
+      --search-height: var(--height-24);
+      --search-clear-size: var(--search-height);
+      --search-padding-bottom: var(--spacing-4);
+      --search-padding-left: var(--spacing-8);
+      --search-padding-right: var(--spacing-8);
+      --search-padding-top: var(--spacing-4);
+      --search-icon-size: 0.75rem;
+    }
+  }
+
+  .icon-wrapper {
+    position: absolute;
+    top: 0;
+    left: var(--icon-placement-left, auto);
+    right: var(--icon-placement-right, auto);
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    pointer-events: none;
+    transition-property: all;
+    transition-timing-function: var(--timing-primary);
+    transition-duration: var(--duration-medium);
+    color: var(--color-neutral-90);
+
+    &.icon-placement-left {
+      --icon-placement-left: var(--spacing-md);
+      &.size-xs {
+        --icon-placement-left: var(--spacing-sm);
+      }
+    }
+
+    &.icon-placement-right {
+      --icon-placement-right: var(--spacing-md);
+      &.size-xs {
+        --icon-placement-right: var(--spacing-sm);
+      }
+    }
+
+    /* for button action */
+    & > button {
+      pointer-events: auto;
+    }
+  }
+
+  .menu {
+    max-height: 9.6875rem; /* 155px */
+    background-color: var(--color-neutral-10);
+    border-color: var(--color-neutral-30);
+    border-radius: var(--radius-md);
+    border-style: solid;
+    border-width: var(--border-width-sm);
+    color: var(--color-neutral-90);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-16);
+    outline: none;
+    position: absolute;
+    z-index: 2;
+    right: 0;
+    left: 0;
+    margin: 0;
+    margin-top: var(--spacing-md);
+    padding: 0;
+    transition-property: all;
+    transition-timing-function: var(--timing-primary);
+    transition-duration: var(--duration-medium);
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+
+    &:hover > * {
+      cursor: pointer;
+    }
+  }
+
+  .item {
+    color: var(--item-text-color, var(--color-beige-70));
+    cursor: var(--item-cursor, default);
+    padding: var(--spacing-md);
+    list-style: none;
+    text-decoration: none;
+    font-size: var(--font-size-sm);
+    transition-property: background;
+    transition-duration: var(--duration-medium);
+    transition-timing-function: var(--timing-primary);
+    @include ellipsis.text-ellipsis;
+
+    &.highlighted {
+      background-color: var(--color-beige-20);
+    }
+
+    &.selected {
+      --item-text-color: var(--color-neutral-90);
+      font-weight: var(--font-weight-bold);
+    }
+
+    &.selected.highlighted {
+      background-image: linear-gradient(0deg, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.08) 100%);
+    }
+  }
+}

--- a/lib/src/components/Search/types.ts
+++ b/lib/src/components/Search/types.ts
@@ -1,0 +1,35 @@
+import type { DownshiftProps } from 'downshift'
+import type { ComponentProps } from 'react'
+
+import type { Size } from '@/types'
+import type { MergeProps } from '@/utils'
+import type { CreateEvent } from '@/utils/create-event'
+
+//TODO fix unknown item
+export type Item = SearchOption | SearchOptionGroup | string | unknown
+export type SearchOption = { label: string; value: string }
+export type SearchOptionGroup = { label: string; options: SearchOption[] }
+
+export interface SearchOptions {
+  dataTestId?: string
+  groupsEnabled?: boolean
+  hasIcon?: boolean
+  icon?: React.ReactElement
+  iconPlacement?: 'left' | 'right'
+  itemToString: (item: Item) => string
+  minChars?: number
+  onChange?: (item: Item, event: CreateEvent) => void
+  renderGroupHeader?: (result: SearchOptionGroup) => React.ReactElement
+  renderItem: (item: Item) => React.ReactElement | string
+  search: (query: string) => Promise<unknown>
+  size?: Size
+  throttle?: number
+  transparent?: boolean
+  value?: Item
+  variant?: 'danger' | 'success' | 'warning'
+}
+
+export type SearchProps = MergeProps<
+  MergeProps<SearchOptions, DownshiftProps<SearchOption>>,
+  ComponentProps<'input'>
+>

--- a/lib/src/components/Select/docs/properties.json
+++ b/lib/src/components/Select/docs/properties.json
@@ -173,7 +173,9 @@
         }
       },
       "iconPlacement": {
-        "defaultValue": null,
+        "defaultValue": {
+          "value": "left"
+        },
         "description": "",
         "name": "iconPlacement",
         "parent": {

--- a/lib/src/components/Select/index.tsx
+++ b/lib/src/components/Select/index.tsx
@@ -3,7 +3,7 @@ import DownshiftImport from 'downshift'
 import { matchSorter } from 'match-sorter'
 import React, { forwardRef, Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 
-import { CloseButton } from '@/components/CloseButton'
+import { CloseButton as ClearButton } from '@/components/CloseButton'
 import { useField } from '@/components/Field'
 import { DownIcon } from '@/components/Icon'
 import { FIELD_ICON_SIZE } from '@/constants/field-icon-size'
@@ -52,6 +52,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       disabled,
       groupsEnabled,
       icon,
+      iconPlacement = 'left',
       id,
       isClearable,
       isCreatable,
@@ -315,7 +316,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       _variant && `variant-${_variant}`,
       isClearable && 'clearable',
       transparent && 'transparent',
-      icon ? 'icon-placement-both' : 'icon-placement-right',
+      icon && `icon-placement-${iconPlacement}`,
       className
     )
 
@@ -349,9 +350,10 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
 
           const DeleteIcon = (
             <div className={cx('dropdown-indicator', isOpen && 'open')}>
-              <CloseButton
+              <ClearButton
                 animatePresence
                 onClick={clearSelection as unknown as React.MouseEventHandler<HTMLButtonElement>}
+                title="Clear"
               />
             </div>
           )

--- a/lib/src/components/Select/select.module.scss
+++ b/lib/src/components/Select/select.module.scss
@@ -1,6 +1,66 @@
 @use './../../theme/utils/text-ellipsis' as ellipsis;
 
 @layer components {
+  .indicators {
+    position: absolute;
+    padding: 0;
+    top: 0;
+    bottom: 0;
+    right: var(--indicators-right, var(--spacing-md));
+    display: flex;
+    gap: var(--spacing-xs);
+
+    &.size-xs {
+      --indicators-right: var(--spacing-sm);
+    }
+  }
+
+  .dropdown-indicator {
+    position: relative;
+    height: 100%;
+    padding: 0;
+    outline: none !important; /* important for firefox */
+    appearance: none;
+    cursor: pointer;
+    border: none;
+    background: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    .styled-icon {
+      transform: none;
+      transition-property: transform;
+      transition-duration: var(--duration-medium);
+      transition-timing-function: var(--timing-primary);
+    }
+
+    &.open {
+      .styled-icon {
+        transform: rotate3d(0, 0, 1, 180deg);
+      }
+    }
+
+    &:not(:last-child) {
+      width: auto;
+    }
+
+    &:disabled {
+      color: var(--color-beige-60);
+    }
+  }
+
+  .input-wrapper {
+    position: relative;
+
+    &:has(> .icon-placement-right) {
+      .indicators {
+        /* icon size + spacing */
+        --indicators-right: calc(var(--spacing-lg) + var(--spacing-md) * 2);
+      }
+    }
+  }
+
   .root {
     --select-placeholder-color: var(--color-neutral-60);
     background-color: var(--select-background-color, var(--color-neutral-10));
@@ -266,54 +326,6 @@
     &.disabled {
       --item-text-color: var(--color-beige-60);
       --item-cursor: not-allowed;
-    }
-  }
-
-  .indicators {
-    position: absolute;
-    padding: 0;
-    top: 0;
-    bottom: 0;
-    right: var(--indicators-right, var(--spacing-md));
-    display: flex;
-    gap: var(--spacing-xs);
-
-    &.size-xs {
-      --indicators-right: var(--spacing-sm);
-    }
-  }
-
-  .dropdown-indicator {
-    position: relative;
-    height: 100%;
-    padding: 0;
-    outline: none !important; /* important for firefox */
-    cursor: pointer;
-    border: none;
-    background: transparent;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    .styled-icon {
-      transform: none;
-      transition-property: transform;
-      transition-duration: var(--duration-medium);
-      transition-timing-function: var(--timing-primary);
-    }
-
-    &.open {
-      .styled-icon {
-        transform: rotate3d(0, 0, 1, 180deg);
-      }
-    }
-
-    &:not(:last-child) {
-      width: auto;
-    }
-
-    &:disabled {
-      color: var(--color-beige-60);
     }
   }
 

--- a/lib/src/utils/throttle.ts
+++ b/lib/src/utils/throttle.ts
@@ -1,0 +1,27 @@
+interface ThrottledFunc<T extends (...args: unknown[]) => unknown> {
+  (...args: Parameters<T>): void
+}
+
+export const throttle = <T extends (...args: unknown[]) => unknown>(
+  callback: T,
+  wait?: number,
+  leading = true
+): ThrottledFunc<T> => {
+  let timeout: ReturnType<typeof setTimeout> = null
+  let lastArgs: unknown[] = null
+
+  return (...args) => {
+    const next = () => {
+      callback(...lastArgs)
+      timeout = null
+    }
+    lastArgs = args
+
+    if (!timeout) {
+      if (leading) {
+        next()
+      }
+      timeout = setTimeout(next, wait)
+    }
+  }
+}

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -150,6 +150,8 @@ export default {
   "/Radio/docs/examples/variants.tsx": dynamic(() => import("../../lib/src/components/Radio/docs/examples/variants.tsx").then(mod => mod), { ssr: false }),
   "/RadioTab/docs/examples/disabled.tsx": dynamic(() => import("../../lib/src/components/RadioTab/docs/examples/disabled.tsx").then(mod => mod), { ssr: false }),
   "/RadioTab/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/RadioTab/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
+  "/Search/docs/examples/option-groups.tsx": dynamic(() => import("../../lib/src/components/Search/docs/examples/option-groups.tsx").then(mod => mod), { ssr: false }),
+  "/Search/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/Search/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/Select/docs/examples/allow-unselect-from-list.tsx": dynamic(() => import("../../lib/src/components/Select/docs/examples/allow-unselect-from-list.tsx").then(mod => mod), { ssr: false }),
   "/Select/docs/examples/clearable.tsx": dynamic(() => import("../../lib/src/components/Select/docs/examples/clearable.tsx").then(mod => mod), { ssr: false }),
   "/Select/docs/examples/creatable-custom.tsx": dynamic(() => import("../../lib/src/components/Select/docs/examples/creatable-custom.tsx").then(mod => mod), { ssr: false }),


### PR DESCRIPTION
This PR migrates Search to tailwind
**A few thing changed**
- Search is always clearable so i removed the prop and simplified the css of icon placement and spacing
- we were not reading and using props `transparent`

It also fixes icon placement right for the Select
- Overall icon placements with the clear button and the dropdown indicator is not optimal 
- Search & Select should be reworked in that aspect with InputText as a blueprint 
