### PR TITLE
style(Button): aria-pressed & :active apply same style

### DIFF
--- a/lib/src/components/Button/button.module.scss
+++ b/lib/src/components/Button/button.module.scss
@@ -87,7 +87,7 @@
       }
     }
 
-    &:active:not(:disabled):not([aria-disabled]) {
+    &:is(:active, [aria-pressed='true']):not(:disabled):not([aria-disabled]) {
       --buttonBackground: var(--buttonBackgroundActive);
       --buttonBorderColor: var(--buttonBorderColorActive, transparent);
       --buttonColor: var(--buttonColorPressed);


### PR DESCRIPTION
## DESCRIPTION
Need: programmatically apply a `pressed` state to a button
Solution: use `aria-pressed` attribute to apply the same style as `:active`
<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## SCREENSHOTS / SCREEN RECORDINGS

<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
