### PR TITLE
Chore modal content migration script

### DIFF
--- a/scripts/migrate-v9/__snapshots__/index.test.mjs.snap
+++ b/scripts/migrate-v9/__snapshots__/index.test.mjs.snap
@@ -185,27 +185,27 @@ export const Example = () => {
         Open modal
       </Modal.Trigger>
       <Modal ariaLabel="example" store={modal}>
-        <Modal.Content
-          className="bg-neutral-90 items-center"
+        <div
+          className="bg-neutral-90 items-center with-closing-button"
           data-testid="modal-content"
-          withClosingButton
+          data-migration="DEPRECATED"
         >
           <Modal.Body>
             Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
             aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. In imperdiet rutrum
             nunc.
           </Modal.Body>
-        </Modal.Content>
+        </div>
       </Modal>
 
       <Modal ariaLabel="example" store={modal}>
-        <Modal.Content>
+        <div data-migration="DEPRECATED">
           <Modal.Body>
             Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
             aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. In imperdiet rutrum
             nunc.
           </Modal.Body>
-        </Modal.Content>
+        </div>
       </Modal>
     </>
   )

--- a/scripts/migrate-v9/__snapshots__/index.test.mjs.snap
+++ b/scripts/migrate-v9/__snapshots__/index.test.mjs.snap
@@ -170,3 +170,45 @@ export const Example = () => {
 }
 "
 `;
+
+exports[`upgrade-v9 migration script > processComponents (integration) > migrates fixtures/Component3.tsx as expected 1`] = `
+"import { Button } from '../../../lib/src/old/components/Button'
+import { Modal, useModal } from '../../../lib/src/old/components/Modal'
+
+// Usage examples
+export const Example = () => {
+  const modal = useModal()
+
+  return (
+    <>
+      <Modal.Trigger as={Button} store={modal}>
+        Open modal
+      </Modal.Trigger>
+      <Modal ariaLabel="example" store={modal}>
+        <Modal.Content
+          className="bg-neutral-90 items-center"
+          data-testid="modal-content"
+          withClosingButton
+        >
+          <Modal.Body>
+            Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
+            aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. In imperdiet rutrum
+            nunc.
+          </Modal.Body>
+        </Modal.Content>
+      </Modal>
+
+      <Modal ariaLabel="example" store={modal}>
+        <Modal.Content>
+          <Modal.Body>
+            Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
+            aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. In imperdiet rutrum
+            nunc.
+          </Modal.Body>
+        </Modal.Content>
+      </Modal>
+    </>
+  )
+}
+"
+`;

--- a/scripts/migrate-v9/fixtures/Component3.tsx
+++ b/scripts/migrate-v9/fixtures/Component3.tsx
@@ -1,0 +1,40 @@
+import { Button } from '../../../lib/src/old/components/Button'
+import { Modal, useModal } from '../../../lib/src/old/components/Modal'
+
+// Usage examples
+export const Example = () => {
+  const modal = useModal()
+
+  return (
+    <>
+      <Modal.Trigger as={Button} store={modal}>
+        Open modal
+      </Modal.Trigger>
+      <Modal ariaLabel="example" store={modal}>
+        <Modal.Content
+          alignItems="center"
+          backgroundColor="neutral-90"
+          data-testid="modal-content"
+          store={modal}
+          withClosingButton
+        >
+          <Modal.Body>
+            Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
+            aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. In imperdiet rutrum
+            nunc.
+          </Modal.Body>
+        </Modal.Content>
+      </Modal>
+
+      <Modal ariaLabel="example" store={modal}>
+        <Modal.Content store={modal} withClosingButton={false}>
+          <Modal.Body>
+            Praesent sit amet quam ac velit faucibus dapibus. Quisque sapien ligula, rutrum quis
+            aliquam nec, convallis sit amet erat. Mauris auctor blandit porta. In imperdiet rutrum
+            nunc.
+          </Modal.Body>
+        </Modal.Content>
+      </Modal>
+    </>
+  )
+}

--- a/scripts/migrate-v9/index.test.mjs
+++ b/scripts/migrate-v9/index.test.mjs
@@ -47,6 +47,25 @@ describe('upgrade-v9 migration script', () => {
       // Assert output (snapshot or inline string)
       expect(migrated).toMatchSnapshot()
     })
+
+    it('migrates fixtures/Component3.tsx as expected', async () => {
+      // Setup temp dir and copy fixture
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wui-upgrade-test-'))
+      const srcFile = path.join(__dirname, './fixtures/Component3.tsx')
+      const destFile = path.join(tmpDir, 'Component3.tsx')
+      fs.copyFileSync(srcFile, destFile)
+
+      // Find components in the temp file
+      const components = findAllComponentUsages(tmpDir)
+      // Run migration (shouldReplace = true)
+      await processComponents(components, true)
+
+      // Read migrated file
+      const migrated = fs.readFileSync(destFile, 'utf8')
+
+      // Assert output (snapshot or inline string)
+      expect(migrated).toMatchSnapshot()
+    })
   })
 
   describe('findAllComponentUsages', () => {

--- a/scripts/migrate-v9/process-components.mjs
+++ b/scripts/migrate-v9/process-components.mjs
@@ -21,7 +21,7 @@ try {
   prettierConfig = {}
 }
 
-const COMPONENTS_TO_REPLACE = ['Box', 'Flex', 'Grid', 'Stack']
+const COMPONENTS_TO_REPLACE = ['Box', 'Flex', 'Grid', 'Stack', 'Modal.Content']
 
 const PROPS_WHITELIST = [
   'aria-label',
@@ -297,6 +297,11 @@ function buildAttributes(component, classnames) {
     if (propData.isExpression) {
       // Modal.Content deprecation: intercept 'store' prop
       if (component.componentType === 'Modal.Content' && key === 'store') {
+        newAttributes.push({
+          name: { name: 'data-migration', type: 'JSXIdentifier' },
+          type: 'JSXAttribute',
+          value: { type: 'StringLiteral', value: 'DEPRECATED' },
+        })
         return
       }
       newAttributes.push({

--- a/scripts/migrate-v9/transform.mjs
+++ b/scripts/migrate-v9/transform.mjs
@@ -180,6 +180,7 @@ export const valueMap = {
   transition: value => `transition_${value}_CSS_TO_EDIT`,
   w: value => transform('w', value),
   whiteSpace: value => transform('whitespace', value),
+  withClosingButton: value => (value === true || value === 'true' ? 'with-closing-button' : ''),
   wrap: value => transform('flex', value),
 }
 

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -63,7 +63,7 @@ const nextConfig = {
   webpack: (config, { isServer }) => {
     if (process.env.NODE_ENV === 'development' && isServer) {
       if (!global.__WATCHERS_INITIALIZED__) {
-        watchTypes()
+        // watchTypes()
         watchExamples()
         global.__WATCHERS_INITIALIZED__ = true
       }

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -63,7 +63,7 @@ const nextConfig = {
   webpack: (config, { isServer }) => {
     if (process.env.NODE_ENV === 'development' && isServer) {
       if (!global.__WATCHERS_INITIALIZED__) {
-        // watchTypes()
+        watchTypes()
         watchExamples()
         global.__WATCHERS_INITIALIZED__ = true
       }


### PR DESCRIPTION
wip migration script change: from `Modal.Content` to `div`
- I can turn `withClosingButton` props into a class but that have no business being in our consumer project.
- It should move to the parent, and this will require some manual actions
- Still, the script will be usefull to highlight where the changes should be