### PR TITLE
fix: fast-uri vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "tailwindcss": "4.1.18"
   },
   "resolutions": {
-    "socks": "2.8.8"
+    "socks": "2.8.8",
+    "fast-uri": "3.1.2"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6156,10 +6156,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.0.6
-  resolution: "fast-uri@npm:3.0.6"
-  checksum: 10c0/74a513c2af0584448aee71ce56005185f81239eab7a2343110e5bad50c39ad4fb19c5a6f99783ead1cac7ccaf3461a6034fda89fffa2b30b6d99b9f21c2f9d29
+"fast-uri@npm:3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## DESCRIPTION

├─ fast-uri
│ ├─ ID: 1117870
│ ├─ Issue: fast-uri vulnerable to path traversal via percent-encoded dot segments
│ ├─ URL: [https://github.com/advisories/GHSA-q3j6-qgpj-74h6](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
│ ├─ Severity: high
│ ├─ Vulnerable Versions: <=3.1.0
│ │
│ ├─ Tree Versions
│ │ └─ 3.0.6
│ │
│ └─ Dependents
│ └─ ajv@npm:8.18.0
│
└─ fast-uri
├─ ID: 1117884
├─ Issue: fast-uri vulnerable to host confusion via percent-encoded authority delimiters
├─ URL: [https://github.com/advisories/GHSA-v39h-62p7-jpjc](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
├─ Severity: high
├─ Vulnerable Versions: <=3.1.1
│
├─ Tree Versions
│ └─ 3.0.6
│
└─ Dependents
└─ ajv@npm:8.18.0

Security vulnerabilities were found that were not ignored
