### PR TITLE
Chore(Checkbox): remove checkbox internal state

### DIFF
--- a/lib/src/components/Checkbox/docs/examples/overview.tsx
+++ b/lib/src/components/Checkbox/docs/examples/overview.tsx
@@ -1,17 +1,38 @@
+import { useState } from 'react'
+
 import { Checkbox } from '@/components/Checkbox'
 
 const Example = () => {
+  const [checked, setChecked] = useState(false)
+
+  const handleChange = (value: boolean) => {
+    setChecked(value)
+    alert(`Checkbox is now ${value ? 'checked' : 'unchecked'}`)
+  }
+
   return (
-    <>
-      <Checkbox
-        name="default"
-        onChange={value => alert(`Checkbox is now ${value ? 'checked' : 'unchecked'}`)}
-      />
-      <Checkbox checked name="not-checked" />
-      <Checkbox indeterminate name="indeterminate" />
-      <Checkbox disabled name="default-disabled" />
-      <Checkbox checked disabled name="not-checked-disabled" />
-    </>
+    <ul className="flex flex-col gap-md mx-auto">
+      <li className="flex gap-sm items-center">
+        <Checkbox checked={checked} name="default" onChange={handleChange} />
+        <span>Checkbox: controlled state</span>
+      </li>
+      <li className="flex gap-sm items-center">
+        <Checkbox checked={false} name="not-checked" />
+        <p>Checkbox: false</p>
+      </li>
+      <li className="flex gap-sm items-center">
+        <Checkbox indeterminate name="indeterminate" />
+        <p>Checkbox: indeterminate</p>
+      </li>
+      <li className="flex gap-sm items-center">
+        <Checkbox disabled name="default-disabled" />
+        <p>Checkbox: disabled</p>
+      </li>
+      <li className="flex gap-sm items-center">
+        <Checkbox checked disabled name="not-checked-disabled" />
+        <p>Checkbox: checked & disabled</p>
+      </li>
+    </ul>
   )
 }
 

--- a/lib/src/components/Checkbox/docs/examples/variants.tsx
+++ b/lib/src/components/Checkbox/docs/examples/variants.tsx
@@ -6,26 +6,37 @@ const Example = () => {
   const [checkbox, setCheckbox] = React.useState(false)
 
   return (
-    <div className="items-center flex gap-sm">
-      <Checkbox
-        checked={checkbox}
-        name="default-variant"
-        onChange={() => setCheckbox(!checkbox)}
-        variant="danger"
-      />
-      <Checkbox
-        checked={checkbox}
-        name="default-variant"
-        onChange={() => setCheckbox(!checkbox)}
-        variant="warning"
-      />
-      <Checkbox
-        checked={checkbox}
-        name="default-variant"
-        onChange={() => setCheckbox(!checkbox)}
-        variant="success"
-      />
-    </div>
+    <ul className="flex flex-col gap-md mx-auto">
+      <li className="flex gap-sm items-center">
+        <Checkbox
+          checked={checkbox}
+          name="danger-variant"
+          onChange={() => setCheckbox(!checkbox)}
+          variant="danger"
+        />
+        <span>Checkbox: danger variant</span>
+      </li>
+
+      <li className="flex gap-sm items-center">
+        <Checkbox
+          checked={checkbox}
+          name="warning-variant"
+          onChange={() => setCheckbox(!checkbox)}
+          variant="warning"
+        />
+        <span>Checkbox: warning variant</span>
+      </li>
+
+      <li className="flex gap-sm items-center">
+        <Checkbox
+          checked={checkbox}
+          name="success-variant"
+          onChange={() => setCheckbox(!checkbox)}
+          variant="success"
+        />
+        <span>Checkbox: success variant</span>
+      </li>
+    </ul>
   )
 }
 

--- a/lib/src/components/Checkbox/index.tsx
+++ b/lib/src/components/Checkbox/index.tsx
@@ -18,7 +18,6 @@ const cx = classNames(checkboxStyles)
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   ({ checked = false, className, indeterminate = false, onChange, variant, ...rest }, ref) => {
-    const [isChecked, setIsChecked] = useState(checked)
     const [focusVisible, setFocusVisible] = useState(false)
     const { getInputProps, variant: fieldVariant } = useField()
 
@@ -26,16 +25,14 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     const { disabled } = getInputProps(rest)
 
     const handleChange = () => {
-      setIsChecked(!isChecked)
-
       if (onChange) {
-        onChange(!isChecked)
+        onChange(!checked)
       }
     }
 
     return (
       <div
-        aria-checked={isChecked}
+        aria-checked={checked}
         aria-disabled={disabled}
         className={cx(
           'root',
@@ -50,14 +47,14 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
         <VisuallyHidden>
           <AriaKitCheckbox
             {...getInputProps(rest)}
-            checked={isChecked}
+            checked={checked}
             onBlur={() => setFocusVisible(false)}
             onFocusVisible={() => setFocusVisible(true)}
             ref={ref}
           />
         </VisuallyHidden>
-        {isChecked ? <Icon name="check" size="sm" /> : null}
-        {!isChecked && indeterminate ? <Icon name="minus" size="sm" /> : null}
+        {checked ? <Icon name="check" size="sm" /> : null}
+        {!checked && indeterminate ? <Icon name="minus" size="sm" /> : null}
       </div>
     )
   }


### PR DESCRIPTION
### Checkbox
> this component handle isChecked value with an internal useState. The internal value is initialized by using the checked props we pass, but we cannot update its value unless we trigger an onclick. So this make impossible to sync its value with an external state.

### The fix
- Remove the internal state since we don't use checkbox without some form of controls. 
