### PR TITLE
feat(utils): add useBreakpoint hook

### DIFF
--- a/lib/src/utils/index.ts
+++ b/lib/src/utils/index.ts
@@ -1,4 +1,7 @@
 export * from './classNames'
 export * from './forwardRefWithAs'
 export * from './ts-utils'
+export * from './use-breakpoint'
 export * from './use-copy-text'
+export * from './use-screens'
+export * from './use-viewport'

--- a/lib/src/utils/use-breakpoint.test.ts
+++ b/lib/src/utils/use-breakpoint.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react'
+
+import { useBreakpoint } from './use-breakpoint'
+
+describe('useBreakpoint', () => {
+  const originalInnerWidth = window.innerWidth
+
+  afterEach(() => {
+    window.innerWidth = originalInnerWidth
+  })
+
+  it.each([
+    { expected: 'xs', width: 0 },
+    { expected: 'xs', width: 479 },
+    { expected: 'sm', width: 480 },
+    { expected: 'sm', width: 735 },
+    { expected: 'md', width: 736 },
+    { expected: 'md', width: 979 },
+    { expected: 'lg', width: 980 },
+    { expected: 'lg', width: 1279 },
+    { expected: 'xl', width: 1280 },
+    { expected: 'xl', width: 1439 },
+    { expected: '2xl', width: 1440 },
+    { expected: '2xl', width: 1619 },
+    { expected: '3xl', width: 1620 },
+    { expected: '3xl', width: 1919 },
+    { expected: '4xl', width: 1920 },
+  ])('returns $expected for a $widthpx wide viewport', ({ expected, width }) => {
+    window.innerWidth = width
+
+    const { result } = renderHook(() => useBreakpoint())
+
+    expect(result.current).toBe(expected)
+  })
+
+  it.each([
+    { expected: 'sm', width: 480 },
+    { expected: 'md', width: 736 },
+    { expected: 'lg', width: 980 },
+  ])(
+    'returns $expected for a $widthpx wide viewport when the boundary is "includeThreshold"',
+    ({ expected, width }) => {
+      window.innerWidth = width
+
+      const { result } = renderHook(() => useBreakpoint('includeThreshold'))
+
+      expect(result.current).toBe(expected)
+    }
+  )
+
+  it.each([
+    { expected: 'xs', width: 480 },
+    { expected: 'sm', width: 736 },
+    { expected: 'md', width: 980 },
+  ])(
+    'returns $expected for a $widthpx wide viewport when the boundary is "excludeThreshold"',
+    ({ expected, width }) => {
+      window.innerWidth = width
+
+      const { result } = renderHook(() => useBreakpoint('excludeThreshold'))
+
+      expect(result.current).toBe(expected)
+    }
+  )
+})

--- a/lib/src/utils/use-breakpoint.ts
+++ b/lib/src/utils/use-breakpoint.ts
@@ -1,0 +1,39 @@
+import type { ScreenSizes } from '@/theme/types'
+
+import { useScreens } from './use-screens'
+import { useViewportSize } from './use-viewport'
+
+// 'xxl' is a legacy alias of '2xl' (same pixel value) — excluded to avoid an ambiguous tie
+export type Breakpoint = Exclude<ScreenSizes, 'xxl'>
+
+export type BreakpointBoundary = 'excludeThreshold' | 'includeThreshold'
+
+/**
+ * Reactive current breakpoint name, derived from the theme's screen tokens
+ * and the live viewport width.
+ *
+ * @param boundary - How to resolve a viewport that's exactly at a breakpoint's threshold:
+ * - `'includeThreshold'` (default): the breakpoint starts as soon as the viewport reaches its
+ *   threshold (`width >= threshold`). E.g. at exactly 736px, `useBreakpoint()` returns `'md'`.
+ * - `'excludeThreshold'`: the breakpoint only starts once the viewport strictly passes its
+ *   threshold (`width > threshold`). E.g. at exactly 736px, `useBreakpoint('excludeThreshold')`
+ *   returns `'sm'` — `'md'` only kicks in at 737px.
+ */
+export function useBreakpoint(boundary: BreakpointBoundary = 'includeThreshold'): Breakpoint {
+  const { width } = useViewportSize()
+  const screens = useScreens()
+
+  const currentWidth = width ?? (typeof window !== 'undefined' ? window.innerWidth : 0)
+
+  const hasReached = (threshold: number) =>
+    boundary === 'includeThreshold' ? currentWidth >= threshold : currentWidth > threshold
+
+  const sortedBreakpoints = (Object.keys(screens) as ScreenSizes[])
+    .filter((name): name is Breakpoint => name !== 'xxl')
+    .sort((a, b) => screens[a] - screens[b])
+
+  return sortedBreakpoints.reduce(
+    (current, name) => (hasReached(screens[name]) ? name : current),
+    sortedBreakpoints[0]
+  )
+}

