### PR TITLE
fix: text component lint error and types

### DIFF
--- a/lib/src/components/Text/index.tsx
+++ b/lib/src/components/Text/index.tsx
@@ -1,16 +1,16 @@
-import { createElement, type CSSProperties } from 'react'
+import { type CSSProperties } from 'react'
 
 import { classNames, forwardRefWithAs } from '@/utils'
 
 import textStyles from './text.module.scss'
-import type { TextProps } from './types'
+import type { TextOptions } from './types'
 
 export { textStyles as textClasses }
 
 const cx = classNames(textStyles)
 
-export const Text = forwardRefWithAs<TextProps, 'p'>(
-  ({ as = 'p', children, className, lines, variant = 'md', withDash, ...rest }, ref) => {
+export const Text = forwardRefWithAs<TextOptions, 'p'>(
+  ({ as: Component = 'p', children, className, lines, variant = 'md', withDash, ...rest }, ref) => {
     const isHeading = variant?.startsWith('heading') || variant?.startsWith('display')
     const isMultiLine = lines && lines > 1 && lines !== Number.POSITIVE_INFINITY
     const isSingleLine = lines === 1
@@ -18,8 +18,8 @@ export const Text = forwardRefWithAs<TextProps, 'p'>(
     const classes = cx(
       'root',
       `variant-${variant}`,
-      lines && 'with-lines',
-      isMultiLine && 'multi-line',
+      Boolean(lines) && 'with-lines',
+      Boolean(isMultiLine) && 'multi-line',
       isSingleLine && 'single-line',
       withDash && isHeading && 'with-dash',
       className
@@ -27,15 +27,15 @@ export const Text = forwardRefWithAs<TextProps, 'p'>(
 
     const cssVariables = isMultiLine || isSingleLine ? { '--lineClamp': lines } : {}
 
-    return createElement(
-      as,
-      {
-        className: classes,
-        ref,
-        style: { ...cssVariables } as CSSProperties,
-        ...rest,
-      },
-      children
+    return (
+      <Component
+        className={classes}
+        ref={ref}
+        style={{ ...cssVariables } as CSSProperties}
+        {...rest}
+      >
+        {children}
+      </Component>
     )
   }
 )


### PR DESCRIPTION
## DESCRIPTION

The `Text` component was typed with `forwardRefWithAs<TextProps, 'p'>`, but `TextProps` already bakes in the props of the default `'p'` element via `PolymorphicProps<'p'>`. Because `MergeProps` inside `forwardRefWithAs` gives priority to the generic prop type over the dynamic `as` prop, event handler types (e.g. `onCopy`, `onClick`) were always typed against `HTMLParagraphElement`, causing TypeScript errors when consumers used `as="a"` (or any other element) and spread props typed for that element:

```
Type 'ClipboardEventHandler<HTMLAnchorElement>' is not assignable to
type 'ClipboardEventHandler<HTMLParagraphElement>'.
```

**Changes**
- Pass only `TextOptions` (the component-specific options) as the generic to `forwardRefWithAs`, letting it inject the polymorphic element props correctly. Now `as="a"` properly types events against `HTMLAnchorElement`. This matches the pattern used by other polymorphic components in the lib (e.g. `Field` uses `forwardRefWithAs<FieldOptions, 'div'>`).
- Replace `createElement(as, …)` with standard JSX (`<Component …>`), which is simpler, more idiomatic, and plays nicely with the polymorphic typing.
- Wrap truthy class-name checks in `Boolean(...)` (`with-lines`, `multi-line`) to avoid the lint warning about non-boolean values being passed to the `cx` helper, and to avoid accidentally rendering numeric falsy values as class names.

**No behavior changes** — only typing and small lint/readability fixes.
