### PR TITLE
feat(Window): add "active" state to window action

### DIFF
--- a/lib/src/components/Window/components/Header.tsx
+++ b/lib/src/components/Window/components/Header.tsx
@@ -24,12 +24,14 @@ const Button = ({
   'aria-label': ariaLabel,
   className,
   icon,
+  isActive,
   onClick,
   ...rest
 }: PropsWithAs<As, ActionButtonProps>) => {
   return (
     <button
       aria-label={ariaLabel}
+      aria-pressed={isActive}
       className={cx('header-action-button', className)}
       onClick={onClick}
       type="button"

--- a/lib/src/components/Window/components/Header.tsx
+++ b/lib/src/components/Window/components/Header.tsx
@@ -24,7 +24,7 @@ const Button = ({
   'aria-label': ariaLabel,
   className,
   icon,
-  isActive = false,
+  isActive,
   onClick,
   ...rest
 }: PropsWithAs<As, ActionButtonProps>) => {

--- a/lib/src/components/Window/components/Header.tsx
+++ b/lib/src/components/Window/components/Header.tsx
@@ -24,7 +24,7 @@ const Button = ({
   'aria-label': ariaLabel,
   className,
   icon,
-  isActive,
+  isActive = false,
   onClick,
   ...rest
 }: PropsWithAs<As, ActionButtonProps>) => {

--- a/lib/src/components/Window/docs/examples/header-active-button.tsx
+++ b/lib/src/components/Window/docs/examples/header-active-button.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+
+import { Window } from '@/components/Window'
+
+const Example = () => {
+  const [isPinned, setIsPinned] = useState(false)
+
+  return (
+    <Window>
+      <Window.Header>
+        <Window.Header.LeftActions />
+        <Window.Header.Title title="Find your people" />
+        <Window.Header.RightActions isClosable>
+          <Window.Header.Button
+            aria-label={isPinned ? 'Unpin window' : 'Pin window'}
+            icon="setting"
+            isActive={isPinned}
+            onClick={() => setIsPinned(v => !v)}
+          />
+        </Window.Header.RightActions>
+      </Window.Header>
+      <Window.Body>
+        At work, behind every success story, someone found their people. Find your next job on
+        Welcome to the Jungle.
+      </Window.Body>
+    </Window>
+  )
+}
+export default Example

--- a/lib/src/components/Window/docs/index.mdx
+++ b/lib/src/components/Window/docs/index.mdx
@@ -31,6 +31,12 @@ Use `Window.Header.RightActions` for closable controls and custom action buttons
 
 <div data-playground="custom-header-action.tsx" data-component="Window"></div>
 
+#### Active button
+
+Use the `isActive` prop on `Window.Header.Button` to keep a button in its pressed state — useful for toggle actions like pinning a window.
+
+<div data-playground="header-active-button.tsx" data-component="Window"></div>
+
 ### Tab Panels
 
 Use `Window.TabPanel` to create content sections that correspond to tabs in the header. Each tab panel requires both a `store` prop (the same tab store used in `Window.Header.Tabs`) and a `tabId` prop that matches the id of its corresponding tab.

--- a/lib/src/components/Window/index.test.tsx
+++ b/lib/src/components/Window/index.test.tsx
@@ -8,6 +8,10 @@ import { render } from '@tests'
 const onClose = vi.fn()
 const onExpand = vi.fn()
 
+const WindowButtonWrapper = ({ isActive = false, ...rest }) => (
+  <Window.Header.Button aria-label="Pin window" icon="setting" isActive={isActive} {...rest} />
+)
+
 describe('<Window>', () => {
   it('should render correctly', () => {
     const { container } = render(<Window>Content</Window>)
@@ -126,6 +130,24 @@ describe('<Window>', () => {
     )
 
     expect(screen.getByAltText('Test image')).toBeInTheDocument()
+  })
+
+  it('should set aria-pressed to true when isActive is true on Header.Button', () => {
+    render(<WindowButtonWrapper data-testid="window-header-button-active" isActive={true} />)
+
+    expect(screen.getByTestId('window-header-button-active')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('should set aria-pressed to false when isActive is not set on Header.Button', () => {
+    render(<WindowButtonWrapper data-testid="window-header-button-inactive" />)
+
+    expect(screen.getByTestId('window-header-button-inactive')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
   })
 
   it('should render with different body sizes', () => {

--- a/lib/src/components/Window/index.test.tsx
+++ b/lib/src/components/Window/index.test.tsx
@@ -8,7 +8,10 @@ import { render } from '@tests'
 const onClose = vi.fn()
 const onExpand = vi.fn()
 
-const WindowButtonWrapper = ({ isActive = false, ...rest }) => (
+const WindowButtonWrapper = ({
+  isActive,
+  ...rest
+}: Partial<React.ComponentProps<typeof Window.Header.Button>>) => (
   <Window.Header.Button aria-label="Pin window" icon="setting" isActive={isActive} {...rest} />
 )
 
@@ -142,12 +145,18 @@ describe('<Window>', () => {
   })
 
   it('should set aria-pressed to false when isActive is not set on Header.Button', () => {
-    render(<WindowButtonWrapper data-testid="window-header-button-inactive" />)
+    render(<WindowButtonWrapper data-testid="window-header-button-inactive" isActive={false} />)
 
     expect(screen.getByTestId('window-header-button-inactive')).toHaveAttribute(
       'aria-pressed',
       'false'
     )
+  })
+
+  it('should keep aria-pressed undefined when isActive props is not sent to Header.Button', () => {
+    render(<WindowButtonWrapper data-testid="window-header-button-inactive" />)
+
+    expect(screen.getByTestId('window-header-button-inactive')).not.toHaveAttribute('aria-pressed')
   })
 
   it('should render with different body sizes', () => {

--- a/lib/src/components/Window/types.ts
+++ b/lib/src/components/Window/types.ts
@@ -8,6 +8,7 @@ import type { IconName } from '../Icon/types'
 
 export interface ActionButtonOptions {
   icon: IconName
+  isActive?: boolean
 }
 
 export type ActionButtonProps = MergeProps<HTMLAttributes<HTMLButtonElement>, ActionButtonOptions>

--- a/lib/src/components/Window/window.module.scss
+++ b/lib/src/components/Window/window.module.scss
@@ -114,7 +114,8 @@
       --windowButtonIconColor: var(--window-header-action-color-icon-common-hover);
     }
 
-    &:active {
+    &:active,
+    &[aria-pressed='true'] {
       --windowButtonBackgroundColor: var(--window-header-action-color-background-common-pressed);
       --windowButtonIconColor: var(--window-header-action-color-icon-common-pressed);
     }

--- a/website/build-app/examples.js
+++ b/website/build-app/examples.js
@@ -290,6 +290,7 @@ export default {
   "/WelcomeLoader/docs/examples/resize.tsx": dynamic(() => import("../../lib/src/components/WelcomeLoader/docs/examples/resize.tsx").then(mod => mod), { ssr: false }),
   "/Window/docs/examples/body-text.tsx": dynamic(() => import("../../lib/src/components/Window/docs/examples/body-text.tsx").then(mod => mod), { ssr: false }),
   "/Window/docs/examples/custom-header-action.tsx": dynamic(() => import("../../lib/src/components/Window/docs/examples/custom-header-action.tsx").then(mod => mod), { ssr: false }),
+  "/Window/docs/examples/header-active-button.tsx": dynamic(() => import("../../lib/src/components/Window/docs/examples/header-active-button.tsx").then(mod => mod), { ssr: false }),
   "/Window/docs/examples/header.tsx": dynamic(() => import("../../lib/src/components/Window/docs/examples/header.tsx").then(mod => mod), { ssr: false }),
   "/Window/docs/examples/media.tsx": dynamic(() => import("../../lib/src/components/Window/docs/examples/media.tsx").then(mod => mod), { ssr: false }),
   "/Window/docs/examples/overview.tsx": dynamic(() => import("../../lib/src/components/Window/docs/examples/overview.tsx").then(mod => mod), { ssr: false }),


### PR DESCRIPTION
## DESCRIPTION

<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Add an active state for Window header button.

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

http://localhost:3020/components/window#header > Active button

click on the "setting" icon

## SCREENSHOTS / SCREEN RECORDINGS

<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

Active
<img width="874" height="641" alt="Capture d’écran 2026-06-10 à 14 59 14" src="https://github.com/user-attachments/assets/1da95c72-9f5e-45f7-9304-9608bda0e2f7" />

Not active
<img width="842" height="623" alt="Capture d’écran 2026-06-10 à 14 59 22" src="https://github.com/user-attachments/assets/fc441d32-cb85-456b-8888-111a9cd5ccd1" />

## COMPATIBILITY

- [x] Tested on Safari (desktop)
- [x] Tested on Chrome (desktop)
- [x] Tested on Firefox (desktop)
- [x] Tested on mobile device sizes
- [x] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [x] Thoroughly tested in local environment
- [x] Added tests for all new features
- [x] Added tests that considered edge cases
