### PR TITLE
fix(tag): prevent tag from nesting button

### DIFF
--- a/lib/src/components/Tag/index.tsx
+++ b/lib/src/components/Tag/index.tsx
@@ -33,6 +33,7 @@ export const Tag = forwardRefWithAs<TagOptions, 'div'>((props, ref) => {
     onRemove,
     removeButtonProps,
     size = 'lg',
+    style,
     variant = 'warm',
     ...rest
   } = props
@@ -90,7 +91,7 @@ export const Tag = forwardRefWithAs<TagOptions, 'div'>((props, ref) => {
 
   if (needsSplitLayout) {
     return (
-      <div className={rootClassName}>
+      <div className={rootClassName} style={style}>
         <Component className={cx('label')} onClick={handleClick} ref={ref} {...rest}>
           {labelContent}
         </Component>
@@ -100,7 +101,7 @@ export const Tag = forwardRefWithAs<TagOptions, 'div'>((props, ref) => {
   }
 
   return (
-    <Component className={rootClassName} onClick={handleClick} ref={ref} {...rest}>
+    <Component className={rootClassName} onClick={handleClick} ref={ref} style={style} {...rest}>
       {labelContent}
       {removeButtonEl}
     </Component>

--- a/lib/src/components/Tag/index.tsx
+++ b/lib/src/components/Tag/index.tsx
@@ -40,6 +40,11 @@ export const Tag = forwardRefWithAs<TagOptions, 'div'>((props, ref) => {
   // Determine if the tag should have a square shape (only one character and no remove action)
   const isSquare = getTextLength(children) === 1 && !onRemove
 
+  // A native button/anchor root can't legally contain the remove button, so that combination
+  // needs to split into sibling interactive elements instead of nesting one inside the other
+  const rootTag = Component as unknown as string
+  const needsSplitLayout = (rootTag === 'button' || rootTag === 'a') && !!onRemove
+
   const handleRemove = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     if (disabled) return
@@ -52,36 +57,52 @@ export const Tag = forwardRefWithAs<TagOptions, 'div'>((props, ref) => {
     if (onClick) onClick(e)
   }
 
-  return (
-    <Component
-      className={cx(
-        'root',
-        `variant-${variant}`,
-        `size-${size}`,
-        !!onRemove && 'hasRemoveAction',
-        isSquare && 'isSquare',
-        ai && 'ai',
-        disabled && 'disabled',
-        className
-      )}
-      onClick={handleClick}
-      ref={ref}
-      {...rest}
-    >
+  const rootClassName = cx(
+    'root',
+    `variant-${variant}`,
+    `size-${size}`,
+    !!onRemove && 'hasRemoveAction',
+    isSquare && 'isSquare',
+    ai && 'ai',
+    disabled && 'disabled',
+    className
+  )
+
+  const labelContent = (
+    <>
       {ai && variant !== 'dash' ? <Icon name="sparkles" size="md" /> : icon}
       <span>{children}</span>
-      {onRemove ? (
-        <button
-          aria-label="remove tag"
-          disabled={disabled}
-          type="button"
-          {...removeButtonProps}
-          className={cx('removeButton', removeButtonProps?.className)}
-          onClick={handleRemove}
-        >
-          <Icon name="times" size="md" />
-        </button>
-      ) : null}
+    </>
+  )
+
+  const removeButtonEl = onRemove ? (
+    <button
+      aria-label="remove tag"
+      disabled={disabled}
+      type="button"
+      {...removeButtonProps}
+      className={cx('removeButton', removeButtonProps?.className)}
+      onClick={handleRemove}
+    >
+      <Icon name="times" size="md" />
+    </button>
+  ) : null
+
+  if (needsSplitLayout) {
+    return (
+      <div className={rootClassName}>
+        <Component className={cx('label')} onClick={handleClick} ref={ref} {...rest}>
+          {labelContent}
+        </Component>
+        {removeButtonEl}
+      </div>
+    )
+  }
+
+  return (
+    <Component className={rootClassName} onClick={handleClick} ref={ref} {...rest}>
+      {labelContent}
+      {removeButtonEl}
     </Component>
   )
 })

--- a/lib/src/components/Tag/index.tsx
+++ b/lib/src/components/Tag/index.tsx
@@ -33,7 +33,6 @@ export const Tag = forwardRefWithAs<TagOptions, 'div'>((props, ref) => {
     onRemove,
     removeButtonProps,
     size = 'lg',
-    style,
     variant = 'warm',
     ...rest
   } = props
@@ -43,8 +42,8 @@ export const Tag = forwardRefWithAs<TagOptions, 'div'>((props, ref) => {
 
   // A native button/anchor root can't legally contain the remove button, so that combination
   // needs to split into sibling interactive elements instead of nesting one inside the other
-  const rootTag = Component as unknown as string
-  const needsSplitLayout = (rootTag === 'button' || rootTag === 'a') && !!onRemove
+  const rootTag = Component as React.ElementType
+  const isInteractiveTagWithRemove = (rootTag === 'button' || rootTag === 'a') && !!onRemove
 
   const handleRemove = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
@@ -89,9 +88,9 @@ export const Tag = forwardRefWithAs<TagOptions, 'div'>((props, ref) => {
     </button>
   ) : null
 
-  if (needsSplitLayout) {
+  if (isInteractiveTagWithRemove) {
     return (
-      <div className={rootClassName} style={style}>
+      <div className={rootClassName}>
         <Component className={cx('label')} onClick={handleClick} ref={ref} {...rest}>
           {labelContent}
         </Component>
@@ -101,7 +100,7 @@ export const Tag = forwardRefWithAs<TagOptions, 'div'>((props, ref) => {
   }
 
   return (
-    <Component className={rootClassName} onClick={handleClick} ref={ref} style={style} {...rest}>
+    <Component className={rootClassName} onClick={handleClick} ref={ref} {...rest}>
       {labelContent}
       {removeButtonEl}
     </Component>

--- a/lib/src/components/Tag/tag.module.scss
+++ b/lib/src/components/Tag/tag.module.scss
@@ -108,14 +108,14 @@
   @media (hover: hover) and (pointer: fine) {
     button.root:hover:not(.disabled),
     a.root:hover:not(.disabled),
-    .root:has(> .label:hover):not(.disabled) {
+    .root:has(> .label):hover:not(.disabled) {
       --backgroundColor: var(--backgroundColorHover);
       --boxShadow: var(--elevation-20);
     }
 
     button.root.variant-dash:hover:not(.disabled),
     a.root.variant-dash:hover:not(.disabled),
-    .root.variant-dash:has(> .label:hover):not(.disabled) {
+    .root.variant-dash:has(> .label):hover:not(.disabled) {
       border-color: var(--tag-color-border-dash-hover);
     }
   }

--- a/lib/src/components/Tag/tag.module.scss
+++ b/lib/src/components/Tag/tag.module.scss
@@ -55,34 +55,68 @@
 
     /* Text overflow for children */
     > span,
-    > p {
+    > p,
+    .label > span,
+    .label > p {
       overflow: hidden;
       text-overflow: ellipsis;
     }
 
     /* Icon sizing */
-    > svg {
+    > svg,
+    .label > svg {
       flex-shrink: 0;
       width: var(--tag-size-icon);
       height: var(--tag-size-icon);
     }
   }
 
+  /*
+   * The clickable label when the root can't be the interactive element itself
+   * (root + remove button are split into siblings, see .hasRemoveAction below)
+   */
+  .label {
+    display: inline-flex;
+    align-items: center;
+    overflow: hidden;
+    min-width: 0;
+    gap: var(--gap);
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    font: inherit;
+    text-decoration: none;
+    cursor: pointer;
+    outline: transparent solid var(--border-width-md);
+
+    &:focus-visible {
+      outline-width: var(--button-border-width-focused);
+      outline-color: var(--button-color-border-focused);
+    }
+  }
+
   /* Interactive states for button and anchor tags */
   button.root,
-  a.root {
+  a.root,
+  /* ...or a root wrapping the split-layout .label */
+  .root:has(> .label) {
     cursor: pointer;
     text-decoration: none;
+  }
 
-    @media (hover: hover) and (pointer: fine) {
-      &:hover:not(.disabled) {
-        --backgroundColor: var(--backgroundColorHover);
-        --boxShadow: var(--elevation-20);
-      }
+  @media (hover: hover) and (pointer: fine) {
+    button.root:hover:not(.disabled),
+    a.root:hover:not(.disabled),
+    .root:has(> .label:hover):not(.disabled) {
+      --backgroundColor: var(--backgroundColorHover);
+      --boxShadow: var(--elevation-20);
+    }
 
-      &.variant-dash:hover:not(.disabled) {
-        border-color: var(--tag-color-border-dash-hover);
-      }
+    button.root.variant-dash:hover:not(.disabled),
+    a.root.variant-dash:hover:not(.disabled),
+    .root.variant-dash:has(> .label:hover):not(.disabled) {
+      border-color: var(--tag-color-border-dash-hover);
     }
   }
 
@@ -97,7 +131,8 @@
       border: inherit;
     }
 
-    .removeButton {
+    .removeButton,
+    .label {
       cursor: inherit;
     }
   }

--- a/lib/src/components/Tag/tag.module.scss
+++ b/lib/src/components/Tag/tag.module.scss
@@ -88,19 +88,13 @@
     font: inherit;
     text-decoration: none;
     cursor: pointer;
-    outline: transparent solid var(--border-width-md);
-
-    &:focus-visible {
-      outline-width: var(--button-border-width-focused);
-      outline-color: var(--button-color-border-focused);
-    }
   }
 
   /* Interactive states for button and anchor tags */
   button.root,
   a.root,
   /* ...or a root wrapping the split-layout .label */
-  .root:has(> .label) {
+  .root:has(> .label):not(.disabled) {
     cursor: pointer;
     text-decoration: none;
   }


### PR DESCRIPTION
## DESCRIPTION

Tag rendered its own remove <button> as a DOM child of the root element.
When `as="button"` or `as="a"` was combined with `onRemove`, the root
itself became a <button>/<a>, producing invalid nested interactive
markup (<button><button aria-label="remove tag">…</button></button>).

That specific combination now renders the clickable label and the
remove button as sibling elements inside a non-interactive wrapper
that carries the pill styling, while every other case (plain onClick,
or onRemove on the default div root) keeps rendering exactly as
before.

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## SCREENSHOTS / SCREEN RECORDINGS

With as button and onclick+onremove:
<img width="1097" height="144" alt="image" src="https://github.com/user-attachments/assets/daddba8f-10a4-43d3-8987-a6e0254bd821" />

without onremove:
<img width="1097" height="144" alt="image" src="https://github.com/user-attachments/assets/3f56a1df-1ea8-4cdc-9445-ee56d7e6ee3b" />

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved removable tags rendered as buttons or links to prevent nested interactive elements.
  * Fixed disabled tag interactions so clicks are properly prevented.
  * Enhanced text overflow handling and icon sizing within tags.

* **Style**
  * Added consistent focus, hover, cursor, and disabled-state styling for interactive tag elements.
  * Improved support for paragraph and nested label content within tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->