### PR TITLE
Fix(Swiper): ensure initial slide is displayed

### DIFF
--- a/lib/src/components/Modal/docs/examples/asset-swiper-title.tsx
+++ b/lib/src/components/Modal/docs/examples/asset-swiper-title.tsx
@@ -22,33 +22,38 @@ const Example = () => {
         >
           <AssetModal.Content>
             <Swiper store={swiper}>
-              <AssetModal.AssetWithTitle subtitle="THE JOB IS YOURS" title="Sapin & Rétroviseur">
-                <AssetModal.Iframe>
-                  <iframe
-                    allowFullScreen
-                    src="https://www.youtube.com/embed/uSTy3cT5hbw"
-                    title="YouTube video player"
-                  />
-                </AssetModal.Iframe>
-              </AssetModal.AssetWithTitle>
-              <AssetModal.AssetWithTitle subtitle="THE JOB IS YOURS" title="Claquette & Chaussette">
-                <AssetModal.Iframe>
-                  <iframe
-                    allowFullScreen
-                    src="https://www.youtube.com/embed/1kjATTF4v5A"
-                    title="YouTube video player"
-                  />
-                </AssetModal.Iframe>
-              </AssetModal.AssetWithTitle>
-              <AssetModal.AssetWithTitle subtitle="THE JOB IS YOURS" title="Pizza & Ananas">
-                <AssetModal.Iframe>
-                  <iframe
-                    allowFullScreen
-                    src="https://www.youtube.com/embed/YlEMLSsv_3w"
-                    title="YouTube video player"
-                  />
-                </AssetModal.Iframe>
-              </AssetModal.AssetWithTitle>
+              <Swiper.Slides>
+                <AssetModal.AssetWithTitle subtitle="THE JOB IS YOURS" title="Sapin & Rétroviseur">
+                  <AssetModal.Iframe>
+                    <iframe
+                      allowFullScreen
+                      src="https://www.youtube.com/embed/uSTy3cT5hbw"
+                      title="YouTube video player"
+                    />
+                  </AssetModal.Iframe>
+                </AssetModal.AssetWithTitle>
+                <AssetModal.AssetWithTitle
+                  subtitle="THE JOB IS YOURS"
+                  title="Claquette & Chaussette"
+                >
+                  <AssetModal.Iframe>
+                    <iframe
+                      allowFullScreen
+                      src="https://www.youtube.com/embed/1kjATTF4v5A"
+                      title="YouTube video player"
+                    />
+                  </AssetModal.Iframe>
+                </AssetModal.AssetWithTitle>
+                <AssetModal.AssetWithTitle subtitle="THE JOB IS YOURS" title="Pizza & Ananas">
+                  <AssetModal.Iframe>
+                    <iframe
+                      allowFullScreen
+                      src="https://www.youtube.com/embed/YlEMLSsv_3w"
+                      title="YouTube video player"
+                    />
+                  </AssetModal.Iframe>
+                </AssetModal.AssetWithTitle>
+              </Swiper.Slides>
             </Swiper>
           </AssetModal.Content>
         </Modal>

--- a/lib/src/components/Modal/docs/examples/asset-swiper.tsx
+++ b/lib/src/components/Modal/docs/examples/asset-swiper.tsx
@@ -22,18 +22,20 @@ const Example = () => {
         >
           <AssetModal.Content>
             <Swiper className="h-[calc(100vh - 10rem)]" store={swiper}>
-              <img
-                src="https://cdn-images.welcometothejungle.com/H6cEYCT1JsY1ipyX37LWouwduQZNHlUikfeUaHhUagA/rs:auto:1500::/q:85/czM6Ly93dHRqLXByb2R1Y3Rpb24vdXBsb2Fkcy9pbWFnZS9maWxlLzk4NTMvMTYzMzYyL2I5OTdhMzIxLTJlNjktNGM1Ny05NzcyLWE0YjU3ZmQ0YWNiMi5qcGc"
-                style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }}
-              />
-              <img
-                src="https://cdn-images.welcometothejungle.com/7DJ8Ggq5-1JMgNEcVXLlM7xqDOBNhBoZ9QpEdO1G4Qs/rs:auto:1500::/q:85/czM6Ly93dHRqLXByb2R1Y3Rpb24vdXBsb2Fkcy9pbWFnZS9maWxlLzQ0OTEvMTcwMzg2LzdiYWRjMjc4LTQ3MWUtNDI1My1hN2NmLWJkM2FiYmNiMTM4Yi5qcGc"
-                style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }}
-              />
-              <img
-                src="https://cdn-images.welcometothejungle.com/rUlGHCfE1zos9CVMJELrqCeCVzH27VuBO8GH5yiMkic/rs:auto:1500::/q:85/czM6Ly93dHRqLXByb2R1Y3Rpb24vdXBsb2Fkcy9pbWFnZS9maWxlLzQ0MjIvMTcwMzg2L2NkNGRhNTc5LWQ4YTktNDQ0OC1iMGM2LWI3ZWYwY2U2ZjQ0MS5qcGc"
-                style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }}
-              />
+              <Swiper.Slides>
+                <img
+                  src="https://cdn-images.welcometothejungle.com/H6cEYCT1JsY1ipyX37LWouwduQZNHlUikfeUaHhUagA/rs:auto:1500::/q:85/czM6Ly93dHRqLXByb2R1Y3Rpb24vdXBsb2Fkcy9pbWFnZS9maWxlLzk4NTMvMTYzMzYyL2I5OTdhMzIxLTJlNjktNGM1Ny05NzcyLWE0YjU3ZmQ0YWNiMi5qcGc"
+                  style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }}
+                />
+                <img
+                  src="https://cdn-images.welcometothejungle.com/7DJ8Ggq5-1JMgNEcVXLlM7xqDOBNhBoZ9QpEdO1G4Qs/rs:auto:1500::/q:85/czM6Ly93dHRqLXByb2R1Y3Rpb24vdXBsb2Fkcy9pbWFnZS9maWxlLzQ0OTEvMTcwMzg2LzdiYWRjMjc4LTQ3MWUtNDI1My1hN2NmLWJkM2FiYmNiMTM4Yi5qcGc"
+                  style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }}
+                />
+                <img
+                  src="https://cdn-images.welcometothejungle.com/rUlGHCfE1zos9CVMJELrqCeCVzH27VuBO8GH5yiMkic/rs:auto:1500::/q:85/czM6Ly93dHRqLXByb2R1Y3Rpb24vdXBsb2Fkcy9pbWFnZS9maWxlLzQ0MjIvMTcwMzg2L2NkNGRhNTc5LWQ4YTktNDQ0OC1iMGM2LWI3ZWYwY2U2ZjQ0MS5qcGc"
+                  style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }}
+                />
+              </Swiper.Slides>
             </Swiper>
           </AssetModal.Content>
         </Modal>

