### PR TITLE
Chore: use breakpoint utils for breakpoint declarations

### DIFF
--- a/lib/src/components/Modal/Assets/assets.module.scss
+++ b/lib/src/components/Modal/Assets/assets.module.scss
@@ -1,14 +1,15 @@
+@use '../../../theme/utils/breakpoints' as breakpoints;
+
 @mixin sizeOfElements {
   width: var(--contentWidthMobile);
   max-height: var(--contentHeight);
 
-  /* var(--breakpoint-md) */
-  @media (min-width: 736px) {
+  @media (min-width: breakpoints.$breakpoint-md) {
     width: var(--contentWidthDesktop);
   }
 
   /* for big screens */
-  @media (min-width: 1700px) {
+  @media (min-width: breakpoints.$breakpoint-3xl) {
     max-width: 1600px;
   }
 }
@@ -74,8 +75,7 @@
       height: var(--titleBlockMobile);
       padding-inline: var(--spacing-md);
 
-      /* var(--breakpoint-md) */
-      @media (min-width: 736px) {
+      @media (min-width: breakpoints.$breakpoint-md) {
         height: var(--titleBlockDesktop);
         padding-inline: var(--spacing-xl);
       }
@@ -87,8 +87,7 @@
       max-height: calc(100vh - 2 * 5rem - var(--titleBlockMobile));
       flex-shrink: 0;
 
-      /* var(--breakpoint-md) */
-      @media (min-width: 736px) {
+      @media (min-width: breakpoints.$breakpoint-md) {
         max-height: calc(100vh - 2 * 5rem - var(--titleBlockDesktop));
       }
     }
@@ -97,8 +96,7 @@
       background-color: var(--color-neutral-90);
       max-height: calc(100vh - 2 * 5rem - var(--titleBlockMobile));
 
-      /* var(--breakpoint-md) */
-      @media (min-width: 736px) {
+      @media (min-width: breakpoints.$breakpoint-md) {
         max-height: calc(100vh - 2 * 5rem - var(--titleBlockDesktop));
       }
     }
@@ -116,13 +114,12 @@
       max-width: var(--contentWidthMobile);
       max-height: var(--contentHeight);
 
-      /* var(--breakpoint-md) */
-      @media (min-width: 736px) {
+      @media (min-width: breakpoints.$breakpoint-md) {
         max-width: var(--contentWidthDesktop);
       }
 
       /* for big screens */
-      @media (min-width: 1700px) {
+      @media (min-width: breakpoints.$breakpoint-3xl) {
         max-width: 1600px;
       }
     }


### PR DESCRIPTION
This pull request imports breakpoint variables from the shared theme utilities.

**SCSS breakpoints refactor:**

* Imported the `breakpoints` module from the shared theme utilities for consistent breakpoint values.
* Replaced hardcoded pixel values (`736px` and `1700px`) in media queries with `breakpoints.$breakpoint-md` and `breakpoints.$breakpoint-3xl` variables throughout the file, ensuring easier updates and alignment with design system standards. [[1]](diffhunk://#diff-6fe9417db25e2b791fc755a9493b9507a9e54bd3da469701f249c170583174f2R1-R12) [[2]](diffhunk://#diff-6fe9417db25e2b791fc755a9493b9507a9e54bd3da469701f249c170583174f2L77-R78) [[3]](diffhunk://#diff-6fe9417db25e2b791fc755a9493b9507a9e54bd3da469701f249c170583174f2L90-R90) [[4]](diffhunk://#diff-6fe9417db25e2b791fc755a9493b9507a9e54bd3da469701f249c170583174f2L100-R99) [[5]](diffhunk://#diff-6fe9417db25e2b791fc755a9493b9507a9e54bd3da469701f249c170583174f2L119-R122)

Thought we used media queries more often that that 