### PR TITLE
fix(Checkbox disabled): apply disabled style only when disabled=true

### DIFF
--- a/lib/src/components/Checkbox/checkbox.module.scss
+++ b/lib/src/components/Checkbox/checkbox.module.scss
@@ -17,17 +17,11 @@
 
     /* VARIABLES THAT CHANGE WITH REACT PROPS */
     color: var(--color, var(--checkbox-color-icon-default));
-    background-color: var(
-      --backgroundColor,
-      var(--checkbox-color-background-unchecked-default)
-    );
-    border-color: var(
-      --borderColor,
-      var(--checkbox-color-border-unchecked-default)
-    );
+    background-color: var(--backgroundColor, var(--checkbox-color-background-unchecked-default));
+    border-color: var(--borderColor, var(--checkbox-color-border-unchecked-default));
 
     &:disabled,
-    &[aria-disabled] {
+    &[aria-disabled='true'] {
       --color: var(--checkbox-color-icon-disabled);
       --backgroundColor: var(--checkbox-color-border-disabled);
       --borderColor: var(--checkbox-color-border-disabled);
@@ -36,22 +30,13 @@
     }
 
     &:not([aria-disabled]):hover {
-      --borderColor: var(
-        --borderColorHover,
-        var(--checkbox-color-border-unchecked-hover)
-      );
+      --borderColor: var(--borderColorHover, var(--checkbox-color-border-unchecked-hover));
     }
 
     &[data-focus-visible],
     &:focus-visible {
-      --borderColor: var(
-        --borderColorFocused,
-        var(--checkbox-color-border-focused)
-      );
-      outline-color: var(
-        --outlineColorFocus,
-        var(--checkbox-color-border-focused)
-      );
+      --borderColor: var(--borderColorFocused, var(--checkbox-color-border-focused));
+      outline-color: var(--outlineColorFocus, var(--checkbox-color-border-focused));
     }
 
     &[aria-checked='true'] {


### PR DESCRIPTION
## DESCRIPTION
### FIX
The component was applyng the disabled style not matter the value of the boolean `disabled`. If the prop was different from `undefined` then the style was applied.
<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## SCREENSHOTS / SCREEN RECORDINGS

<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
