### PR TITLE
chore(Dropdown Trigger): remove event stopPropagation

### DIFF
--- a/lib/src/components/DropdownMenu/Trigger.tsx
+++ b/lib/src/components/DropdownMenu/Trigger.tsx
@@ -1,5 +1,5 @@
-import { MenuButton } from '@ariakit/react'
 import type { MenuButtonProps } from '@ariakit/react'
+import { MenuButton } from '@ariakit/react'
 import type { MouseEvent } from 'react'
 
 import { forwardRefWithAs } from '@/utils'
@@ -9,8 +9,8 @@ import type { TriggerProps } from './types'
 export const Trigger = forwardRefWithAs<TriggerProps, 'button'>(
   ({ as: Component, onClick, store, ...rest }, ref) => {
     const handleMenuButtonClick = (e: MouseEvent<HTMLButtonElement>) => {
+      // this will prevent to autoclose the menu
       e.preventDefault()
-      e.stopPropagation()
       onClick?.(e)
       store.toggle()
     }


### PR DESCRIPTION
## DESCRIPTION
This PR aims to:
- Remove event stopPropagation from the DropdownMenu.Trigger onClick
- Add a comment on why we have a `e.preventDefault` on the onClick
<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## SCREENSHOTS / SCREEN RECORDINGS

<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
