### PR TITLE
fix(Search): stop defaultHighlightedIndex leaking onto the DOM

### DIFF
--- a/lib/src/components/Search/index.tsx
+++ b/lib/src/components/Search/index.tsx
@@ -29,6 +29,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
       autoFocus,
       className,
       dataTestId,
+      defaultHighlightedIndex,
       disabled,
       groupsEnabled,
       icon,
@@ -108,6 +109,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
 
     return (
       <Downshift
+        defaultHighlightedIndex={defaultHighlightedIndex}
         initialInputValue={initialInputValue}
         itemToString={handleItemToString}
         onInputValueChange={handleInputChange}


### PR DESCRIPTION
## DESCRIPTION

Root cause:
Search destructures its named props and puts everything else in rest, which it spreads twice: once onto <Downshift> (correct) and again inside getInputProps(...), which lands on the native <input>. defaultHighlightedIndex is a Downshift-only prop, not a valid HTML attribute, so it leaked onto the DOM and triggered React's "unrecognized DOM attribute" warning.

Fix:
Destructure defaultHighlightedIndex explicitly (like the other named props) and pass it directly to <Downshift>. This removes it from rest before the <input> spread, so it no longer reaches the DOM. Scoped to this one prop — no other forwarded props change behavior.

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## SCREENSHOTS / SCREEN RECORDINGS

BEFORE:
<img width="1500" height="759" alt="Screenshot 2026-08-19 at 10 59 45" src="https://github.com/user-attachments/assets/df13cb1b-8e0f-47a0-a4fa-efdbeae3e464" />

AFTER:
<img width="1500" height="759" alt="Screenshot 2026-08-19 at 10 58 19" src="https://github.com/user-attachments/assets/41e15cea-a45f-4422-8896-38115da1f6b8" />

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Search results can now open with a specified result highlighted by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->