### PR TITLE
fix(checkbox): manage aria-label correclty

### DIFF
--- a/lib/src/components/Checkbox/checkbox.module.scss
+++ b/lib/src/components/Checkbox/checkbox.module.scss
@@ -29,7 +29,7 @@
       cursor: not-allowed;
     }
 
-    &:not([aria-disabled]):hover {
+    &:not([aria-disabled='true']):hover {
       --borderColor: var(--borderColorHover, var(--checkbox-color-border-unchecked-hover));
     }
 
@@ -40,7 +40,7 @@
     }
 
     &[aria-checked='true'] {
-      &:not([aria-disabled]) {
+      &:not([aria-disabled='true']) {
         --backgroundColor: var(--checkbox-color-background-checked-default);
         --borderColor: var(--checkbox-color-background-checked-default);
 
@@ -76,7 +76,7 @@
   }
 
   .indeterminate {
-    &:not([aria-disabled]) {
+    &:not([aria-disabled='true']) {
       --backgroundColor: var(--checkbox-color-background-checked-default);
       --borderColor: var(--checkbox-color-background-checked-default);
 


### PR DESCRIPTION
## DESCRIPTION

When passing disabled={false} explicitly to the Checkbox component, a checked checkbox renders with a white background instead of the expected yellow

Root cause
aria-disabled={false} was being rendered as the string attribute aria-disabled="false" on the DOM element. The CSS selector :not([aria-disabled]) checks for the absence of the attribute, so it failed to match even when the checkbox was not disabled, preventing the yellow background from applying.

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## SCREENSHOTS / SCREEN RECORDINGS

BEFORE:

https://github.com/user-attachments/assets/4a4daa15-8b78-4000-b242-b2461d15af34

AFTER: 

https://github.com/user-attachments/assets/06bae035-d3cb-43a8-84ee-79ffed22f89a

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