--- a/lib/src/components/Swiper/index.test.tsx
+++ b/lib/src/components/Swiper/index.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { act, fireEvent, screen } from '@testing-library/react'
 
 import { render } from '@tests'
 
@@ -146,6 +146,167 @@ describe('<Swiper>', () => {
 
       expect(slide2).toHaveAttribute('aria-hidden', 'false')
       expect(scrollToSpy).toHaveBeenCalled()
+    })
+  })
+
+  // These tests pin the contract, they cannot reproduce the bug they guard
+  // against: jsdom has no layout and no scroll snapping, `getBoundingClientRect`
+  // always reports a width of 0, and `ResizeObserver` is stubbed out globally in
+  // tests/setup.ts (so `useViewportSize` never resolves). What they cover is that
+  // the initial scroll is deferred, that the target page is clamped, that state
+  // is synced without a second scroll, and that the one-shot snap guard neither
+  // swallows a user scroll nor wedges navigation.
+  describe('initialIndex', () => {
+    const TestSwiperWithInitialIndex = ({ initialIndex }: { initialIndex?: number }) => {
+      const swiper = useSwiper({ slides: { initialIndex } })
+
+      return (
+        <Swiper store={swiper}>
+          <Swiper.Slides>
+            <div>page1</div>
+            <div>page2</div>
+            <div>page3</div>
+          </Swiper.Slides>
+        </Swiper>
+      )
+    }
+
+    let requestAnimationFrameSpy: ReturnType<typeof vi.spyOn>
+    let cancelAnimationFrameSpy: ReturnType<typeof vi.spyOn>
+
+    /** Runs frames synchronously, so init lands inside `render`'s `act` */
+    const useSyncAnimationFrames = () => {
+      requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation(callback => {
+          callback(0)
+
+          return 0
+        })
+      cancelAnimationFrameSpy = vi
+        .spyOn(window, 'cancelAnimationFrame')
+        .mockImplementation(() => {})
+    }
+
+    /** Captures frames instead of running them, so deferral is observable */
+    const useCapturedAnimationFrames = () => {
+      const frames: FrameRequestCallback[] = []
+
+      requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation(callback => {
+          frames.push(callback)
+
+          return frames.length
+        })
+      cancelAnimationFrameSpy = vi
+        .spyOn(window, 'cancelAnimationFrame')
+        .mockImplementation(() => {})
+
+      return {
+        flush: () => {
+          const pending = frames.splice(0, frames.length)
+
+          act(() => {
+            pending.forEach(callback => callback(0))
+          })
+        },
+      }
+    }
+
+    beforeEach(() => {
+      scrollToSpy.mockClear()
+    })
+
+    afterEach(() => {
+      // Restore these two specifically: `Element.prototype.scrollTo` is assigned
+      // in the outer `beforeAll` and `scrollToSpy` is shared across the file, so
+      // a blanket restore would break the tests above.
+      requestAnimationFrameSpy?.mockRestore()
+      cancelAnimationFrameSpy?.mockRestore()
+      vi.useRealTimers()
+    })
+
+    it('should scroll to the page holding the initial slide', () => {
+      useSyncAnimationFrames()
+
+      render(<TestSwiperWithInitialIndex initialIndex={2} />)
+
+      // initialIndex is 1-based, so slide 2 with 1 slide per view is page 1.
+      // childWidth is 0 in jsdom, gap is 20, hence left: 1 * (0 + 20) * 1
+      expect(scrollToSpy).toHaveBeenCalledWith({ behavior: 'auto', left: 20, top: 0 })
+      expect(screen.getByText('page1')).toHaveAttribute('aria-hidden', 'true')
+      expect(screen.getByText('page2')).toHaveAttribute('aria-hidden', 'false')
+    })
+
+    it('should defer the initial scroll until after the first paint', () => {
+      const { flush } = useCapturedAnimationFrames()
+
+      render(<TestSwiperWithInitialIndex initialIndex={2} />)
+
+      expect(scrollToSpy).not.toHaveBeenCalled()
+
+      // First frame only schedules the second one
+      flush()
+
+      expect(scrollToSpy).not.toHaveBeenCalled()
+
+      flush()
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ behavior: 'auto', left: 20, top: 0 })
+    })
+
+    it('should not scroll when the initial slide is already the first one', () => {
+      useSyncAnimationFrames()
+
+      render(<TestSwiperWithInitialIndex />)
+
+      // The default initialIndex of 0 computes to page -1 before clamping
+      expect(scrollToSpy).not.toHaveBeenCalled()
+      expect(screen.getByText('page1')).toHaveAttribute('aria-hidden', 'false')
+    })
+
+    it('should clamp an initial slide past the last page', () => {
+      useSyncAnimationFrames()
+
+      render(<TestSwiperWithInitialIndex initialIndex={99} />)
+
+      // 3 slides, 1 per view, so the last page is 2: left: 2 * (0 + 20) * 1
+      expect(scrollToSpy).toHaveBeenCalledWith({ behavior: 'auto', left: 40, top: 0 })
+      expect(screen.getByText('page3')).toHaveAttribute('aria-hidden', 'false')
+    })
+
+    it('should still follow user scrolls after the initial one', () => {
+      vi.useFakeTimers()
+      useSyncAnimationFrames()
+
+      render(<TestSwiperWithInitialIndex initialIndex={2} />)
+
+      const track = screen.getByRole('list')
+
+      // Consumes the one-shot guard
+      fireEvent.scroll(track)
+      act(() => {
+        vi.advanceTimersByTime(150)
+      })
+
+      // A genuine scroll back to the first page, with enough geometry for
+      // updatePage to take its non-last-page branch
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        value: 896,
+      })
+      Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+        configurable: true,
+        value: 2688,
+      })
+      fireEvent.scroll(track)
+      act(() => {
+        vi.advanceTimersByTime(150)
+      })
+
+      expect(screen.getByText('page1')).toHaveAttribute('aria-hidden', 'false')
+      expect(screen.getByText('page2')).toHaveAttribute('aria-hidden', 'true')
     })
   })
 })