--- a/lib/src/utils/use-viewport.test.ts
+++ b/lib/src/utils/use-viewport.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useViewportSize } from './use-viewport'
+
+describe('useViewportSize', () => {
+  let resizeCallback: (
+    entries: Array<{ contentBoxSize: [{ blockSize: number; inlineSize: number }] }>
+  ) => void
+  const disconnect = vi.fn()
+  const observe = vi.fn()
+
+  const triggerResize = (width: number, height: number) => {
+    resizeCallback([{ contentBoxSize: [{ blockSize: height, inlineSize: width }] }])
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+
+    global.ResizeObserver = vi.fn().mockImplementation(function (callback) {
+      resizeCallback = callback
+      this.disconnect = disconnect
+      this.observe = observe
+      this.unobserve = vi.fn()
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('returns an undefined size before any resize is observed', () => {
+    const { result } = renderHook(() => useViewportSize())
+
+    expect(result.current).toEqual({ height: undefined, width: undefined })
+  })
+
+  it('observes the document element on mount', () => {
+    renderHook(() => useViewportSize())
+
+    expect(observe).toHaveBeenCalledWith(document.documentElement)
+  })
+
+  it('updates the size once a resize is observed', () => {
+    const { result } = renderHook(() => useViewportSize())
+
+    act(() => {
+      triggerResize(1024, 768)
+      vi.runAllTimers()
+    })
+
+    expect(result.current).toEqual({ height: 768, width: 1024 })
+  })
+
+  it('disconnects the observer on unmount', () => {
+    const { unmount } = renderHook(() => useViewportSize())
+
+    unmount()
+
+    expect(disconnect).toHaveBeenCalled()
+  })
+})

--- a/lib/src/utils/use-viewport.ts
+++ b/lib/src/utils/use-viewport.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect'
 
@@ -7,27 +7,29 @@ type Size = {
   width: number
 }
 
+const RESIZE_THROTTLE_MS = 300
+
 export function useViewportSize(): Size {
   const [size, setSize] = useState<Size>({ height: undefined, width: undefined })
-
-  // Throttle resize events to prevent excessive updates
-  const handleResize = ({ height, width }: { height: number; width: number }) => {
-    let timer: NodeJS.Timeout = undefined
-    clearTimeout(timer)
-    timer = setTimeout(() => {
-      setSize({ height, width })
-    }, 300)
-  }
+  // Persisted across resize events so each new resize cancels the previous pending update
+  const timerRef = useRef<NodeJS.Timeout>()
 
   useIsomorphicLayoutEffect(() => {
     // ResizeObserver is more performant than the window resize event
     const observer = new ResizeObserver(([entry]) => {
       const { blockSize: height, inlineSize: width } = entry.contentBoxSize[0]
-      handleResize({ height, width })
+
+      clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        setSize({ height, width })
+      }, RESIZE_THROTTLE_MS)
     })
 
     observer.observe(document.documentElement)
-    return () => observer.disconnect()
+    return () => {
+      clearTimeout(timerRef.current)
+      observer.disconnect()
+    }
   }, [])
 
   return size


### PR DESCRIPTION
This pr adds a useBreakpoint hook that derives the current breakpoint (xs → 4xl) from the theme's screen tokens and the live viewport width, with a configurable boundary mode (includeThreshold default / excludeThreshold) to handle viewports sitting exactly on a threshold.

  - Exposes useScreens and useViewportSize from the utils barrel (previously internal-only, used by Swiper; now public since useBreakpoint builds on top of them).
  - Fixes a bug in useViewportSize: the throttle timer was redeclared on every resize, so clearTimeout never actually cancelled anything — each resize scheduled its own independent update.
  - Adds test coverage for both hooks.