### PR TITLE
feat(toast): add missing export

### DIFF
--- a/lib/src/components/Toast/docs/examples/programmatically.tsx
+++ b/lib/src/components/Toast/docs/examples/programmatically.tsx
@@ -1,0 +1,58 @@
+import { useRef } from 'react'
+
+import { Button } from '@/components/Button'
+import { dismiss, remove, toast, Toast } from '@/components/Toast'
+
+const Example = () => {
+  const toastIdsRef = useRef<string[]>([])
+
+  const handleClick = () => {
+    const id = toast(
+      <Toast.Snackbar cta={<Toast.SnackbarAction>Action</Toast.SnackbarAction>} variant="info">
+        Lorem ipsum dolor sit amet taciti sociosqu ad
+      </Toast.Snackbar>
+    )
+    toastIdsRef.current.push(id)
+  }
+
+  const dismissLast = () => {
+    const lastId = toastIdsRef.current.pop()
+    if (lastId) {
+      dismiss(lastId)
+    }
+  }
+
+  const removeLast = () => {
+    const lastId = toastIdsRef.current.pop()
+    if (lastId) {
+      remove(lastId)
+    }
+  }
+
+  return (
+    <>
+      <Button onClick={handleClick}>Open</Button>
+      <Button
+        onClick={() => {
+          dismiss()
+          toastIdsRef.current = []
+        }}
+      >
+        Dismiss all
+      </Button>
+      <Button onClick={dismissLast}>Dismiss last</Button>
+
+      <Button
+        onClick={() => {
+          remove()
+          toastIdsRef.current = []
+        }}
+      >
+        Remove all
+      </Button>
+      <Button onClick={removeLast}>Remove last</Button>
+    </>
+  )
+}
+
+export default Example

--- a/lib/src/components/Toast/docs/index.mdx
+++ b/lib/src/components/Toast/docs/index.mdx
@@ -83,14 +83,4 @@ For the Growl, the progress bar is hidden by default, you can show it with the `
 
 You can close or dismiss a toast programmatically with the `dismiss` and `remove` functions. Dismiss will hide the toast with a fade out animation, while remove will hide the toast immediately.
 
-```jsx
-const toastId = toast(<Toast />)
-
-// Remove or dismiss this specific toast
-remove(toastId)
-dismiss(toastId)
-
-// Remove or dismiss all toasts
-remove()
-dismiss()
-```
+<div data-playground="programmatically.tsx" data-component="Toast"></div>

--- a/lib/src/components/Toast/index.tsx
+++ b/lib/src/components/Toast/index.tsx
@@ -13,6 +13,7 @@ import toastStyles from './toast.module.scss'
 import type { ToastOptions, ToastVariant } from './types'
 
 export { toastStyles as toastClasses }
+export const { dismiss, remove } = toastRHT
 
 const cx = classNames(toastStyles)
 

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -267,6 +267,7 @@ export default {
   "/Toast/docs/examples/growl.tsx": dynamic(() => import("../../lib/src/components/Toast/docs/examples/growl.tsx").then(mod => mod), { ssr: false }),
   "/Toast/docs/examples/latency.tsx": dynamic(() => import("../../lib/src/components/Toast/docs/examples/latency.tsx").then(mod => mod), { ssr: false }),
   "/Toast/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/Toast/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
+  "/Toast/docs/examples/programmatically.tsx": dynamic(() => import("../../lib/src/components/Toast/docs/examples/programmatically.tsx").then(mod => mod), { ssr: false }),
   "/Toast/docs/examples/snackbar.tsx": dynamic(() => import("../../lib/src/components/Toast/docs/examples/snackbar.tsx").then(mod => mod), { ssr: false }),
   "/Toast/docs/examples/toast.tsx": dynamic(() => import("../../lib/src/components/Toast/docs/examples/toast.tsx").then(mod => mod), { ssr: false }),
   "/Toast/docs/examples/without-close.tsx": dynamic(() => import("../../lib/src/components/Toast/docs/examples/without-close.tsx").then(mod => mod), { ssr: false }),


### PR DESCRIPTION
## DESCRIPTION

Add export for dismiss and remove function for toast

## HOW TO TEST

Check the last exemple with remove and dismiss button

## SCREENSHOTS / SCREEN RECORDINGS

https://github.com/user-attachments/assets/91caaf6a-c3c2-4a76-9521-c3357afb4eff


## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [x] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [x] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