--- a/lib/src/components/Swiper/index.test.tsx
+++ b/lib/src/components/Swiper/index.test.tsx
@@ -225,6 +225,10 @@ describe('<Swiper>', () => {
       requestAnimationFrameSpy?.mockRestore()
       cancelAnimationFrameSpy?.mockRestore()
       vi.useRealTimers()
+
+      // undo the per-test geometry stubs
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { value: 0 })
+      Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { value: 0 })
     })
 
     it('should scroll to the page holding the initial slide', () => {

--- a/lib/src/components/Swiper/index.tsx
+++ b/lib/src/components/Swiper/index.tsx
@@ -16,10 +16,6 @@ export { swiperStyles as swiperClasses }
 
 const cx = classNames(swiperStyles)
 
-// Fallback release for the one-shot guard below, in case our own initial scroll
-// never emits a scroll event to consume it.
-const INITIAL_SCROLL_GUARD_TIMEOUT = 500
-
 type SwiperContextValue = {
   navigation: {
     desktop: boolean
@@ -173,13 +169,10 @@ export const Swiper: SwiperComponent = ({
   const hasInitializedRef = useRef(false)
   // Pending frame of the deferred initial scroll, `undefined` once it has run.
   const initFrameRef = useRef<number>()
-  const hasScheduledInitialScrollRef = useRef(false)
-  // Set while the browser settles our own initial scroll, so the scroll-snap
-  // correction that follows it can't be read back as the current page.
-  const initialScrollGuardRef = useRef(false)
-  const initialScrollGuardTimerRef = useRef<ReturnType<typeof setTimeout>>()
+  // Swallows the scroll-snap correction that follows our own initial scroll.
+  const skipSnapBackRef = useRef(false)
   const skipNextPageScrollRef = useRef(false)
-  // Read inside the deferred frame so it picks up the viewport-corrected value.
+  // Read inside the deferred frame so it reflects the viewport-corrected perView.
   const firstPageToShowRef = useRef(0)
 
   const [slidesLength, setSlidesLength] = useState(0)
@@ -227,9 +220,8 @@ export const Swiper: SwiperComponent = ({
         // Navigation state should always reflect the real geometry, guard or not
         getNavigationState()
 
-        if (initialScrollGuardRef.current) {
-          initialScrollGuardRef.current = false
-          clearTimeout(initialScrollGuardTimerRef.current)
+        if (skipSnapBackRef.current) {
+          skipSnapBackRef.current = false
 
           return
         }
@@ -239,9 +231,8 @@ export const Swiper: SwiperComponent = ({
     [getNavigationState, updatePage]
   )
 
-  // Keep the latest debounced instance in a ref so we can cancel exactly one
-  // pending call, on unmount. Cancelling on `[handleScroll]` instead would drop
-  // legitimate updates, since `handleScroll` is re-memoized on every
+  // Cancel exactly one pending call on unmount. Depending on `[handleScroll]`
+  // would drop legitimate updates, since it is re-memoized on every
   // `currentPage` change — that is, mid-swipe.
   const handleScrollRef = useRef(handleScroll)
   handleScrollRef.current = handleScroll
@@ -328,56 +319,41 @@ export const Swiper: SwiperComponent = ({
   firstPageToShowRef.current = firstPageToShow
 
   useEffect(() => {
-    // Only navigate to initial page once, when slidesLength is first known
-    if (!slidesLength || hasScheduledInitialScrollRef.current) {
+    // Only navigate to the initial page once, when slidesLength is first known.
+    // `hasInitializedRef` is set synchronously as it also gates the
+    // external-`setCurrentPage` effect below.
+    if (!slidesLength || hasInitializedRef.current) {
       return
     }
 
-    hasScheduledInitialScrollRef.current = true
-    // Flagged synchronously: it gates the external-`setCurrentPage` effect below,
-    // which has to keep working even before the deferred scroll has run.
     hasInitializedRef.current = true
 
-    // The initial scroll has to land after the first paint. Issued during the
-    // first layout pass it is reverted to 0 by the browser's
-    // `scroll-snap-type: x mandatory` correction, and `updatePage` then latches
-    // that revert as the current page — which is why `initialIndex` was ignored
-    // in hosts that mount the swiper into an already-painting subtree (a dialog
-    // in a Next.js app, for instance) but worked in a plain client-only mount.
-    // One frame is not enough: a callback scheduled from a passive effect still
-    // runs before the next paint. The second frame also lets `useViewportSize`
-    // commit, so `firstPageToShowRef` holds the width-corrected page.
+    // The scroll must land after the first paint: issued during the first layout
+    // pass it is reverted to 0 by the browser's `scroll-snap-type: x mandatory`
+    // correction. One frame is not enough — a callback scheduled from a passive
+    // effect still runs before the next paint. The second frame also lets
+    // `useViewportSize` commit, so `firstPageToShowRef` is breakpoint-correct.
     initFrameRef.current = requestAnimationFrame(() => {
       initFrameRef.current = requestAnimationFrame(() => {
         initFrameRef.current = undefined
 
         const initialPage = firstPageToShowRef.current
 
-        // The track already starts at 0, so the first page needs no scroll
+        // The track already starts on the first page, so it needs no scroll
         if (initialPage <= 0) {
           return
         }
 
-        initialScrollGuardRef.current = true
-        initialScrollGuardTimerRef.current = setTimeout(() => {
-          initialScrollGuardRef.current = false
-        }, INITIAL_SCROLL_GUARD_TIMEOUT)
-
+        skipSnapBackRef.current = true
         goTo(initialPage, true)
-
-        if (initialPage !== currentPage) {
-          // `currentPage` is otherwise only ever synced by the scroll handler,
-          // which the guard above suppresses for this very scroll
-          skipNextPageScrollRef.current = true
-          setCurrentPage(initialPage)
-        }
+        // `currentPage` is otherwise only synced by the scroll handler, which we
+        // just told to skip this scroll, so set it here.
+        skipNextPageScrollRef.current = true
+        setCurrentPage(initialPage)
       })
     })
 
     return () => {
-      clearTimeout(initialScrollGuardTimerRef.current)
-      initialScrollGuardRef.current = false
-
       if (initFrameRef.current === undefined) {
         return
       }
@@ -386,7 +362,7 @@ export const Swiper: SwiperComponent = ({
       // the next mount schedule it again
       cancelAnimationFrame(initFrameRef.current)
       initFrameRef.current = undefined
-      hasScheduledInitialScrollRef.current = false
+      hasInitializedRef.current = false
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slidesLength])

--- a/lib/src/components/Swiper/index.tsx
+++ b/lib/src/components/Swiper/index.tsx
@@ -16,6 +16,10 @@ export { swiperStyles as swiperClasses }
 
 const cx = classNames(swiperStyles)
 
+// Fallback release for the one-shot guard below, in case our own initial scroll
+// never emits a scroll event to consume it.
+const INITIAL_SCROLL_GUARD_TIMEOUT = 500
+
 type SwiperContextValue = {
   navigation: {
     desktop: boolean
@@ -41,7 +45,7 @@ type SwiperContextValue = {
       mobile: number
       tablet: number
     }
-    ref: React.RefObject<HTMLUListElement>
+    ref: React.RefObject<HTMLUListElement | null>
     setLength: (length: number) => void
   }
 }
@@ -165,8 +169,18 @@ export const Swiper: SwiperComponent = ({
 }: SwiperProps) => {
   const { autoplay, navigation, slides } = store
   const { currentPage, setCurrentPage } = slides
-  const ref = useRef<HTMLUListElement>()
+  const ref = useRef<HTMLUListElement | null>(null)
   const hasInitializedRef = useRef(false)
+  // Pending frame of the deferred initial scroll, `undefined` once it has run.
+  const initFrameRef = useRef<number>()
+  const hasScheduledInitialScrollRef = useRef(false)
+  // Set while the browser settles our own initial scroll, so the scroll-snap
+  // correction that follows it can't be read back as the current page.
+  const initialScrollGuardRef = useRef(false)
+  const initialScrollGuardTimerRef = useRef<ReturnType<typeof setTimeout>>()
+  const skipNextPageScrollRef = useRef(false)
+  // Read inside the deferred frame so it picks up the viewport-corrected value.
+  const firstPageToShowRef = useRef(0)
 
   const [slidesLength, setSlidesLength] = useState(0)
   const [isPrevDisabled, setIsPrevDisabled] = useState(false)
@@ -210,18 +224,36 @@ export const Swiper: SwiperComponent = ({
   const handleScroll = useMemo(
     () =>
       debounce(() => {
+        // Navigation state should always reflect the real geometry, guard or not
         getNavigationState()
+
+        if (initialScrollGuardRef.current) {
+          initialScrollGuardRef.current = false
+          clearTimeout(initialScrollGuardTimerRef.current)
+
+          return
+        }
+
         updatePage()
       }, 100),
     [getNavigationState, updatePage]
   )
+
+  // Keep the latest debounced instance in a ref so we can cancel exactly one
+  // pending call, on unmount. Cancelling on `[handleScroll]` instead would drop
+  // legitimate updates, since `handleScroll` is re-memoized on every
+  // `currentPage` change — that is, mid-swipe.
+  const handleScrollRef = useRef(handleScroll)
+  handleScrollRef.current = handleScroll
+
+  useEffect(() => () => handleScrollRef.current.cancel(), [])
 
   // Navigation functions
 
   const goTo = useCallback(
     (page: number, isFirstInit = false) => {
       const sliderContainer = ref?.current
-      const childWidth = sliderContainer?.children?.[0]?.getBoundingClientRect()?.width
+      const childWidth = sliderContainer?.children?.[0]?.getBoundingClientRect()?.width || 0
 
       sliderContainer?.scrollTo({
         // We don't want to have a scroll effect when we first render the swiper
@@ -278,18 +310,83 @@ export const Swiper: SwiperComponent = ({
     return () => window.removeEventListener('keydown', handleKeys)
   }, [goPrev, goNext])
 
-  const firstPageToShow =
+  const pageForInitialIndex =
     slides.alignment === 'center'
       ? // if centeredSlides is true, we calculate which number is the middle page
         Math.floor(numberOfPage / 2)
       : // if centeredSlides is false, we calculate on which page the number in firstSlideToShow props is
         Math.ceil(slides.initialIndex / slides.currentSlidesPerView) - 1
 
+  // `initialIndex` is 1-based, so its default of `0` computes to page -1, and a
+  // value past the last slide would scroll beyond the end and then fight the
+  // `isLastPage` branch of `updatePage`. An explicit `initialIndex: undefined`
+  // shadows the default and computes to NaN, so guard that too.
+  const firstPageToShow = Number.isFinite(pageForInitialIndex)
+    ? Math.min(Math.max(pageForInitialIndex, 0), numberOfPage - 1)
+    : 0
+
+  firstPageToShowRef.current = firstPageToShow
+
   useEffect(() => {
     // Only navigate to initial page once, when slidesLength is first known
-    if (slidesLength > 0 && !hasInitializedRef.current) {
-      goTo(firstPageToShow, true)
-      hasInitializedRef.current = true
+    if (!slidesLength || hasScheduledInitialScrollRef.current) {
+      return
+    }
+
+    hasScheduledInitialScrollRef.current = true
+    // Flagged synchronously: it gates the external-`setCurrentPage` effect below,
+    // which has to keep working even before the deferred scroll has run.
+    hasInitializedRef.current = true
+
+    // The initial scroll has to land after the first paint. Issued during the
+    // first layout pass it is reverted to 0 by the browser's
+    // `scroll-snap-type: x mandatory` correction, and `updatePage` then latches
+    // that revert as the current page — which is why `initialIndex` was ignored
+    // in hosts that mount the swiper into an already-painting subtree (a dialog
+    // in a Next.js app, for instance) but worked in a plain client-only mount.
+    // One frame is not enough: a callback scheduled from a passive effect still
+    // runs before the next paint. The second frame also lets `useViewportSize`
+    // commit, so `firstPageToShowRef` holds the width-corrected page.
+    initFrameRef.current = requestAnimationFrame(() => {
+      initFrameRef.current = requestAnimationFrame(() => {
+        initFrameRef.current = undefined
+
+        const initialPage = firstPageToShowRef.current
+
+        // The track already starts at 0, so the first page needs no scroll
+        if (initialPage <= 0) {
+          return
+        }
+
+        initialScrollGuardRef.current = true
+        initialScrollGuardTimerRef.current = setTimeout(() => {
+          initialScrollGuardRef.current = false
+        }, INITIAL_SCROLL_GUARD_TIMEOUT)
+
+        goTo(initialPage, true)
+
+        if (initialPage !== currentPage) {
+          // `currentPage` is otherwise only ever synced by the scroll handler,
+          // which the guard above suppresses for this very scroll
+          skipNextPageScrollRef.current = true
+          setCurrentPage(initialPage)
+        }
+      })
+    })
+
+    return () => {
+      clearTimeout(initialScrollGuardTimerRef.current)
+      initialScrollGuardRef.current = false
+
+      if (initFrameRef.current === undefined) {
+        return
+      }
+
+      // The deferred scroll never ran (unmount, or a StrictMode remount) — let
+      // the next mount schedule it again
+      cancelAnimationFrame(initFrameRef.current)
+      initFrameRef.current = undefined
+      hasScheduledInitialScrollRef.current = false
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slidesLength])
@@ -301,6 +398,13 @@ export const Swiper: SwiperComponent = ({
 
   // Triggers navigation when currentPage is changed by external setCurrentPage calls
   useEffect(() => {
+    if (skipNextPageScrollRef.current) {
+      // The initial scroll already put us on this page, no need to scroll again
+      skipNextPageScrollRef.current = false
+
+      return
+    }
+
     if (hasInitializedRef.current) {
       goTo(currentPage)
     }

--- a/lib/src/components/Swiper/index.tsx
+++ b/lib/src/components/Swiper/index.tsx
@@ -347,9 +347,17 @@ export const Swiper: SwiperComponent = ({
         skipSnapBackRef.current = true
         goTo(initialPage, true)
         // `currentPage` is otherwise only synced by the scroll handler, which we
-        // just told to skip this scroll, so set it here.
-        skipNextPageScrollRef.current = true
-        setCurrentPage(initialPage)
+        // just told to skip this scroll — so set it here, reading the freshest
+        // value to arm the redundant-scroll skip only if the page really changes.
+        setCurrentPage(current => {
+          if (current === initialPage) {
+            return current
+          }
+
+          skipNextPageScrollRef.current = true
+
+          return initialPage
+        })
       })
     })
 

--- a/lib/src/components/Swiper/utils.ts
+++ b/lib/src/components/Swiper/utils.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 
-export const useInterval = (callback: () => void, delay: number): void => {
+export const useInterval = (callback: () => void, delay: null | number): void => {
   const savedCallback = useRef<() => void>()
 
   // Remember the latest callback.
@@ -11,7 +11,7 @@ export const useInterval = (callback: () => void, delay: number): void => {
   // Set up the interval.
   useEffect(() => {
     function tick() {
-      savedCallback.current()
+      savedCallback.current?.()
     }
     if (delay !== null) {
       const id = setInterval(tick, delay)


### PR DESCRIPTION
### Bug
Swiper's `initialIndex` option was ignored whenever the swiper mounted into a subtree that was still painting (happened to me in a Next.js app) because of internal mechanism, it would always show the first slide.

#### Timeline:
1. The init effect ran too early: On the first render, during the same frame the container first paints, the react effect issued a programmatic scroll to the target slide.
2. CSS scroll-snap undid it: The slide track css has `scroll-snap-type: x mandatory`. A scroll issued mid-first-layout isn't a settled snap point yet, so the browser's snap correction yanked it back to offset 0px.
3. That revert became the internal truth for the swiper's state: The scroll-back-to-0 fired an onScroll, the debounced handler read scrollLeft (now 0px) to derive which slide is visible, computed it as the current slide and set state `currentPage` to 0. A one-time init flag then blocked any retry, so the wrong position was permanent.

A Vite SPA escaped it only by luck: its client-only mount left layout already settled before the react effect ran, so the initial scroll landed on a valid snap point and stuck.

Two latent bugs sat in the same path: 
- the default `initialIndex` of 0 computed to slide -1 (it's a 1-based value)
- undefined `initialIndex` produced NaN, both were used into the scroll math

### Fix (thank you Claude)
**Defer the initial scroll to after the first paint:**
- It's scheduled across two animation frames instead of running during the commit, so it lands once layout is settled, and snap-back no longer fires. 
- Two frames are required because a frame scheduled from an effect still runs before the next paint. 
- The second frame also gives the viewport-size hook time to resolve, so the target page is correct even when slides-per-view varies by breakpoint.

**Ignore the swiper's own scroll once:** 
- A one-shot guard makes the scroll handler skip exactly the settle that follows the initial programmatic scroll, so a scroll correction by the css can't be computed as the current page. 
- It's aimed only at the initial scroll, and only when the target isn't the first page, so ordinary arrow/keyboard/swipe navigation, which relies on that same "scroll -> state" feedback, is untouched.

Sync state directly at init:
- Since the one-shot guard suppresses the usual feedback that does it, and we skip the redundant follow-up scroll that the state change would otherwise trigger.
- Clamp the target page into valid range, which fixes the -1 default and the NaN case and makes an out-of-range initialIndex land on the last page instead of scrolling past the end.
- Also cancel the pending frame on unmount (clean StrictMode re-mount) and cancel one pending scroll-handler call on unmount.

#### none of the unit tests reproduce the bug
jsdom has no layout, paint, or scroll-snap. Tests are here to lock the fix's mechanism against future refactors (that the scroll is deferred, and that the guard is one-shot rather than permanent).

#### Bonus fixes
Two doc examples (asset-swiper, asset-swiper-title) were also fixed: their assets weren't wrapped in Swiper.Slides, so the swiper never registered any slides and initialIndex did nothing.


#### Screen captures from marketplace-front X Next.js

Before 


https://github.com/user-attachments/assets/ae5d0fba-91ab-4ad4-87a7-18ff8db6b094



After


https://github.com/user-attachments/assets/a41828df-f946-4dbc-aff0-fc6a78b9ae38



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Swiper’s initial positioning across breakpoints and multi-page layouts.
  - Prevented redundant scrolling and scroll-snap corrections during initialization.
  - Preserved reliable navigation after the initial position is set.
  - Improved handling when the requested starting slide exceeds the available slides.

- **Examples**
  - Updated modal swiper examples to use the supported slide container structure.

- **Tests**
  - Added coverage for initial positioning, deferred scrolling, boundary handling, and subsequent user navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->