### PR TITLE
fix: custom menu height for search and select component

### DIFF
--- a/lib/src/components/Search/docs/index.mdx
+++ b/lib/src/components/Search/docs/index.mdx
@@ -17,3 +17,11 @@ To use option groups, you must provide two additional props: `groupsEnabled` tha
 You can add an icon and choose its position. To change the icon size, set the `size` prop on the `Search` component — the icon scales with it.
 
 <div data-playground="with-icon.tsx" data-component="Search"></div>
+
+### Results list height
+
+The results list is capped at `155px` by default. Override it with the `--searchMenuMaxHeight` CSS variable, set through `className` (the prop lands on the component wrapper), inline, or from any parent:
+
+```jsx
+<Search className="[--searchMenuMaxHeight:20rem]" search={handleSearch} />
+```

--- a/lib/src/components/Search/index.tsx
+++ b/lib/src/components/Search/index.tsx
@@ -166,7 +166,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
           }) as React.InputHTMLAttributes<HTMLInputElement>
 
           return (
-            <div {...rootProps} className={cx('wrapper', 'field-input')}>
+            <div {...rootProps} className={cx('wrapper', 'field-input', className)}>
               <div className={cx('input-wrapper')}>
                 <input
                   className={cx(
@@ -174,8 +174,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
                     `size-${size}`,
                     variant && `variant-${variant}`,
                     transparent && 'transparent',
-                    icon && `icon-placement-${iconPlacement}`,
-                    className
+                    icon && `icon-placement-${iconPlacement}`
                   )}
                   {...inputProps}
                 />

--- a/lib/src/components/Search/search.module.scss
+++ b/lib/src/components/Search/search.module.scss
@@ -215,7 +215,7 @@
   }
 
   .menu {
-    max-height: 9.6875rem; /* 155px */
+    max-height: var(--searchMenuMaxHeight, 9.6875rem); /* 155px */
     background-color: var(--color-background-neutral-inverse-fixed);
     border-color: var(--color-background-neutral-subtlest);
     border-radius: var(--border-radius-md);

--- a/lib/src/components/Select/docs/index.mdx
+++ b/lib/src/components/Select/docs/index.mdx
@@ -73,3 +73,11 @@ These two options combined allows you, for example, to build a filter dropdown w
 To use option groups, you must provide two additional props: `groupsEnabled` that allow nested options and `renderGroupHeader` that renders the header of a specific group
 
 <div data-playground="option-groups.tsx" data-component="Select"></div>
+
+### Options list height
+
+The dropdown list is capped at `155px` by default. Override it with the `--selectMenuMaxHeight` CSS variable, set through `className` (the prop lands on the component wrapper), inline, or from any parent:
+
+```jsx
+<Select className="[--selectMenuMaxHeight:20rem]" options={options} />
+```

--- a/lib/src/components/Select/index.tsx
+++ b/lib/src/components/Select/index.tsx
@@ -319,7 +319,6 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       isClearable && 'clearable',
       transparent && 'transparent',
       icon && `icon-placement-${iconPlacement}`,
-      className,
       disabled && 'disabled'
     )
 
@@ -399,7 +398,10 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
           }) as React.InputHTMLAttributes<HTMLInputElement>
 
           return (
-            <div {...rootProps} className={cx('wrapper', disabled && 'disabled', 'field-input')}>
+            <div
+              {...rootProps}
+              className={cx('wrapper', disabled && 'disabled', 'field-input', className)}
+            >
               <div className={cx('input-wrapper')}>
                 {isSearchable ? (
                   <input

--- a/lib/src/components/Select/select.module.scss
+++ b/lib/src/components/Select/select.module.scss
@@ -261,7 +261,7 @@
   }
 
   .menu {
-    max-height: 9.6875rem; /* 155px */
+    max-height: var(--selectMenuMaxHeight, 9.6875rem); /* 155px */
     background-color: var(--input-color-background-default);
     border-color: var(--input-color-border-hover);
     border-radius: var(--input-border-radius);


### PR DESCRIPTION
We can now customize the height of the menu of the select or search component: 

**Before**
<img width="268" height="250" alt="Screenshot 2026-08-20 at 15 33 57" src="https://github.com/user-attachments/assets/5d3afb24-8a76-4c41-bf4a-456cceeacee1" />

**After**
<img width="1131" height="329" alt="Capture d’écran 2026-09-01 à 14 10 25" src="https://github.com/user-attachments/assets/8743b3fa-578b-42d2-9c43-fde3e721897c" />
