### PR TITLE
feat(Window): add Header LeftActions children

### DIFF
--- a/lib/src/components/Window/components/Header.tsx
+++ b/lib/src/components/Window/components/Header.tsx
@@ -102,7 +102,11 @@ const RightActions = ({ children, isClosable = false, onClose }: HeaderRightActi
   )
 }
 
-const LeftActions = ({ isExpandable = false, onExpandChange }: HeaderLeftActionsProps) => {
+const LeftActions = ({
+  children,
+  isExpandable = false,
+  onExpandChange,
+}: HeaderLeftActionsProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
 
   const handleExpandWindow = () => {
@@ -124,6 +128,7 @@ const LeftActions = ({ isExpandable = false, onExpandChange }: HeaderLeftActions
           <Icon name={isExpanded ? 'compress-alt' : 'arrow-resize-diagonal'} />
         </button>
       ) : null}
+      {children}
     </div>
   )
 }

--- a/lib/src/components/Window/docs/examples/custom-header-action.tsx
+++ b/lib/src/components/Window/docs/examples/custom-header-action.tsx
@@ -4,7 +4,10 @@ const Example = () => {
   return (
     <>
       <Window.Header>
-        <Window.Header.LeftActions isExpandable />
+        <Window.Header.LeftActions isExpandable>
+          {/* eslint-disable-next-line no-console */}
+          <Window.Header.Button icon="setting" onClick={() => console.log('custom action')} />
+        </Window.Header.LeftActions>
         <Window.Header.Title title="My Window Title" />
         <Window.Header.RightActions isClosable>
           {/* eslint-disable-next-line no-console */}


### PR DESCRIPTION


This PR aims to add children to `Window.Header.LeftActions` (already present in [Belonging design](https://www.figma.com/design/rS99VkKaw9ITOcduMu5aX7/Belonging-Experience---Design-System?node-id=2526-12025&t=4JAD1uNKf2KGK45V-4))

- `children` props was already accepted but not render
- show children after `expandable` button (if present)
- update doc example

<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## SCREENSHOTS / SCREEN RECORDINGS

<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom actions in the window header’s left action area.
  * Custom header actions can now include expandable controls and respond to clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->