### PR TITLE
chore(passwordInput): improve a11y

### DIFF
--- a/lib/src/components/PasswordInput/ToggleButton.tsx
+++ b/lib/src/components/PasswordInput/ToggleButton.tsx
@@ -7,7 +7,7 @@ export type ToggleButtonProps = React.ComponentPropsWithoutRef<typeof Button> & 
   isHidden: boolean
 }
 
-export const ToggleButton = ({ isHidden, onClick, title, ...rest }: ToggleButtonProps) => {
+export const ToggleButton = ({ isHidden, onClick, ...rest }: ToggleButtonProps) => {
   return (
     <Button
       aria-controls="password"
@@ -15,7 +15,6 @@ export const ToggleButton = ({ isHidden, onClick, title, ...rest }: ToggleButton
       onClick={onClick}
       shape="circle"
       size="xs"
-      title={title}
       variant="ghost"
       {...rest}
     >

--- a/lib/src/components/PasswordInput/index.tsx
+++ b/lib/src/components/PasswordInput/index.tsx
@@ -6,7 +6,7 @@ import { ToggleButton } from './ToggleButton'
 import type { PasswordInputProps } from './types'
 
 export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
-  ({ title, ...rest }, ref) => {
+  ({ toggleAriaLabel, ...rest }, ref) => {
     const [type, setType] = useState<'password' | 'text'>('password')
     const isHidden = type === 'password'
 
@@ -23,10 +23,10 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
         {...rest}
         icon={
           <ToggleButton
+            aria-label={toggleAriaLabel ?? (isHidden ? 'Show password' : 'Hide password')}
             data-testid={dataTestId}
             isHidden={isHidden}
             onClick={handleToggle}
-            title={title}
           />
         }
         iconPlacement="right"

--- a/lib/src/components/PasswordInput/types.ts
+++ b/lib/src/components/PasswordInput/types.ts
@@ -1,5 +1,5 @@
 import type { InputTextProps } from '@/components/InputText/types'
 
 export type PasswordInputProps = InputTextProps & {
-  'data-testid'?: string
+  toggleAriaLabel?: string
 }


### PR DESCRIPTION
## DESCRIPTION

This pull request refactors the `PasswordInput` component to improve accessibility and clarify prop usage. The main change is replacing the ambiguous `title` prop with a more descriptive `toggleAriaLabel` prop, which is now used for the toggle button's `aria-label`. This ensures better support for assistive technologies and cleans up the component API.

**Accessibility improvements:**

* Replaced the `title` prop with a new `toggleAriaLabel` prop in `PasswordInputProps`, and updated its usage throughout the component to set the toggle button's `aria-label` for improved accessibility. [[1]](diffhunk://#diff-7e9eff8c3aba19ca748dee9ef5028fe85b3c75aaafa0b5dcb8ae9f8a49785038L4-R4) [[2]](diffhunk://#diff-11ba961dd3a891a1492be4bc5162e27dee8fc86f3437b0df76bd3a6b8ec664c9L9-R9) [[3]](diffhunk://#diff-11ba961dd3a891a1492be4bc5162e27dee8fc86f3437b0df76bd3a6b8ec664c9R26-L29)

**Code cleanup:**

* Removed the unused `title` prop from the `ToggleButton` component, simplifying its interface and preventing confusion.
