### PR TITLE
feat(search): fix icon placement

### DIFF
--- a/lib/src/components/Search/docs/examples/with-icon.tsx
+++ b/lib/src/components/Search/docs/examples/with-icon.tsx
@@ -1,0 +1,77 @@
+import { Icon } from '@/components/Icon'
+import { Search } from '@/components/Search'
+
+type Item = { Title: string }
+
+const Example = () => {
+  const searchFunction = async (s: string) => {
+    const response = await fetch(`https://www.omdbapi.com?apikey=41514363&s=${s}`)
+    const data = await response.json()
+    return data.Search
+  }
+
+  return (
+    <div className="flex flex-col gap-md">
+      <h3>Position</h3>
+      <Search
+        icon={<Icon name="search" />}
+        iconPlacement="left"
+        itemToString={(item: Item) => item && item.Title}
+        name="movies"
+        placeholder="Search a movie"
+        renderItem={(item: Item) => (
+          <div style={{ alignItems: 'center', display: 'flex' }}>{item.Title}</div>
+        )}
+        search={searchFunction}
+      />
+      <Search
+        icon={<Icon name="search" />}
+        iconPlacement="right"
+        itemToString={(item: Item) => item && item.Title}
+        name="movies"
+        placeholder="Search a movie"
+        renderItem={(item: Item) => (
+          <div style={{ alignItems: 'center', display: 'flex' }}>{item.Title}</div>
+        )}
+        search={searchFunction}
+      />
+
+      <h3>Size</h3>
+      <Search
+        icon={<Icon name="search" />}
+        itemToString={(item: Item) => item && item.Title}
+        name="movies"
+        placeholder="Search a movie"
+        renderItem={(item: Item) => (
+          <div style={{ alignItems: 'center', display: 'flex' }}>{item.Title}</div>
+        )}
+        search={searchFunction}
+        size="sm"
+      />
+      <Search
+        icon={<Icon name="search" />}
+        itemToString={(item: Item) => item && item.Title}
+        name="movies"
+        placeholder="Search a movie"
+        renderItem={(item: Item) => (
+          <div style={{ alignItems: 'center', display: 'flex' }}>{item.Title}</div>
+        )}
+        search={searchFunction}
+        size="md"
+      />
+      <Search
+        icon={<Icon name="search" />}
+        itemToString={(item: Item) => item && item.Title}
+        name="movies"
+        placeholder="Search a movie"
+        renderItem={(item: Item) => (
+          <div style={{ alignItems: 'center', display: 'flex' }}>{item.Title}</div>
+        )}
+        search={searchFunction}
+        size="lg"
+      />
+    </div>
+  )
+}
+
+export default Example

--- a/lib/src/components/Search/docs/index.mdx
+++ b/lib/src/components/Search/docs/index.mdx
@@ -11,3 +11,9 @@ peerDependencies: 'downshift'
 To use option groups, you must provide two additional props: `groupsEnabled` that allow nested options and `renderGroupHeader` that renders the header of a specific group
 
 <div data-playground="option-groups.tsx" data-component="Search"></div>
+
+### With icon
+
+You can add an icon and choose its position. To change the icon size, set the `size` prop on the `Search` component — the icon scales with it.
+
+<div data-playground="with-icon.tsx" data-component="Search"></div>

--- a/lib/src/components/Search/index.tsx
+++ b/lib/src/components/Search/index.tsx
@@ -182,10 +182,10 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
                     className={cx(
                       'icon-wrapper',
                       `icon-placement-${iconPlacement}`,
-                      `size-${size}`
+                      `icon-placement-${iconPlacement}-${size}`
                     )}
                   >
-                    <Icon {...icon.props} size="lg" />
+                    <Icon {...icon.props} size={size} />
                   </div>
                 ) : null}
                 <div className={cx('indicators', `size-${size}`)}>

--- a/lib/src/components/Search/search.module.scss
+++ b/lib/src/components/Search/search.module.scss
@@ -10,7 +10,7 @@
     padding: 0;
     top: 0;
     height: var(--searchHeight, 100%);
-    right: var(--indicatorsRight, 0);
+    right: var(--indicatorsRight, var(--searchPaddingInline));
     display: flex;
     gap: var(--border-radius-sm);
   }
@@ -34,7 +34,7 @@
 
     &:has(> .icon-placement-right) {
       .indicators {
-        --indicatorsRight: calc((var(--searchIconSize, 1rem) + var(--border-radius-md)));
+        --indicatorsRight: calc(var(--searchPaddingInline) + var(--searchIconSize, var(--size-icon-md)));
       }
     }
   }
