### PR TITLE
Chore/migrate npm publish to OIDC trusted publisher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,11 @@ commands:
             corepack enable
             corepack prepare yarn@4.7.0 --activate
             yarn --version
+  setup_npm:
+    steps:
+      - run:
+          name: Upgrade npm to latest v11
+          command: npm install -g npm@^11.5.1
 
 default: &default
   working_directory: /home/circleci/welcome-ui
@@ -203,12 +208,12 @@ jobs:
       - *checkout
       - attach_workspace:
           at: ~/welcome-ui
+      - setup_npm
       - run:
-          name: Login to registry
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-      - run:
-          name: publish
-          command: cd /home/circleci/welcome-ui/lib && npm publish --registry https://registry.npmjs.org
+          name: Authenticate and publish to registry using OIDC
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            cd /home/circleci/welcome-ui/lib && npm publish --registry https://registry.npmjs.org
 
   alpha_release:
     executor: nodejs
@@ -216,12 +221,12 @@ jobs:
       - *checkout
       - attach_workspace:
           at: ~/welcome-ui
+      - setup_npm
       - run:
-          name: Login to registry
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-      - run:
-          name: publish
-          command: cd /home/circleci/welcome-ui/lib && npm publish --tag beta --registry https://registry.npmjs.org
+          name: Authenticate and publish to registry using OIDC
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            cd /home/circleci/welcome-ui/lib && npm publish --tag beta --registry https://registry.npmjs.org
 
   dev_release:
     executor: nodejs
@@ -229,12 +234,12 @@ jobs:
       - *checkout
       - attach_workspace:
           at: ~/welcome-ui
+      - setup_npm
       - run:
-          name: Login to registry
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-      - run:
-          name: publish
-          command: node /home/circleci/welcome-ui/.dev-releases/publish.mjs
+          name: Authenticate and publish to registry using OIDC
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            node /home/circleci/welcome-ui/.dev-releases/publish.mjs
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
             corepack enable
             corepack prepare yarn@4.7.0 --activate
             yarn --version
-  setup_npm:
+  upgrade_npm_version:
     steps:
       - run:
           name: Upgrade npm to latest v11
@@ -208,7 +208,7 @@ jobs:
       - *checkout
       - attach_workspace:
           at: ~/welcome-ui
-      - setup_npm
+      - upgrade_npm_version
       - run:
           name: Authenticate and publish to registry using OIDC
           command: |
@@ -221,7 +221,7 @@ jobs:
       - *checkout
       - attach_workspace:
           at: ~/welcome-ui
-      - setup_npm
+      - upgrade_npm_version
       - run:
           name: Authenticate and publish to registry using OIDC
           command: |
@@ -234,7 +234,7 @@ jobs:
       - *checkout
       - attach_workspace:
           at: ~/welcome-ui
-      - setup_npm
+      - upgrade_npm_version
       - run:
           name: Authenticate and publish to registry using OIDC
           command: |

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   "resolutions": {
     "socks": "2.8.8",
     "fast-uri": "3.1.2",
-    "brace-expansion": "5.0.6"
+    "brace-expansion@^5.0.2": "^5.0.6"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
   },
   "resolutions": {
     "socks": "2.8.8",
-    "fast-uri": "3.1.2"
+    "fast-uri": "3.1.2",
+    "brace-expansion": "5.0.6"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4265,12 +4265,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+"brace-expansion@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## DESCRIPTION

Migrates npm publishing from static long-lived `$NPM_TOKEN` to OIDC-based Trusted Publishing for all 3 release jobs (`release`, `alpha_release`, `dev_release`).

**Changes:**
- Replaced the `Login to registry` step (writing `$NPM_TOKEN` to `.npmrc`) with a single `Authenticate and publish to registry using OIDC` step using `circleci run oidc get`
- Added a `setup_npm` shared command to upgrade npm to `v11.5.1+`, required for OIDC Trusted Publishing (not bundled in `cimg/node:22.14.0`)
- Fixed a moderate DoS vulnerability on `brace-expansion@5.0.5` (GHSA-jxxr-4gwj-5jf2) by adding a Yarn resolution scoped to the `5.x` range only, bumping it to `5.0.6`

**Prerequisites before merging:**

- [x] Configure the Trusted Publisher on npmjs.com for the package (CircleCI org ID, project ID, pipeline definition ID) https://docs.npmjs.com/trusted-publishers

## HOW TO TEST

- Trigger a `release`, `alpha_release` or `dev_release` job on CircleCI and verify the publish step succeeds without `$NPM_TOKEN`

## SCREENSHOTS / SCREEN RECORDINGS

N/A — CI configuration changes only.

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

> Not applicable — no UI changes.

## QA

- [x] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases

> No application logic changes — CI/CD and dependency fixes only.