### PR TITLE
feat(Checkbox): pass click event as second argument to onChange

### DIFF
--- a/lib/src/components/Checkbox/index.tsx
+++ b/lib/src/components/Checkbox/index.tsx
@@ -24,9 +24,9 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     const _variant = fieldVariant || variant
     const { disabled } = getInputProps(rest)
 
-    const handleChange = () => {
+    const handleChange = (e: React.MouseEvent<HTMLDivElement>) => {
       if (onChange) {
-        onChange(!checked)
+        onChange(!checked, e)
       }
     }
 

--- a/lib/src/components/Checkbox/types.ts
+++ b/lib/src/components/Checkbox/types.ts
@@ -7,7 +7,7 @@ export interface CheckboxOptions {
 
 export type CheckboxProps = CheckboxOptions &
   Omit<ComponentProps<'input'>, 'onChange'> & {
-    onChange?: (isChecked: boolean) => void
+    onChange?: (isChecked: boolean, e: React.MouseEvent<HTMLDivElement>) => void
   }
 
 export type Variant = 'danger' | 'success' | 'warning'


### PR DESCRIPTION
## DESCRIPTION

**Need:** 
we do not have access to the click event outside of the Checkbox, so action like `stopPropagation` or `preventDefault` are not possible.

**Solution:**
pass the event as the second argument to the onChange function. No breaking changes
<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## SCREENSHOTS / SCREEN RECORDINGS

<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