@@ -65,17 +65,22 @@
     padding-inline: var(--searchPaddingInline);
     padding-block: var(--searchPaddingBlock);
 
-    /* left icon */
+    /* left icon: equal padding on both sides — border→paddingInline→icon→paddingInline→text */
     &.icon-placement-left {
-      padding-left: calc(
-        var(--searchPaddingLeft) + var(--searchIconSize, 1rem) + var(--border-radius-md)
+      padding-left: calc(var(--searchPaddingInline) * 2 + var(--searchIconSize, var(--size-icon-md)));
+    }
+
+    /* right icon: reserve space for icon + clear button + padding */
+    &.icon-placement-right {
+      padding-right: calc(
+        var(--searchPaddingInline) * 2 + var(--searchIconSize, var(--size-icon-md)) + var(--button-size-icon-sm)
       );
     }
 
-    /*  right icon */
-    &.icon-placement-right {
+    /* no right icon: reserve space for clear button when there's a value */
+    &:not(.icon-placement-right):not(:placeholder-shown) {
       padding-right: calc(
-        var(--searchPaddingRight) + (var(--searchIconSize, 1rem) + var(--border-radius-md)) * 2
+        var(--searchPaddingInline) * 2 + var(--button-size-icon-sm)
       );
     }
 
@@ -133,18 +138,21 @@
       --searchHeight: var(--input-max-height-lg);
       --searchPaddingBlock: var(--input-padding-block-lg);
       --searchPaddingInline: var(--input-padding-inline-lg);
+      --searchIconSize: var(--size-icon-lg);
     }
 
     &-md {
       --searchHeight: var(--input-max-height-md);
       --searchPaddingBlock: var(--input-padding-block-md);
       --searchPaddingInline: var(--input-padding-inline-md);
+      --searchIconSize: var(--size-icon-md);
     }
 
     &-sm {
       --searchHeight: var(--input-max-height-sm);
       --searchPaddingBlock: var(--input-padding-block-sm);
       --searchPaddingInline: var(--input-padding-inline-sm);
+      --searchIconSize: var(--size-icon-sm);
     }
   }
 
@@ -185,6 +193,10 @@
       &-md {
         --searchIconLeft: var(--input-padding-inline-md);
       }
+
+      &-lg {
+        --searchIconLeft: var(--input-padding-inline-lg);
+      }
     }
 
     &-right {
@@ -194,6 +206,10 @@
 
       &-md {
         --searchIconRight: var(--input-padding-inline-md);
+      }
+
+      &-lg {
+        --searchIconRight: var(--input-padding-inline-lg);
       }
     }
   }

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -193,6 +193,7 @@ export default {
   "/RadioTab/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/RadioTab/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
   "/Search/docs/examples/option-groups.tsx": dynamic(() => import("../../lib/src/components/Search/docs/examples/option-groups.tsx").then(mod => mod), { ssr: false }),
   "/Search/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/Search/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),
+  "/Search/docs/examples/with-icon.tsx": dynamic(() => import("../../lib/src/components/Search/docs/examples/with-icon.tsx").then(mod => mod), { ssr: false }),
   "/Select/docs/examples/allow-unselect-from-list.tsx": dynamic(() => import("../../lib/src/components/Select/docs/examples/allow-unselect-from-list.tsx").then(mod => mod), { ssr: false }),
   "/Select/docs/examples/clearable.tsx": dynamic(() => import("../../lib/src/components/Select/docs/examples/clearable.tsx").then(mod => mod), { ssr: false }),
   "/Select/docs/examples/creatable-custom.tsx": dynamic(() => import("../../lib/src/components/Select/docs/examples/creatable-custom.tsx").then(mod => mod), { ssr: false }),


### PR DESCRIPTION
## DESCRIPTION

The icon placement is wrong and overlap with the current placeholder/value: 

<img width="620" height="98" alt="image" src="https://github.com/user-attachments/assets/693a50c2-2383-40a1-b1fd-c6f33a105834" />

And the current code:
```typescript
     <Search
        icon={<Icon name="search" />}
        iconPlacement="right"
        ...
     />
``` 

The icon is also not on the right position.

## SCREENSHOTS / SCREEN RECORDINGS

After the fix:

<img width="856" height="745" alt="Screenshot 2026-06-10 at 09 20 37" src="https://github.com/user-attachments/assets/6a6b10d4-e19d-4216-a7a0-c173e2cdeecb" />

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases
