### PR TITLE
fix: invoke hide props if function

### DIFF
--- a/lib/src/components/Drawer/index.tsx
+++ b/lib/src/components/Drawer/index.tsx
@@ -50,6 +50,9 @@ const DrawerComponent = forwardRef<HTMLDivElement, DrawerProps>(
     const hideOnInteractOutsideFn = useCallback(
       (event: Event) => {
         if (!hideOnInteractOutside) return false
+        if (typeof hideOnInteractOutside === 'function') {
+          return hideOnInteractOutside(event)
+        }
 
         const target = event.target as HTMLElement
         const isTargetWithinPersistentElements = getPersistentElements().some(element =>


### PR DESCRIPTION
`hideOnInteractOutside` takes either a boolean or a callback that returns a boolean.
We currently only check if the props is truthy
**Fix - Check if props `hideOnInteractOutside` is a function**
-  if it is, invoke and return its result