### PR TITLE
fix(Tooltip): tooltip placement w/ disabled child

### DIFF
--- a/lib/src/components/Tooltip/tooltip.module.scss
+++ b/lib/src/components/Tooltip/tooltip.module.scss
@@ -24,6 +24,7 @@
   }
 
   .childItem {
-    display: inline;
+    display: inline-block;
+    width: fit-content;
   }
 }


### PR DESCRIPTION
## DESCRIPTION
Fix Tooltip placement with disabled child

### FIX
**What we have**
When the child is a disabled element the Tooltip wrap it with a span to allow cursor events and the tooltip to show
**Problem**
The span width not always fit its child width. This can show a tooltip in a wrong position (see video)
<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## HOW TO TEST

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## SCREENSHOTS / SCREEN RECORDINGS

https://github.com/user-attachments/assets/c1838e71-f1c9-4f8d-a414-147ac1e9a31d


<!--
Add screenshots or screen recordings to help the reviewer find and understand your changes.
-->

## COMPATIBILITY

- [ ] Tested on Safari (desktop)
- [ ] Tested on Chrome (desktop)
- [ ] Tested on Firefox (desktop)
- [ ] Tested on mobile device sizes
- [ ] Tested on tablet device sizes
- [ ] Tested on IOS Safari (either device or simulator)

## QA

- [ ] Thoroughly tested in local environment
- [ ] Added tests for all new features
- [ ] Added tests that considered edge cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved tooltip child item sizing and layout for more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->