### PR TITLE
Fix(Tabs): update focused tab color tokens

### DIFF
--- a/lib/src/components/Tabs/tabs.module.scss
+++ b/lib/src/components/Tabs/tabs.module.scss
@@ -35,9 +35,9 @@
       --tabItemBorderColor: var(--tab-color-border-unchecked-pressed);
 
       &[aria-selected='true'] {
-        --tabItemColor: var(--tab-color-text-checked-pressed);
-        --tabItemBackgroundColor: var(--tab-color-background-checked-pressed);
-        --tabItemBorderColor: var(--tab-color-border-checked-pressed);
+        --tabItemColor: var(--tab-color-text-checked-default);
+        --tabItemBackgroundColor: var(--tab-color-background-checked-default);
+        --tabItemBorderColor: var(--tab-color-border-checked-default);
       }
     }
 


### PR DESCRIPTION
### Update focused tab color tokens
According to the design team, the focused state on an active tab should use the same colors as the active state. The previous color token introduced a darker shade of yellow. 
Colors of focused unactive tabs remain unchanged.
[Figma](https://www.figma.com/design/rS99VkKaw9ITOcduMu5aX7/Belonging-Experience---Design-System?node-id=2436-1537&t=aG4mpaX3eQ1AFQGE-0)

### HOW TO TEST
Click on a selected tab to trigger a focus state

### SCREENSHOTS / SCREEN RECORDINGS
<img width="531" height="85" alt="wui-tab-focused-colors" src="https://github.com/user-attachments/assets/7dc9ee0b-a098-422f-92b0-5be74b11fbab" />
